### PR TITLE
client/resource_group: enforce one active controller per process

### DIFF
--- a/client/errs/errno.go
+++ b/client/errs/errno.go
@@ -99,10 +99,11 @@ var (
 
 // resource group errors
 var (
-	ErrClientListResourceGroup                  = errors.Normalize("get all resource group failed, %v", errors.RFCCodeText("PD:client:ErrClientListResourceGroup"))
-	ErrClientResourceGroupConfigUnavailable     = errors.Normalize("resource group config is unavailable, %v", errors.RFCCodeText("PD:client:ErrClientResourceGroupConfigUnavailable"))
-	ErrClientResourceGroupThrottled             = errors.Normalize("exceeded resource group quota limitation, estimated wait time %s, ltb state is %.2f:%.2f", errors.RFCCodeText("PD:client:ErrClientResourceGroupThrottled"))
-	ErrClientPutResourceGroupMismatchKeyspaceID = errors.Normalize("resource group keyspace ID %d does not match inner client keyspace ID %d", errors.RFCCodeText("PD:client:ErrClientPutResourceGroupMismatchKeyspaceID"))
+	ErrClientListResourceGroup                    = errors.Normalize("get all resource group failed, %v", errors.RFCCodeText("PD:client:ErrClientListResourceGroup"))
+	ErrClientResourceGroupConfigUnavailable       = errors.Normalize("resource group config is unavailable, %v", errors.RFCCodeText("PD:client:ErrClientResourceGroupConfigUnavailable"))
+	ErrClientResourceGroupThrottled               = errors.Normalize("exceeded resource group quota limitation, estimated wait time %s, ltb state is %.2f:%.2f", errors.RFCCodeText("PD:client:ErrClientResourceGroupThrottled"))
+	ErrClientPutResourceGroupMismatchKeyspaceID   = errors.Normalize("resource group keyspace ID %d does not match inner client keyspace ID %d", errors.RFCCodeText("PD:client:ErrClientPutResourceGroupMismatchKeyspaceID"))
+	ErrClientResourceGroupControllerAlreadyExists = errors.Normalize("another resource group controller already exists in this process", errors.RFCCodeText("PD:client:ErrClientResourceGroupControllerAlreadyExists"))
 )
 
 // ErrClientGetResourceGroup is the error type for getting resource group.

--- a/client/resource_group/controller/global_controller.go
+++ b/client/resource_group/controller/global_controller.go
@@ -186,10 +186,21 @@ type ResourceGroupsController struct {
 	// 0 means not loaded or not configured (treated as v1).
 	ruVersion atomic.Int32
 
+	// stopOnce makes Stop idempotent and guarantees the process-wide
+	// ownership slot is released exactly once. stopped keeps a stopped
+	// controller from being started afterwards, which would leak an
+	// unowned run loop.
+	stopOnce sync.Once
+	stopped  atomic.Bool
+
 	wg sync.WaitGroup
 }
 
-// NewResourceGroupController returns a new ResourceGroupsController which impls ResourceGroupKVInterceptor
+// NewResourceGroupController returns a new ResourceGroupsController which impls ResourceGroupKVInterceptor.
+// At most one controller acquired through this constructor may exist in a
+// process at a time; a second acquisition fails with
+// ErrClientResourceGroupControllerAlreadyExists until the previous controller
+// has released ownership via Stop.
 func NewResourceGroupController(
 	ctx context.Context,
 	clientUniqueID uint64,
@@ -198,8 +209,14 @@ func NewResourceGroupController(
 	keyspaceID uint32,
 	opts ...ResourceControlCreateOption,
 ) (*ResourceGroupsController, error) {
+	// Reserve the process-wide ownership slot before any side effect: the
+	// steps below perform network I/O and update process-global state.
+	if err := ownership.reserve(); err != nil {
+		return nil, err
+	}
 	config, err := loadServerConfig(ctx, provider)
 	if err != nil {
+		ownership.unreserve()
 		return nil, err
 	}
 	if requestUnitConfig != nil {
@@ -226,6 +243,7 @@ func NewResourceGroupController(
 	enableControllerTraceLog.Store(config.EnableControllerTraceLog)
 	// Extract initial ruVersion from the controller config's RUVersionPolicy.
 	controller.updateRUVersionFromConfig(config)
+	ownership.bind(controller)
 	return controller, nil
 }
 
@@ -299,7 +317,13 @@ const (
 )
 
 // Start starts ResourceGroupController service.
+// Canceling ctx stops the run loop but does not release the process-wide
+// ownership slot; call Stop to release it.
 func (c *ResourceGroupsController) Start(ctx context.Context) {
+	if c.stopped.Load() {
+		log.Error("resource group controller is already stopped, cannot be started again")
+		return
+	}
 	c.loopCtx, c.loopCancel = context.WithCancel(ctx)
 	c.wg.Add(1)
 	go func() {
@@ -514,13 +538,19 @@ func (c *ResourceGroupsController) Start(ctx context.Context) {
 	}()
 }
 
-// Stop stops ResourceGroupController service.
+// Stop stops ResourceGroupController service and releases the process-wide
+// ownership slot, allowing a replacement controller to be constructed. It is
+// idempotent and also valid on a controller that was never started. A stopped
+// controller cannot be started again.
 func (c *ResourceGroupsController) Stop() error {
-	if c.loopCancel == nil {
-		return errors.Errorf("resource groups controller does not start")
-	}
-	c.loopCancel()
-	c.wg.Wait()
+	c.stopOnce.Do(func() {
+		c.stopped.Store(true)
+		if c.loopCancel != nil {
+			c.loopCancel()
+			c.wg.Wait()
+		}
+		ownership.release(c)
+	})
 	return nil
 }
 

--- a/client/resource_group/controller/global_controller.go
+++ b/client/resource_group/controller/global_controller.go
@@ -186,12 +186,16 @@ type ResourceGroupsController struct {
 	// 0 means not loaded or not configured (treated as v1).
 	ruVersion atomic.Int32
 
-	// stopOnce makes Stop idempotent and guarantees the process-wide
-	// ownership slot is released exactly once. stopped keeps a stopped
-	// controller from being started afterwards, which would leak an
-	// unowned run loop.
-	stopOnce sync.Once
-	stopped  atomic.Bool
+	// lifecycleMu serializes Start against Stop: it guards the publication
+	// of loopCtx/loopCancel and the stopped flag, so that a Stop concurrent
+	// with Start either observes the started loop and cancels it, or marks
+	// the controller stopped before Start launches the loop. Without it, a
+	// racing Start could leak a run loop that no longer owns the
+	// process-wide slot. stopOnce makes Stop idempotent and guarantees the
+	// slot is released exactly once.
+	lifecycleMu sync.Mutex
+	stopOnce    sync.Once
+	stopped     bool
 
 	wg sync.WaitGroup
 }
@@ -210,13 +214,20 @@ func NewResourceGroupController(
 	opts ...ResourceControlCreateOption,
 ) (*ResourceGroupsController, error) {
 	// Reserve the process-wide ownership slot before any side effect: the
-	// steps below perform network I/O and update process-global state.
+	// steps below perform network I/O and update process-global state. The
+	// deferred unreserve keeps a failure (or panic) on any construction path
+	// from leaking the slot.
 	if err := ownership.reserve(); err != nil {
 		return nil, err
 	}
+	bound := false
+	defer func() {
+		if !bound {
+			ownership.unreserve()
+		}
+	}()
 	config, err := loadServerConfig(ctx, provider)
 	if err != nil {
-		ownership.unreserve()
 		return nil, err
 	}
 	if requestUnitConfig != nil {
@@ -244,6 +255,7 @@ func NewResourceGroupController(
 	// Extract initial ruVersion from the controller config's RUVersionPolicy.
 	controller.updateRUVersionFromConfig(config)
 	ownership.bind(controller)
+	bound = true
 	return controller, nil
 }
 
@@ -320,7 +332,9 @@ const (
 // Canceling ctx stops the run loop but does not release the process-wide
 // ownership slot; call Stop to release it.
 func (c *ResourceGroupsController) Start(ctx context.Context) {
-	if c.stopped.Load() {
+	c.lifecycleMu.Lock()
+	defer c.lifecycleMu.Unlock()
+	if c.stopped {
 		log.Error("resource group controller is already stopped, cannot be started again")
 		return
 	}
@@ -413,11 +427,7 @@ func (c *ResourceGroupsController) Start(ctx context.Context) {
 				c.executeOnAllGroups((*groupCostController).resetEmergencyTokenAcquisition)
 			/* channels */
 			case <-c.loopCtx.Done():
-				metrics.ResourceGroupStatusGauge.Reset()
-				c.requestSourceStates.Range(func(_, v any) bool {
-					v.(*requestSourceMetricsState).cleanup()
-					return true
-				})
+				c.cleanupProcessGlobalMetrics()
 				return
 			case <-c.responseDeadlineCh:
 				c.run.inDegradedMode.Store(true)
@@ -544,14 +554,32 @@ func (c *ResourceGroupsController) Start(ctx context.Context) {
 // controller cannot be started again.
 func (c *ResourceGroupsController) Stop() error {
 	c.stopOnce.Do(func() {
-		c.stopped.Store(true)
-		if c.loopCancel != nil {
-			c.loopCancel()
+		c.lifecycleMu.Lock()
+		c.stopped = true
+		cancel := c.loopCancel
+		c.lifecycleMu.Unlock()
+		if cancel != nil {
+			cancel()
 			c.wg.Wait()
 		}
+		// The run loop cleans the process-global metrics up on exit, but a
+		// controller that was never started (or was used again after its
+		// run loop already exited) has no loop to do it, so clean them up
+		// here as well before handing the slot to a replacement.
+		c.cleanupProcessGlobalMetrics()
 		ownership.release(c)
 	})
 	return nil
+}
+
+// cleanupProcessGlobalMetrics cleans the process-global metric state
+// populated on behalf of this controller. It is safe to call more than once.
+func (c *ResourceGroupsController) cleanupProcessGlobalMetrics() {
+	metrics.ResourceGroupStatusGauge.Reset()
+	c.requestSourceStates.Range(func(_, v any) bool {
+		v.(*requestSourceMetricsState).cleanup()
+		return true
+	})
 }
 
 // loadGroupController just wraps the `Load` method of `sync.Map`.

--- a/client/resource_group/controller/global_controller.go
+++ b/client/resource_group/controller/global_controller.go
@@ -555,7 +555,9 @@ func (c *ResourceGroupsController) Start(ctx context.Context) {
 // Stop stops ResourceGroupController service and releases the process-wide
 // ownership slot, allowing a replacement controller to be constructed. It is
 // idempotent and also valid on a controller that was never started. A stopped
-// controller cannot be started again.
+// controller cannot be started again and must not be used further: requests
+// served after Stop would repopulate the process-global metric state with
+// series that no cleanup path collects anymore.
 func (c *ResourceGroupsController) Stop() error {
 	c.stopOnce.Do(func() {
 		c.lifecycleMu.Lock()

--- a/client/resource_group/controller/global_controller.go
+++ b/client/resource_group/controller/global_controller.go
@@ -186,13 +186,9 @@ type ResourceGroupsController struct {
 	// 0 means not loaded or not configured (treated as v1).
 	ruVersion atomic.Int32
 
-	// lifecycleMu serializes Start against Stop: it guards the publication
-	// of loopCtx/loopCancel and the stopped flag, so that a Stop concurrent
-	// with Start either observes the started loop and cancels it, or marks
-	// the controller stopped before Start launches the loop. Without it, a
-	// racing Start could leak a run loop that no longer owns the
-	// process-wide slot. stopOnce makes Stop idempotent and guarantees the
-	// slot is released exactly once.
+	// lifecycleMu serializes Start against Stop; without it, a Start racing
+	// a Stop could leak a run loop that no longer owns the process-wide
+	// slot.
 	lifecycleMu sync.Mutex
 	stopOnce    sync.Once
 	stopped     bool
@@ -213,10 +209,8 @@ func NewResourceGroupController(
 	keyspaceID uint32,
 	opts ...ResourceControlCreateOption,
 ) (*ResourceGroupsController, error) {
-	// Reserve the process-wide ownership slot before any side effect: the
-	// steps below perform network I/O and update process-global state. The
-	// deferred unreserve keeps a failure (or panic) on any construction path
-	// from leaking the slot.
+	// Reserve the ownership slot before any side effect: the steps below
+	// perform network I/O and update process-global state.
 	if err := ownership.reserve(); err != nil {
 		return nil, err
 	}
@@ -555,9 +549,8 @@ func (c *ResourceGroupsController) Start(ctx context.Context) {
 // Stop stops ResourceGroupController service and releases the process-wide
 // ownership slot, allowing a replacement controller to be constructed. It is
 // idempotent and also valid on a controller that was never started. A stopped
-// controller cannot be started again and must not be used further: requests
-// served after Stop would repopulate the process-global metric state with
-// series that no cleanup path collects anymore.
+// controller cannot be started again and must not serve further requests:
+// metric series created after Stop are never cleaned up.
 func (c *ResourceGroupsController) Stop() error {
 	c.stopOnce.Do(func() {
 		c.lifecycleMu.Lock()
@@ -568,21 +561,17 @@ func (c *ResourceGroupsController) Stop() error {
 			cancel()
 			c.wg.Wait()
 		}
-		// The run loop cleans the process-global metrics up on exit, but a
-		// controller that was never started (or was used again after its
-		// run loop already exited) has no loop to do it, so clean them up
-		// here as well before handing the slot to a replacement.
+		// Also covers controllers without a run loop to do it on exit,
+		// e.g. never started, or used again after context cancellation.
 		c.cleanupProcessGlobalMetrics()
 		ownership.release(c)
 	})
 	return nil
 }
 
-// cleanupProcessGlobalMetrics cleans the process-global metric state
-// populated on behalf of this controller. It is safe to call more than once.
-// Only the current ownership holder may reset the process-global collectors:
-// a controller allocated outside the supported API must not disturb the
-// owner's state.
+// cleanupProcessGlobalMetrics is idempotent. It is restricted to the current
+// ownership holder so that a controller allocated outside the supported API
+// cannot reset the owner's process-global collectors.
 func (c *ResourceGroupsController) cleanupProcessGlobalMetrics() {
 	if !ownership.owns(c) {
 		return

--- a/client/resource_group/controller/global_controller.go
+++ b/client/resource_group/controller/global_controller.go
@@ -338,6 +338,10 @@ func (c *ResourceGroupsController) Start(ctx context.Context) {
 		log.Error("resource group controller is already stopped, cannot be started again")
 		return
 	}
+	if c.loopCtx != nil {
+		log.Error("resource group controller is already started")
+		return
+	}
 	c.loopCtx, c.loopCancel = context.WithCancel(ctx)
 	c.wg.Add(1)
 	go func() {
@@ -574,7 +578,13 @@ func (c *ResourceGroupsController) Stop() error {
 
 // cleanupProcessGlobalMetrics cleans the process-global metric state
 // populated on behalf of this controller. It is safe to call more than once.
+// Only the current ownership holder may reset the process-global collectors:
+// a controller allocated outside the supported API must not disturb the
+// owner's state.
 func (c *ResourceGroupsController) cleanupProcessGlobalMetrics() {
+	if !ownership.owns(c) {
+		return
+	}
 	metrics.ResourceGroupStatusGauge.Reset()
 	c.requestSourceStates.Range(func(_, v any) bool {
 		v.(*requestSourceMetricsState).cleanup()

--- a/client/resource_group/controller/global_controller_test.go
+++ b/client/resource_group/controller/global_controller_test.go
@@ -139,6 +139,9 @@ func TestControllerWithTwoGroupRequestConcurrency(t *testing.T) {
 	controller, err := NewResourceGroupController(ctx, 1, mockProvider, nil, constants.NullKeyspaceID)
 	re.NoError(err)
 	controller.Start(ctx)
+	defer func() {
+		re.NoError(controller.Stop())
+	}()
 
 	defaultResourceGroup := &rmpb.ResourceGroup{Name: defaultResourceGroupName, Mode: rmpb.GroupMode_RUMode, RUSettings: &rmpb.GroupRequestUnitSettings{RU: &rmpb.TokenBucket{Settings: &rmpb.TokenLimitSettings{FillRate: 1000000}}}}
 	testResourceGroup := &rmpb.ResourceGroup{Name: "test-group", Mode: rmpb.GroupMode_RUMode, RUSettings: &rmpb.GroupRequestUnitSettings{RU: &rmpb.TokenBucket{Settings: &rmpb.TokenLimitSettings{FillRate: 1000000}}}}
@@ -254,6 +257,9 @@ func TestTryGetController(t *testing.T) {
 	controller, err := NewResourceGroupController(ctx, 1, mockProvider, nil, constants.NullKeyspaceID)
 	re.NoError(err)
 	controller.Start(ctx)
+	defer func() {
+		re.NoError(controller.Stop())
+	}()
 
 	defaultResourceGroup := &rmpb.ResourceGroup{Name: defaultResourceGroupName, Mode: rmpb.GroupMode_RUMode, RUSettings: &rmpb.GroupRequestUnitSettings{RU: &rmpb.TokenBucket{Settings: &rmpb.TokenLimitSettings{FillRate: 1000000}}}}
 	testResourceGroup := &rmpb.ResourceGroup{Name: "test-group", Mode: rmpb.GroupMode_RUMode, RUSettings: &rmpb.GroupRequestUnitSettings{RU: &rmpb.TokenBucket{Settings: &rmpb.TokenLimitSettings{FillRate: 1000000}}}}
@@ -342,6 +348,9 @@ func TestGetResourceGroup(t *testing.T) {
 		re := require.New(t)
 		controller, err := NewResourceGroupController(ctx, 1, provider, nil, constants.NullKeyspaceID, opts...)
 		re.NoError(err)
+		t.Cleanup(func() {
+			re.NoError(controller.Stop())
+		})
 		return controller
 	}
 
@@ -620,6 +629,9 @@ func TestTokenBucketsRequestWithKeyspaceID(t *testing.T) {
 		controller, err := NewResourceGroupController(ctx, 1, mockProvider, nil, keyspaceID)
 		re.NoError(err)
 		controller.Start(ctx)
+		defer func() {
+			re.NoError(controller.Stop())
+		}()
 
 		testResourceGroup := &rmpb.ResourceGroup{
 			Name: "test-group",
@@ -667,6 +679,9 @@ func TestGetRUVersionDefault(t *testing.T) {
 	mockProvider := newMockResourceGroupProvider()
 	gc, err := NewResourceGroupController(context.Background(), 1, mockProvider, nil, 1)
 	re.NoError(err)
+	defer func() {
+		re.NoError(gc.Stop())
+	}()
 
 	// Default should return 1 (v1) when no policy is set.
 	re.Equal(int32(1), gc.GetRUVersion())
@@ -677,6 +692,9 @@ func TestGetRUVersionAfterSet(t *testing.T) {
 	mockProvider := newMockResourceGroupProvider()
 	gc, err := NewResourceGroupController(context.Background(), 1, mockProvider, nil, 1)
 	re.NoError(err)
+	defer func() {
+		re.NoError(gc.Stop())
+	}()
 
 	// Simulate ru_version update via atomic store.
 	gc.ruVersion.Store(3)
@@ -697,6 +715,9 @@ func TestRUVersionFromControllerConfig(t *testing.T) {
 	// keyspaceID = 42
 	gc, err := NewResourceGroupController(context.Background(), 1, mockProvider, nil, 42)
 	re.NoError(err)
+	defer func() {
+		re.NoError(gc.Stop())
+	}()
 
 	// Simulate a controller config with RUVersionPolicy containing an override for keyspace 42.
 	config := DefaultConfig()
@@ -714,6 +735,9 @@ func TestRUVersionOverrideFromControllerConfig(t *testing.T) {
 	// keyspaceID = 42
 	gc, err := NewResourceGroupController(context.Background(), 1, mockProvider, nil, 42)
 	re.NoError(err)
+	defer func() {
+		re.NoError(gc.Stop())
+	}()
 
 	// Override takes precedence over default.
 	config := DefaultConfig()
@@ -731,6 +755,9 @@ func TestRUVersionDefaultFallback(t *testing.T) {
 	// keyspaceID = 42, no override for 42
 	gc, err := NewResourceGroupController(context.Background(), 1, mockProvider, nil, 42)
 	re.NoError(err)
+	defer func() {
+		re.NoError(gc.Stop())
+	}()
 
 	config := DefaultConfig()
 	config.RUVersionPolicy = &RUVersionPolicy{
@@ -747,6 +774,9 @@ func TestRUVersionNilPolicy(t *testing.T) {
 	mockProvider := newMockResourceGroupProvider()
 	gc, err := NewResourceGroupController(context.Background(), 1, mockProvider, nil, 42)
 	re.NoError(err)
+	defer func() {
+		re.NoError(gc.Stop())
+	}()
 
 	// Set a non-default version first.
 	gc.ruVersion.Store(5)
@@ -786,6 +816,9 @@ func TestRUVersionFromInitialControllerConfig(t *testing.T) {
 
 	gc, err := NewResourceGroupController(context.Background(), 1, mockProvider, nil, 42)
 	re.NoError(err)
+	defer func() {
+		re.NoError(gc.Stop())
+	}()
 	// The initial load should set ruVersion from the policy.
 	re.Equal(int32(3), gc.GetRUVersion())
 }
@@ -808,6 +841,9 @@ func TestRUVersionWatchViaControllerConfig(t *testing.T) {
 	controller, err := NewResourceGroupController(ctx, 1, mockProvider, nil, 42)
 	re.NoError(err)
 	controller.Start(ctx)
+	defer func() {
+		re.NoError(controller.Stop())
+	}()
 
 	// Case 1: Config with RUVersionPolicy containing override for keyspace 42
 	configWithPolicy := &Config{

--- a/client/resource_group/controller/ownership.go
+++ b/client/resource_group/controller/ownership.go
@@ -1,0 +1,83 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"sync"
+
+	"github.com/tikv/pd/client/errs"
+)
+
+// controllerOwnership enforces the process-wide single-controller contract:
+// at most one ResourceGroupsController acquired through
+// NewResourceGroupController may exist in a process at a time. The contract
+// exists because several integrations around the controller are process-global
+// and carry no controller identity, e.g. the resource-control Prometheus
+// collectors, the enableControllerTraceLog flag, and the client-go
+// resource-control interceptor.
+//
+// The ownership slot is reserved before the controller is constructed (the
+// constructor performs network I/O and updates process-global state), bound to
+// the controller on success, and released either on a failed construction or
+// by an idempotent Stop. Canceling the context passed to Start stops the run
+// loop but does NOT release ownership; callers must call Stop explicitly.
+type controllerOwnership struct {
+	mu sync.Mutex
+	// reserved is true while a constructor holds the slot but has not bound
+	// a controller to it yet.
+	reserved bool
+	// owner is the controller currently holding the slot.
+	owner *ResourceGroupsController
+}
+
+// ownership is the process-wide ownership slot.
+var ownership controllerOwnership
+
+// reserve claims the slot for a construction in progress. It returns
+// ErrClientResourceGroupControllerAlreadyExists if the slot is held.
+func (o *controllerOwnership) reserve() error {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if o.reserved || o.owner != nil {
+		return errs.ErrClientResourceGroupControllerAlreadyExists.FastGenByArgs()
+	}
+	o.reserved = true
+	return nil
+}
+
+// unreserve releases a reservation after a failed construction.
+func (o *controllerOwnership) unreserve() {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.reserved = false
+}
+
+// bind transfers the reservation to the successfully constructed controller.
+func (o *controllerOwnership) bind(c *ResourceGroupsController) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.owner = c
+	o.reserved = false
+}
+
+// release frees the slot if and only if c is the current owner, so a stale
+// controller's Stop cannot release a newer controller's slot.
+func (o *controllerOwnership) release(c *ResourceGroupsController) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if o.owner == c {
+		o.owner = nil
+	}
+}

--- a/client/resource_group/controller/ownership.go
+++ b/client/resource_group/controller/ownership.go
@@ -20,33 +20,23 @@ import (
 	"github.com/tikv/pd/client/errs"
 )
 
-// controllerOwnership enforces the process-wide single-controller contract:
-// at most one ResourceGroupsController acquired through
-// NewResourceGroupController may exist in a process at a time. The contract
-// exists because several integrations around the controller are process-global
-// and carry no controller identity, e.g. the resource-control Prometheus
-// collectors, the enableControllerTraceLog flag, and the client-go
-// resource-control interceptor.
-//
-// The ownership slot is reserved before the controller is constructed (the
-// constructor performs network I/O and updates process-global state), bound to
-// the controller on success, and released either on a failed construction or
-// by an idempotent Stop. Canceling the context passed to Start stops the run
-// loop but does NOT release ownership; callers must call Stop explicitly.
+// controllerOwnership enforces the single-controller contract of
+// tikv/pd#11080: at most one ResourceGroupsController acquired through
+// NewResourceGroupController may exist in a process at a time, because the
+// integrations around the controller (Prometheus collectors, the trace-log
+// flag, the client-go interceptor) are process-global and carry no
+// controller identity. The slot is released only by an explicit Stop; in
+// particular, canceling the context passed to Start does not release it.
 type controllerOwnership struct {
 	mu sync.Mutex
-	// reserved is true while a constructor holds the slot but has not bound
-	// a controller to it yet.
+	// reserved marks a construction in progress, before a controller is
+	// bound to the slot.
 	reserved bool
-	// owner is the controller currently holding the slot.
-	owner *ResourceGroupsController
+	owner    *ResourceGroupsController
 }
 
-// ownership is the process-wide ownership slot.
 var ownership controllerOwnership
 
-// reserve claims the slot for a construction in progress. It returns
-// ErrClientResourceGroupControllerAlreadyExists if the slot is held.
 func (o *controllerOwnership) reserve() error {
 	o.mu.Lock()
 	defer o.mu.Unlock()
@@ -57,14 +47,12 @@ func (o *controllerOwnership) reserve() error {
 	return nil
 }
 
-// unreserve releases a reservation after a failed construction.
 func (o *controllerOwnership) unreserve() {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	o.reserved = false
 }
 
-// bind transfers the reservation to the successfully constructed controller.
 func (o *controllerOwnership) bind(c *ResourceGroupsController) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
@@ -72,8 +60,8 @@ func (o *controllerOwnership) bind(c *ResourceGroupsController) {
 	o.reserved = false
 }
 
-// release frees the slot if and only if c is the current owner, so a stale
-// controller's Stop cannot release a newer controller's slot.
+// release only honors the current owner, so a stale controller's Stop cannot
+// free a newer controller's slot.
 func (o *controllerOwnership) release(c *ResourceGroupsController) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
@@ -82,7 +70,6 @@ func (o *controllerOwnership) release(c *ResourceGroupsController) {
 	}
 }
 
-// owns reports whether c currently holds the slot.
 func (o *controllerOwnership) owns(c *ResourceGroupsController) bool {
 	o.mu.Lock()
 	defer o.mu.Unlock()

--- a/client/resource_group/controller/ownership.go
+++ b/client/resource_group/controller/ownership.go
@@ -81,3 +81,10 @@ func (o *controllerOwnership) release(c *ResourceGroupsController) {
 		o.owner = nil
 	}
 }
+
+// owns reports whether c currently holds the slot.
+func (o *controllerOwnership) owns(c *ResourceGroupsController) bool {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.owner == c
+}

--- a/client/resource_group/controller/ownership_test.go
+++ b/client/resource_group/controller/ownership_test.go
@@ -1,0 +1,158 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/kvproto/pkg/meta_storagepb"
+
+	"github.com/tikv/pd/client/constants"
+	"github.com/tikv/pd/client/errs"
+)
+
+// TestControllerOwnershipExclusive verifies that acquiring a second controller
+// fails while the first one owns the process-wide slot.
+func TestControllerOwnershipExclusive(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mockProvider := newMockResourceGroupProvider()
+
+	c1, err := NewResourceGroupController(ctx, 1, mockProvider, nil, constants.NullKeyspaceID)
+	re.NoError(err)
+	defer func() {
+		re.NoError(c1.Stop())
+	}()
+
+	// A second acquisition must fail deterministically, both before and
+	// after the first controller is started.
+	_, err = NewResourceGroupController(ctx, 2, mockProvider, nil, constants.NullKeyspaceID)
+	re.ErrorIs(err, errs.ErrClientResourceGroupControllerAlreadyExists)
+	c1.Start(ctx)
+	_, err = NewResourceGroupController(ctx, 2, mockProvider, nil, constants.NullKeyspaceID)
+	re.ErrorIs(err, errs.ErrClientResourceGroupControllerAlreadyExists)
+}
+
+// TestControllerOwnershipReleaseOnStop verifies that stopping a started or an
+// unstarted controller releases ownership exactly once, and that a replacement
+// can be acquired after a complete shutdown.
+func TestControllerOwnershipReleaseOnStop(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mockProvider := newMockResourceGroupProvider()
+
+	// Stopping an unstarted controller releases ownership.
+	c1, err := NewResourceGroupController(ctx, 1, mockProvider, nil, constants.NullKeyspaceID)
+	re.NoError(err)
+	re.NoError(c1.Stop())
+
+	// A replacement can be acquired, and stopping a started controller
+	// releases ownership as well.
+	c2, err := NewResourceGroupController(ctx, 2, mockProvider, nil, constants.NullKeyspaceID)
+	re.NoError(err)
+	c2.Start(ctx)
+	re.NoError(c2.Stop())
+	// Stop is idempotent.
+	re.NoError(c2.Stop())
+
+	// A stale controller's Stop must not release the current owner's slot.
+	c3, err := NewResourceGroupController(ctx, 3, mockProvider, nil, constants.NullKeyspaceID)
+	re.NoError(err)
+	re.NoError(c1.Stop())
+	re.NoError(c2.Stop())
+	_, err = NewResourceGroupController(ctx, 4, mockProvider, nil, constants.NullKeyspaceID)
+	re.ErrorIs(err, errs.ErrClientResourceGroupControllerAlreadyExists)
+	re.NoError(c3.Stop())
+
+	// A stopped controller cannot be started again.
+	c3.Start(ctx)
+	re.Nil(c3.loopCtx)
+}
+
+// TestControllerOwnershipNotLeakedOnInitFailure verifies that a failed
+// construction does not leak the ownership slot.
+func TestControllerOwnershipNotLeakedOnInitFailure(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	failingProvider := &MockResourceGroupProvider{}
+	failingProvider.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(
+		(*meta_storagepb.GetResponse)(nil), errors.New("mock load config error"))
+	_, err := NewResourceGroupController(ctx, 1, failingProvider, nil, constants.NullKeyspaceID)
+	re.Error(err)
+	re.NotErrorIs(err, errs.ErrClientResourceGroupControllerAlreadyExists)
+
+	// The slot must be available again after the failure.
+	mockProvider := newMockResourceGroupProvider()
+	c, err := NewResourceGroupController(ctx, 1, mockProvider, nil, constants.NullKeyspaceID)
+	re.NoError(err)
+	re.NoError(c.Stop())
+}
+
+// TestControllerOwnershipConcurrent verifies that concurrent acquire/stop
+// attempts never let two controllers own the slot at the same time.
+func TestControllerOwnershipConcurrent(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mockProvider := newMockResourceGroupProvider()
+
+	var (
+		wg        sync.WaitGroup
+		active    atomic.Int32
+		successes atomic.Int32
+		overlaps  atomic.Int32
+	)
+	for i := range 16 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 8 {
+				c, err := NewResourceGroupController(ctx, uint64(i), mockProvider, nil, constants.NullKeyspaceID)
+				if err != nil {
+					continue
+				}
+				successes.Add(1)
+				if active.Add(1) > 1 {
+					overlaps.Add(1)
+				}
+				// Decrement before Stop: ownership is still held here, so
+				// no other goroutine can acquire until Stop releases it.
+				active.Add(-1)
+				if err := c.Stop(); err != nil {
+					overlaps.Add(1)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	re.Zero(overlaps.Load())
+	re.Positive(successes.Load())
+
+	// The slot must end up free.
+	c, err := NewResourceGroupController(ctx, 1, mockProvider, nil, constants.NullKeyspaceID)
+	re.NoError(err)
+	re.NoError(c.Stop())
+}

--- a/client/resource_group/controller/ownership_test.go
+++ b/client/resource_group/controller/ownership_test.go
@@ -258,6 +258,58 @@ func TestStopUnstartedControllerCleansMetrics(t *testing.T) {
 	re.Zero(gaugeSeriesCount(metrics.ResourceGroupStatusGauge))
 }
 
+// TestControllerDoubleStart verifies that a second Start is refused instead
+// of launching a duplicate run loop whose context could never be canceled.
+func TestControllerDoubleStart(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mockProvider := newMockResourceGroupProvider()
+
+	c, err := NewResourceGroupController(ctx, 1, mockProvider, nil, constants.NullKeyspaceID)
+	re.NoError(err)
+	c.Start(ctx)
+	loopCtx := c.loopCtx
+	c.Start(ctx)
+	re.Same(loopCtx, c.loopCtx, "second Start must not replace the run loop context")
+	re.NoError(c.Stop())
+}
+
+// TestForeignControllerStopDoesNotDisturbOwner verifies that stopping a
+// controller allocated outside the supported API neither releases the
+// owner's slot nor clears the owner's process-global metric state.
+func TestForeignControllerStopDoesNotDisturbOwner(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mockProvider := newMockResourceGroupProvider()
+	group := &rmpb.ResourceGroup{
+		Name: "owner_group",
+		Mode: rmpb.GroupMode_RUMode,
+		RUSettings: &rmpb.GroupRequestUnitSettings{
+			RU: &rmpb.TokenBucket{
+				Settings: &rmpb.TokenLimitSettings{FillRate: 1000},
+			},
+		},
+	}
+	mockProvider.On("GetResourceGroup", mock.Anything, "owner_group", mock.Anything).Return(group, nil)
+
+	owner, err := NewResourceGroupController(ctx, 1, mockProvider, nil, constants.NullKeyspaceID)
+	re.NoError(err)
+	_, err = owner.tryGetResourceGroupController(ctx, "owner_group", false)
+	re.NoError(err)
+	re.NotZero(gaugeSeriesCount(metrics.ResourceGroupStatusGauge))
+
+	foreign := &ResourceGroupsController{}
+	re.NoError(foreign.Stop())
+	re.NotZero(gaugeSeriesCount(metrics.ResourceGroupStatusGauge))
+	_, err = NewResourceGroupController(ctx, 2, mockProvider, nil, constants.NullKeyspaceID)
+	re.ErrorIs(err, errs.ErrClientResourceGroupControllerAlreadyExists)
+
+	re.NoError(owner.Stop())
+	re.Zero(gaugeSeriesCount(metrics.ResourceGroupStatusGauge))
+}
+
 // gaugeSeriesCount returns the number of series currently exported by vec.
 func gaugeSeriesCount(vec *prometheus.GaugeVec) int {
 	ch := make(chan prometheus.Metric)

--- a/client/resource_group/controller/ownership_test.go
+++ b/client/resource_group/controller/ownership_test.go
@@ -20,14 +20,17 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/meta_storagepb"
+	rmpb "github.com/pingcap/kvproto/pkg/resource_manager"
 
 	"github.com/tikv/pd/client/constants"
 	"github.com/tikv/pd/client/errs"
+	"github.com/tikv/pd/client/resource_group/controller/metrics"
 )
 
 // TestControllerOwnershipExclusive verifies that acquiring a second controller
@@ -48,6 +51,9 @@ func TestControllerOwnershipExclusive(t *testing.T) {
 	// after the first controller is started.
 	_, err = NewResourceGroupController(ctx, 2, mockProvider, nil, constants.NullKeyspaceID)
 	re.ErrorIs(err, errs.ErrClientResourceGroupControllerAlreadyExists)
+	// The rejection happens before any side effect: the provider has served
+	// exactly one config load (from the first acquisition).
+	mockProvider.AssertNumberOfCalls(t, "Get", 1)
 	c1.Start(ctx)
 	_, err = NewResourceGroupController(ctx, 2, mockProvider, nil, constants.NullKeyspaceID)
 	re.ErrorIs(err, errs.ErrClientResourceGroupControllerAlreadyExists)
@@ -124,6 +130,7 @@ func TestControllerOwnershipConcurrent(t *testing.T) {
 		active    atomic.Int32
 		successes atomic.Int32
 		overlaps  atomic.Int32
+		stopErrs  atomic.Int32
 	)
 	for i := range 16 {
 		wg.Add(1)
@@ -142,17 +149,125 @@ func TestControllerOwnershipConcurrent(t *testing.T) {
 				// no other goroutine can acquire until Stop releases it.
 				active.Add(-1)
 				if err := c.Stop(); err != nil {
-					overlaps.Add(1)
+					stopErrs.Add(1)
 				}
 			}
 		}()
 	}
 	wg.Wait()
 	re.Zero(overlaps.Load())
+	re.Zero(stopErrs.Load())
 	re.Positive(successes.Load())
 
 	// The slot must end up free.
 	c, err := NewResourceGroupController(ctx, 1, mockProvider, nil, constants.NullKeyspaceID)
 	re.NoError(err)
 	re.NoError(c.Stop())
+}
+
+// TestControllerOwnershipHeldAfterContextCancel verifies that canceling the
+// context passed to Start stops the run loop but does not release the
+// process-wide ownership slot; only an explicit Stop does.
+func TestControllerOwnershipHeldAfterContextCancel(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	mockProvider := newMockResourceGroupProvider()
+
+	c, err := NewResourceGroupController(ctx, 1, mockProvider, nil, constants.NullKeyspaceID)
+	re.NoError(err)
+	c.Start(ctx)
+	cancel()
+	// Wait for the run loop to exit; the slot must still be held.
+	c.wg.Wait()
+	_, err = NewResourceGroupController(context.Background(), 2, mockProvider, nil, constants.NullKeyspaceID)
+	re.ErrorIs(err, errs.ErrClientResourceGroupControllerAlreadyExists)
+
+	re.NoError(c.Stop())
+	replacement, err := NewResourceGroupController(context.Background(), 3, mockProvider, nil, constants.NullKeyspaceID)
+	re.NoError(err)
+	re.NoError(replacement.Stop())
+}
+
+// TestControllerConcurrentStartStop verifies that a Stop racing a Start can
+// neither leak a run loop that no longer owns the slot nor leave the slot
+// held after both return.
+func TestControllerConcurrentStartStop(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mockProvider := newMockResourceGroupProvider()
+
+	for range 50 {
+		c, err := NewResourceGroupController(ctx, 1, mockProvider, nil, constants.NullKeyspaceID)
+		re.NoError(err)
+		var (
+			wg      sync.WaitGroup
+			stopErr error
+		)
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			c.Start(ctx)
+		}()
+		go func() {
+			defer wg.Done()
+			stopErr = c.Stop()
+		}()
+		wg.Wait()
+		re.NoError(stopErr)
+		// Whichever side won, no run loop may survive Stop: either Start
+		// was refused, or Stop canceled the started loop and waited for it.
+		c.wg.Wait()
+		// The slot must be free for a replacement.
+		replacement, err := NewResourceGroupController(ctx, 2, mockProvider, nil, constants.NullKeyspaceID)
+		re.NoError(err)
+		re.NoError(replacement.Stop())
+	}
+}
+
+// TestStopUnstartedControllerCleansMetrics verifies that stopping a
+// controller that was used but never started still cleans the process-global
+// metric state before releasing the slot.
+func TestStopUnstartedControllerCleansMetrics(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mockProvider := newMockResourceGroupProvider()
+	group := &rmpb.ResourceGroup{
+		Name: "unstarted_cleanup",
+		Mode: rmpb.GroupMode_RUMode,
+		RUSettings: &rmpb.GroupRequestUnitSettings{
+			RU: &rmpb.TokenBucket{
+				Settings: &rmpb.TokenLimitSettings{FillRate: 1000},
+			},
+		},
+	}
+	mockProvider.On("GetResourceGroup", mock.Anything, "unstarted_cleanup", mock.Anything).Return(group, nil)
+
+	c, err := NewResourceGroupController(ctx, 1, mockProvider, nil, constants.NullKeyspaceID)
+	re.NoError(err)
+	// Controller methods are usable before Start and populate the
+	// process-global status gauge.
+	_, err = c.tryGetResourceGroupController(ctx, "unstarted_cleanup", false)
+	re.NoError(err)
+	re.NotZero(gaugeSeriesCount(metrics.ResourceGroupStatusGauge))
+
+	// Stop on the unstarted controller must clean the process-global state
+	// before handing the slot to a replacement.
+	re.NoError(c.Stop())
+	re.Zero(gaugeSeriesCount(metrics.ResourceGroupStatusGauge))
+}
+
+// gaugeSeriesCount returns the number of series currently exported by vec.
+func gaugeSeriesCount(vec *prometheus.GaugeVec) int {
+	ch := make(chan prometheus.Metric)
+	go func() {
+		vec.Collect(ch)
+		close(ch)
+	}()
+	count := 0
+	for range ch {
+		count++
+	}
+	return count
 }

--- a/client/resource_group/controller/request_source_metrics_test.go
+++ b/client/resource_group/controller/request_source_metrics_test.go
@@ -192,6 +192,9 @@ func TestCleanupResourceGroupRemovesRequestSourceMetrics(t *testing.T) {
 	mockProvider := newMockResourceGroupProvider()
 	controller, err := NewResourceGroupController(ctx, 1, mockProvider, nil, 0)
 	re.NoError(err)
+	defer func() {
+		re.NoError(controller.Stop())
+	}()
 
 	group := &rmpb.ResourceGroup{
 		Name: "request-source-cleanup",
@@ -246,6 +249,9 @@ func TestCleanupDoesNotReexportExistingCachedHandle(t *testing.T) {
 	mockProvider := newMockResourceGroupProvider()
 	controller, err := NewResourceGroupController(ctx, 1, mockProvider, nil, 0)
 	re.NoError(err)
+	defer func() {
+		re.NoError(controller.Stop())
+	}()
 
 	group := &rmpb.ResourceGroup{
 		Name: "request-source-cleanup-cached-handle",
@@ -306,6 +312,9 @@ func TestCleanupPreventsRecreateRequestSourceMetrics(t *testing.T) {
 	mockProvider := newMockResourceGroupProvider()
 	controller, err := NewResourceGroupController(ctx, 1, mockProvider, nil, 0)
 	re.NoError(err)
+	defer func() {
+		re.NoError(controller.Stop())
+	}()
 
 	group := &rmpb.ResourceGroup{
 		Name: "request-source-cleanup-prevent-recreate",
@@ -365,6 +374,9 @@ func TestTombstoneCleanupRemovesExistingRequestSourceMetrics(t *testing.T) {
 	mockProvider := newMockResourceGroupProvider()
 	controller, err := NewResourceGroupController(ctx, 1, mockProvider, nil, 0)
 	re.NoError(err)
+	defer func() {
+		re.NoError(controller.Stop())
+	}()
 
 	group := &rmpb.ResourceGroup{
 		Name: "request-source-tombstone-cleanup",
@@ -426,6 +438,9 @@ func TestRevivedResourceGroupCleanupRemovesExistingRequestSourceMetrics(t *testi
 	mockProvider := newMockResourceGroupProvider()
 	controller, err := NewResourceGroupController(ctx, 1, mockProvider, nil, 0)
 	re.NoError(err)
+	defer func() {
+		re.NoError(controller.Stop())
+	}()
 
 	group := &rmpb.ResourceGroup{
 		Name: "request-source-revive-cleanup",
@@ -506,6 +521,9 @@ func TestGetOrCreateAfterCleanupReturnsFreshState(t *testing.T) {
 	mockProvider := newMockResourceGroupProvider()
 	controller, err := NewResourceGroupController(ctx, 1, mockProvider, nil, 0)
 	re.NoError(err)
+	defer func() {
+		re.NoError(controller.Stop())
+	}()
 
 	group := &rmpb.ResourceGroup{
 		Name: "request-source-create-after-cleanup",
@@ -592,6 +610,9 @@ func TestCleanupThenRecreateViaFullPath(t *testing.T) {
 	mockProvider := newMockResourceGroupProvider()
 	controller, err := NewResourceGroupController(ctx, 1, mockProvider, nil, 0)
 	re.NoError(err)
+	defer func() {
+		re.NoError(controller.Stop())
+	}()
 
 	group := &rmpb.ResourceGroup{
 		Name: "request-source-full-recreate",
@@ -663,6 +684,9 @@ func TestStopCleansUpRequestSourceMetricsState(t *testing.T) {
 	mockProvider := newMockResourceGroupProvider()
 	c, err := NewResourceGroupController(ctx, 1, mockProvider, nil, 0)
 	re.NoError(err)
+	defer func() {
+		re.NoError(c.Stop())
+	}()
 
 	group := &rmpb.ResourceGroup{
 		Name: "request-source-stop-cleanup",

--- a/tests/integrations/mcs/resourcemanager/resource_manager_test.go
+++ b/tests/integrations/mcs/resourcemanager/resource_manager_test.go
@@ -802,6 +802,12 @@ func (suite *resourceManagerClientTestSuite) TestWatchWithSingleGroupByKeyspace(
 	keyspaceController, err := controller.NewResourceGroupController(suite.ctx, 1, cli, nil, constants.NullKeyspaceID, controller.EnableSingleGroupByKeyspace())
 	re.NoError(err)
 	keyspaceController.Start(suite.ctx)
+	// Deferred backstop: Stop is idempotent, so this is a no-op after the
+	// inline Stop below, but keeps a mid-test failure from leaving the
+	// ownership slot held and cascading into later tests.
+	defer func() {
+		re.NoError(keyspaceController.Stop())
+	}()
 
 	_, _, _, _, err = keyspaceController.OnRequestWait(suite.ctx, group.Name, tcs.makeReadRequest())
 	re.NoError(err)
@@ -1809,9 +1815,12 @@ func (suite *resourceManagerClientTestSuite) TestLoadRequestUnitConfig() {
 	re := suite.Require()
 	cli := suite.client
 	// Test load from resource manager.
-	ctr, err := controller.NewResourceGroupController(suite.ctx, 1, cli, nil, constants.NullKeyspaceID)
+	ctr1, err := controller.NewResourceGroupController(suite.ctx, 1, cli, nil, constants.NullKeyspaceID)
 	re.NoError(err)
-	config := ctr.GetConfig()
+	defer func() {
+		re.NoError(ctr1.Stop())
+	}()
+	config := ctr1.GetConfig()
 	re.NotNil(config)
 	expectedConfig := controller.DefaultRUConfig()
 	re.Equal(expectedConfig.ReadBaseCost, config.ReadBaseCost)
@@ -1820,7 +1829,7 @@ func (suite *resourceManagerClientTestSuite) TestLoadRequestUnitConfig() {
 	re.Equal(expectedConfig.WriteBytesCost, config.WriteBytesCost)
 	re.Equal(expectedConfig.CPUMsCost, config.CPUMsCost)
 	// Release the ownership before acquiring the replacement.
-	re.NoError(ctr.Stop())
+	re.NoError(ctr1.Stop())
 	// Test init from given config.
 	ruConfig := &controller.RequestUnitConfig{
 		ReadBaseCost:     1,
@@ -1829,12 +1838,12 @@ func (suite *resourceManagerClientTestSuite) TestLoadRequestUnitConfig() {
 		WriteCostPerByte: 4,
 		CPUMsCost:        5,
 	}
-	ctr, err = controller.NewResourceGroupController(suite.ctx, 1, cli, ruConfig, constants.NullKeyspaceID)
+	ctr2, err := controller.NewResourceGroupController(suite.ctx, 1, cli, ruConfig, constants.NullKeyspaceID)
 	re.NoError(err)
 	defer func() {
-		re.NoError(ctr.Stop())
+		re.NoError(ctr2.Stop())
 	}()
-	config = ctr.GetConfig()
+	config = ctr2.GetConfig()
 	re.NotNil(config)
 	controllerConfig := controller.DefaultConfig()
 	controllerConfig.RequestUnit = *ruConfig
@@ -2015,6 +2024,11 @@ func (suite *resourceManagerClientTestSuite) TestResourceGroupControllerConfigCh
 	c1, err := controller.NewResourceGroupController(suite.ctx, 1, cli, nil, constants.NullKeyspaceID)
 	re.NoError(err)
 	c1.Start(suite.ctx)
+	// Deferred backstop for a mid-test failure; a no-op after the inline
+	// Stop below since Stop is idempotent.
+	defer func() {
+		re.NoError(c1.Stop())
+	}()
 	// helper function for sending HTTP requests and checking responses
 	sendRequest := func(method, url string, body io.Reader) []byte {
 		req, err := http.NewRequest(method, url, body)
@@ -2114,6 +2128,9 @@ func (suite *resourceManagerClientTestSuite) TestResourceGroupControllerConfigCh
 	c2, err := controller.NewResourceGroupController(suite.ctx, 2, cli, nil, constants.NullKeyspaceID, controller.WithMaxWaitDuration(time.Hour))
 	re.NoError(err)
 	c2.Start(suite.ctx)
+	defer func() {
+		re.NoError(c2.Stop())
+	}()
 	expectRUCfg2 := *expectRUCfg
 	// always apply the client option
 	expectRUCfg2.LTBMaxWaitDuration = time.Hour
@@ -2133,8 +2150,10 @@ func (suite *resourceManagerClientTestSuite) TestResourceGroupControllerConfigCh
 	// construction.
 	c3, err := controller.NewResourceGroupController(suite.ctx, 3, cli, nil, constants.NullKeyspaceID)
 	re.NoError(err)
+	defer func() {
+		re.NoError(c3.Stop())
+	}()
 	re.Equal(expectRUCfg, c3.GetConfig())
-	re.NoError(c3.Stop())
 }
 
 func (suite *resourceManagerClientTestSuite) TestResourceGroupCURDWithKeyspace() {
@@ -2415,6 +2434,11 @@ func (suite *resourceManagerClientTestSuite) TestLoadAndWatchWithDifferentKeyspa
 		c, err := controller.NewResourceGroupController(suite.ctx, clientID, cli, nil, keyspace)
 		re.NoError(err)
 		c.Start(suite.ctx)
+		// Cleanup backstop for a mid-iteration failure; a no-op after the
+		// inline Stop at the end of the iteration since Stop is idempotent.
+		suite.T().Cleanup(func() {
+			re.NoError(c.Stop())
+		})
 
 		// Test to load resource groups: only the controller's own keyspace
 		// group is visible to it.

--- a/tests/integrations/mcs/resourcemanager/resource_manager_test.go
+++ b/tests/integrations/mcs/resourcemanager/resource_manager_test.go
@@ -802,9 +802,8 @@ func (suite *resourceManagerClientTestSuite) TestWatchWithSingleGroupByKeyspace(
 	keyspaceController, err := controller.NewResourceGroupController(suite.ctx, 1, cli, nil, constants.NullKeyspaceID, controller.EnableSingleGroupByKeyspace())
 	re.NoError(err)
 	keyspaceController.Start(suite.ctx)
-	// Deferred backstop: Stop is idempotent, so this is a no-op after the
-	// inline Stop below, but keeps a mid-test failure from leaving the
-	// ownership slot held and cascading into later tests.
+	// Backstop: a mid-test failure must not leave the ownership slot held,
+	// which would fail every later test in the suite.
 	defer func() {
 		re.NoError(keyspaceController.Stop())
 	}()
@@ -1062,9 +1061,7 @@ func (suite *resourceManagerClientTestSuite) TestSwitchBurst() {
 	controller, err := controller.NewResourceGroupController(suite.ctx, 1, cli, cfg, constants.NullKeyspaceID, controller.EnableSingleGroupByKeyspace())
 	re.NoError(err)
 	controller.Start(suite.ctx)
-	// Backstop for a mid-test failure; a no-op after the inline Stop at the
-	// end of the test since Stop is idempotent. Without it, a held ownership
-	// slot would fail every later test in the suite.
+	// Backstop for a mid-test failure; Stop is idempotent.
 	defer func() {
 		re.NoError(controller.Stop())
 	}()
@@ -2042,8 +2039,7 @@ func (suite *resourceManagerClientTestSuite) TestResourceGroupControllerConfigCh
 	c1, err := controller.NewResourceGroupController(suite.ctx, 1, cli, nil, constants.NullKeyspaceID)
 	re.NoError(err)
 	c1.Start(suite.ctx)
-	// Deferred backstop for a mid-test failure; a no-op after the inline
-	// Stop below since Stop is idempotent.
+	// Backstop for a mid-test failure; Stop is idempotent.
 	defer func() {
 		re.NoError(c1.Stop())
 	}()
@@ -2440,10 +2436,9 @@ func (suite *resourceManagerClientTestSuite) TestLoadAndWatchWithDifferentKeyspa
 		re.Contains(resp, "Success!")
 	}
 
-	// For each keyspace in turn, run one active controller and verify that it
-	// loads and watches only its own keyspace's resource groups. The process
-	// contract allows at most one active controller at a time, so the
-	// per-keyspace coverage is sequential.
+	// One active controller per keyspace in turn (the process contract
+	// forbids coexistence), verifying that each loads and watches only its
+	// own keyspace's resource groups.
 	clientID := uint64(1)
 	tcs := tokenConsumptionPerSecond{rruTokensAtATime: 100}
 	fillRate := uint64(12345)
@@ -2452,8 +2447,7 @@ func (suite *resourceManagerClientTestSuite) TestLoadAndWatchWithDifferentKeyspa
 		c, err := controller.NewResourceGroupController(suite.ctx, clientID, cli, nil, keyspace)
 		re.NoError(err)
 		c.Start(suite.ctx)
-		// Cleanup backstop for a mid-iteration failure; a no-op after the
-		// inline Stop at the end of the iteration since Stop is idempotent.
+		// Backstop for a mid-iteration failure; Stop is idempotent.
 		suite.T().Cleanup(func() {
 			re.NoError(c.Stop())
 		})

--- a/tests/integrations/mcs/resourcemanager/resource_manager_test.go
+++ b/tests/integrations/mcs/resourcemanager/resource_manager_test.go
@@ -1062,6 +1062,12 @@ func (suite *resourceManagerClientTestSuite) TestSwitchBurst() {
 	controller, err := controller.NewResourceGroupController(suite.ctx, 1, cli, cfg, constants.NullKeyspaceID, controller.EnableSingleGroupByKeyspace())
 	re.NoError(err)
 	controller.Start(suite.ctx)
+	// Backstop for a mid-test failure; a no-op after the inline Stop at the
+	// end of the test since Stop is idempotent. Without it, a held ownership
+	// slot would fail every later test in the suite.
+	defer func() {
+		re.NoError(controller.Stop())
+	}()
 	resourceGroupName := suite.initGroups[1].Name
 	tcs := tokenConsumptionPerSecond{rruTokensAtATime: 1, wruTokensAtATime: 2, times: 100, waitDuration: 0}
 	for range tcs.times {
@@ -1195,6 +1201,9 @@ func (suite *resourceManagerClientTestSuite) TestResourcePenalty() {
 	c, err := controller.NewResourceGroupController(suite.ctx, 1, cli, cfg, constants.NullKeyspaceID, controller.EnableSingleGroupByKeyspace())
 	re.NoError(err)
 	c.Start(suite.ctx)
+	defer func() {
+		re.NoError(c.Stop())
+	}()
 
 	resourceGroupName := groupNames[0]
 	// init
@@ -1783,6 +1792,9 @@ func (suite *resourceManagerClientTestSuite) TestResourceManagerClientDegradedMo
 	controller, err := controller.NewResourceGroupController(suite.ctx, 1, cli, cfg, constants.NullKeyspaceID)
 	re.NoError(err)
 	controller.Start(suite.ctx)
+	defer func() {
+		re.NoError(controller.Stop())
+	}()
 	tc := tokenConsumptionPerSecond{
 		rruTokensAtATime: 0,
 		wruTokensAtATime: 10000,
@@ -1885,6 +1897,9 @@ func (suite *resourceManagerClientTestSuite) TestRemoveStaleResourceGroup() {
 	controller, err := controller.NewResourceGroupController(suite.ctx, 1, cli, nil, constants.NullKeyspaceID)
 	re.NoError(err)
 	controller.Start(suite.ctx)
+	defer func() {
+		re.NoError(controller.Stop())
+	}()
 
 	testConfig := struct {
 		tcs   tokenConsumptionPerSecond
@@ -1953,6 +1968,9 @@ func (suite *resourceManagerClientTestSuite) TestCheckBackgroundJobs() {
 	c, err := controller.NewResourceGroupController(suite.ctx, 1, cli, nil, constants.NullKeyspaceID)
 	re.NoError(err)
 	c.Start(suite.ctx)
+	defer func() {
+		re.NoError(c.Stop())
+	}()
 
 	resourceGroupName := enableBackgroundGroup(false)
 	re.False(c.IsBackgroundRequest(suite.ctx, resourceGroupName, "internal_default"))

--- a/tests/integrations/mcs/resourcemanager/resource_manager_test.go
+++ b/tests/integrations/mcs/resourcemanager/resource_manager_test.go
@@ -761,20 +761,6 @@ func (suite *resourceManagerClientTestSuite) TestWatchWithSingleGroupByKeyspace(
 	defer func() {
 		re.NoError(failpoint.Disable("github.com/tikv/pd/client/resource_group/controller/disableWatch"))
 	}()
-	// Distinguish the controller with and without enabling `isSingleGroupByKeyspace`.
-	controllerKeySpace, err := controller.NewResourceGroupController(suite.ctx, 1, cli, nil, constants.NullKeyspaceID, controller.EnableSingleGroupByKeyspace())
-	re.NoError(err)
-	controller, err := controller.NewResourceGroupController(suite.ctx, 2, cli, nil, constants.NullKeyspaceID)
-	re.NoError(err)
-	controller.Start(suite.ctx)
-	controllerKeySpace.Start(suite.ctx)
-	defer func() {
-		err := controller.Stop()
-		re.NoError(err)
-		err = controllerKeySpace.Stop()
-		re.NoError(err)
-	}()
-
 	// Mock add resource group.
 	group := &rmpb.ResourceGroup{
 		Name: "keyspace_test",
@@ -801,18 +787,6 @@ func (suite *resourceManagerClientTestSuite) TestWatchWithSingleGroupByKeyspace(
 	}, testutil.WithTickInterval(50*time.Millisecond))
 
 	tcs := tokenConsumptionPerSecond{rruTokensAtATime: 100}
-	_, _, _, _, err = controller.OnRequestWait(suite.ctx, group.Name, tcs.makeReadRequest())
-	re.NoError(err)
-	meta := controller.GetActiveResourceGroup(group.Name)
-	re.NotNil(meta)
-	re.Equal(meta.RUSettings.RU, group.RUSettings.RU)
-
-	_, _, _, _, err = controllerKeySpace.OnRequestWait(suite.ctx, group.Name, tcs.makeReadRequest())
-	re.NoError(err)
-	metaKeySpace := controllerKeySpace.GetActiveResourceGroup(group.Name)
-	re.Equal(metaKeySpace.RUSettings.RU, group.RUSettings.RU)
-
-	// Mock modify resource groups
 	modifySettings := func(gs *rmpb.ResourceGroup, fillRate uint64) {
 		gs.RUSettings = &rmpb.GroupRequestUnitSettings{
 			RU: &rmpb.TokenBucket{
@@ -822,17 +796,60 @@ func (suite *resourceManagerClientTestSuite) TestWatchWithSingleGroupByKeyspace(
 			},
 		}
 	}
+
+	// Phase 1: a controller with `isSingleGroupByKeyspace` enabled loads the
+	// group but does not watch subsequent modifications.
+	keyspaceController, err := controller.NewResourceGroupController(suite.ctx, 1, cli, nil, constants.NullKeyspaceID, controller.EnableSingleGroupByKeyspace())
+	re.NoError(err)
+	keyspaceController.Start(suite.ctx)
+
+	_, _, _, _, err = keyspaceController.OnRequestWait(suite.ctx, group.Name, tcs.makeReadRequest())
+	re.NoError(err)
+	metaKeySpace := keyspaceController.GetActiveResourceGroup(group.Name)
+	re.NotNil(metaKeySpace)
+	re.Equal(metaKeySpace.RUSettings.RU, group.RUSettings.RU)
+
+	// Mock modify resource groups
 	modifySettings(group, 20000)
 	resp, err = cli.ModifyResourceGroup(suite.ctx, group)
 	re.NoError(err)
 	re.Contains(resp, "Success!")
-
+	// Wait until the modification is persisted and visible on the read path...
 	testutil.Eventually(re, func() bool {
-		meta = controller.GetActiveResourceGroup(group.Name)
-		return meta.RUSettings.RU.Settings.FillRate == uint64(20000)
-	}, testutil.WithTickInterval(100*time.Millisecond))
-	metaKeySpace = controllerKeySpace.GetActiveResourceGroup(group.Name)
+		g, err := cli.GetResourceGroup(suite.ctx, group.Name)
+		return err == nil && g.RUSettings.RU.Settings.FillRate == uint64(20000)
+	}, testutil.WithTickInterval(50*time.Millisecond))
+	// ...and verify that the single-group-by-keyspace controller does not
+	// watch it.
+	metaKeySpace = keyspaceController.GetActiveResourceGroup(group.Name)
 	re.Equal(uint64(10000), metaKeySpace.RUSettings.RU.Settings.FillRate)
+
+	// Release the ownership before acquiring the replacement.
+	re.NoError(keyspaceController.Stop())
+
+	// Phase 2: a normal controller loads the latest settings and watches
+	// subsequent modifications.
+	normalController, err := controller.NewResourceGroupController(suite.ctx, 2, cli, nil, constants.NullKeyspaceID)
+	re.NoError(err)
+	normalController.Start(suite.ctx)
+	defer func() {
+		re.NoError(normalController.Stop())
+	}()
+
+	_, _, _, _, err = normalController.OnRequestWait(suite.ctx, group.Name, tcs.makeReadRequest())
+	re.NoError(err)
+	meta := normalController.GetActiveResourceGroup(group.Name)
+	re.NotNil(meta)
+	re.Equal(uint64(20000), meta.RUSettings.RU.Settings.FillRate)
+
+	modifySettings(group, 30000)
+	resp, err = cli.ModifyResourceGroup(suite.ctx, group)
+	re.NoError(err)
+	re.Contains(resp, "Success!")
+	testutil.Eventually(re, func() bool {
+		meta = normalController.GetActiveResourceGroup(group.Name)
+		return meta.RUSettings.RU.Settings.FillRate == uint64(30000)
+	}, testutil.WithTickInterval(100*time.Millisecond))
 }
 
 const buffDuration = time.Millisecond * 300
@@ -1802,6 +1819,8 @@ func (suite *resourceManagerClientTestSuite) TestLoadRequestUnitConfig() {
 	re.Equal(expectedConfig.WriteBaseCost, config.WriteBaseCost)
 	re.Equal(expectedConfig.WriteBytesCost, config.WriteBytesCost)
 	re.Equal(expectedConfig.CPUMsCost, config.CPUMsCost)
+	// Release the ownership before acquiring the replacement.
+	re.NoError(ctr.Stop())
 	// Test init from given config.
 	ruConfig := &controller.RequestUnitConfig{
 		ReadBaseCost:     1,
@@ -1812,6 +1831,9 @@ func (suite *resourceManagerClientTestSuite) TestLoadRequestUnitConfig() {
 	}
 	ctr, err = controller.NewResourceGroupController(suite.ctx, 1, cli, ruConfig, constants.NullKeyspaceID)
 	re.NoError(err)
+	defer func() {
+		re.NoError(ctr.Stop())
+	}()
 	config = ctr.GetConfig()
 	re.NotNil(config)
 	controllerConfig := controller.DefaultConfig()
@@ -1989,17 +2011,10 @@ func (suite *resourceManagerClientTestSuite) TestResourceGroupControllerConfigCh
 	re.NoError(err)
 	re.Contains(resp, "Success!")
 
+	// Phase 1: a default controller observes dynamic configuration changes.
 	c1, err := controller.NewResourceGroupController(suite.ctx, 1, cli, nil, constants.NullKeyspaceID)
 	re.NoError(err)
 	c1.Start(suite.ctx)
-	// with client option
-	c2, err := controller.NewResourceGroupController(suite.ctx, 2, cli, nil, constants.NullKeyspaceID, controller.WithMaxWaitDuration(time.Hour))
-	re.NoError(err)
-	c2.Start(suite.ctx)
-	defer func() {
-		err := c2.Stop()
-		re.NoError(err)
-	}()
 	// helper function for sending HTTP requests and checking responses
 	sendRequest := func(method, url string, body io.Reader) []byte {
 		req, err := http.NewRequest(method, url, body)
@@ -2090,18 +2105,36 @@ func (suite *resourceManagerClientTestSuite) TestResourceGroupControllerConfigCh
 		time.Sleep(500 * time.Millisecond)
 		t.expected(expectRUCfg)
 		re.Equal(expectRUCfg, c1.GetConfig())
+	}
+	re.NoError(c1.Stop())
 
-		expectRUCfg2 := *expectRUCfg
-		// always apply the client option
+	// Phase 2: a controller with a client-side max-wait override loads the
+	// latest server configuration on construction and keeps applying the
+	// override across dynamic configuration changes.
+	c2, err := controller.NewResourceGroupController(suite.ctx, 2, cli, nil, constants.NullKeyspaceID, controller.WithMaxWaitDuration(time.Hour))
+	re.NoError(err)
+	c2.Start(suite.ctx)
+	expectRUCfg2 := *expectRUCfg
+	// always apply the client option
+	expectRUCfg2.LTBMaxWaitDuration = time.Hour
+	re.Equal(&expectRUCfg2, c2.GetConfig())
+	// replay the same server configuration changes and verify each time
+	for _, t := range testCases {
+		sendRequest("POST", getAddr()+configURL, strings.NewReader(t.configJSON))
+		time.Sleep(500 * time.Millisecond)
+		t.expected(expectRUCfg)
+		expectRUCfg2 = *expectRUCfg
 		expectRUCfg2.LTBMaxWaitDuration = time.Hour
 		re.Equal(&expectRUCfg2, c2.GetConfig())
 	}
-	// restart c1
-	err = c1.Stop()
+	re.NoError(c2.Stop())
+
+	// Phase 3: a fresh default controller loads the latest configuration on
+	// construction.
+	c3, err := controller.NewResourceGroupController(suite.ctx, 3, cli, nil, constants.NullKeyspaceID)
 	re.NoError(err)
-	c1, err = controller.NewResourceGroupController(suite.ctx, 1, cli, nil, constants.NullKeyspaceID)
-	re.NoError(err)
-	re.Equal(expectRUCfg, c1.GetConfig())
+	re.Equal(expectRUCfg, c3.GetConfig())
+	re.NoError(c3.Stop())
 }
 
 func (suite *resourceManagerClientTestSuite) TestResourceGroupCURDWithKeyspace() {
@@ -2370,17 +2403,21 @@ func (suite *resourceManagerClientTestSuite) TestLoadAndWatchWithDifferentKeyspa
 		re.Contains(resp, "Success!")
 	}
 
-	// Create controllers for different keyspaces
-	// Test to load resource groups with different keyspaces
+	// For each keyspace in turn, run one active controller and verify that it
+	// loads and watches only its own keyspace's resource groups. The process
+	// contract allows at most one active controller at a time, so the
+	// per-keyspace coverage is sequential.
 	clientID := uint64(1)
 	tcs := tokenConsumptionPerSecond{rruTokensAtATime: 100}
-	controllers := map[uint32]*controller.ResourceGroupsController{}
-	for _, keyspace := range keyspaces {
+	fillRate := uint64(12345)
+	for i, keyspace := range keyspaces {
 		cli := clients[keyspace]
 		c, err := controller.NewResourceGroupController(suite.ctx, clientID, cli, nil, keyspace)
 		re.NoError(err)
-		controllers[keyspace] = c
 		c.Start(suite.ctx)
+
+		// Test to load resource groups: only the controller's own keyspace
+		// group is visible to it.
 		for _, keyspaceToFind := range keyspaces {
 			groupToFind := genGroupByKeyspace(keyspaceToFind)
 			testutil.Eventually(re, func() bool {
@@ -2396,53 +2433,49 @@ func (suite *resourceManagerClientTestSuite) TestLoadAndWatchWithDifferentKeyspa
 				return meta == nil
 			})
 		}
-		clientID += 1
-	}
 
-	// Modify resource groups with different keyspaces
-	fillRate := uint64(12345)
-	for _, keyspace := range keyspaces {
-		cli := clients[keyspace]
-		group := genGroupByKeyspace(keyspace)
-		group.RUSettings.RU.Settings.FillRate = fillRate
-		resp, err := cli.ModifyResourceGroup(suite.ctx, group)
-		re.NoError(err)
-		re.Contains(resp, "Success!")
-	}
-
-	// Test to watch resource groups with different keyspaces
-	for _, keyspace := range keyspaces {
-		c := controllers[keyspace]
+		// Modify resource groups in every keyspace and verify that the
+		// controller watches its own keyspace's modification.
+		for _, keyspaceToModify := range keyspaces {
+			group := genGroupByKeyspace(keyspaceToModify)
+			group.RUSettings.RU.Settings.FillRate = fillRate
+			resp, err := clients[keyspaceToModify].ModifyResourceGroup(suite.ctx, group)
+			re.NoError(err)
+			re.Contains(resp, "Success!")
+		}
 		group := genGroupByKeyspace(keyspace)
 		testutil.Eventually(re, func() bool {
 			meta := c.GetActiveResourceGroup(group.Name)
 			return meta.RUSettings.RU.Settings.FillRate == fillRate
 		})
-	}
 
-	// Delete resource groups with different keyspaces
-	for _, keyspace := range keyspaces {
-		cli := clients[keyspace]
-		group := genGroupByKeyspace(keyspace)
-		resp, err := cli.DeleteResourceGroup(suite.ctx, group.Name)
-		re.NoError(err)
-		re.Contains(resp, "Success!")
-	}
-
-	// Test to watch resource groups with different keyspaces
-	for _, keyspace := range keyspaces {
-		c := controllers[keyspace]
-		group := genGroupByKeyspace(keyspace)
+		// Delete resource groups in every keyspace and verify that the
+		// controller watches its own keyspace's deletion.
+		for _, keyspaceToDelete := range keyspaces {
+			resp, err := clients[keyspaceToDelete].DeleteResourceGroup(suite.ctx, genGroupByKeyspace(keyspaceToDelete).Name)
+			re.NoError(err)
+			re.Contains(resp, "Success!")
+		}
 		testutil.Eventually(re, func() bool {
-			meta := c.GetActiveResourceGroup(group.Name)
-			return meta == nil
+			return c.GetActiveResourceGroup(group.Name) == nil
 		})
+
+		// Release the ownership before the next keyspace's controller.
+		re.NoError(c.Stop())
+		clientID += 1
+
+		// Re-add the resource groups for the next keyspace's iteration.
+		if i < len(keyspaces)-1 {
+			for _, keyspaceToAdd := range keyspaces {
+				resp, err := clients[keyspaceToAdd].AddResourceGroup(suite.ctx, genGroupByKeyspace(keyspaceToAdd))
+				re.NoError(err)
+				re.Contains(resp, "Success!")
+			}
+		}
 	}
 
-	// Stop controllers and close clients
+	// Close the keyspace clients.
 	for _, keyspace := range keyspaces {
-		err := controllers[keyspace].Stop()
-		re.NoError(err)
 		if keyspace == constants.NullKeyspaceID {
 			continue
 		}

--- a/tests/integrations/mcs/resourcemanager/service_limit_test.go
+++ b/tests/integrations/mcs/resourcemanager/service_limit_test.go
@@ -87,9 +87,8 @@ func (suite *serviceLimitTestSuite) SetupTest() {
 }
 
 func (suite *serviceLimitTestSuite) TearDownTest() {
-	// Release the controller ownership so the next test can acquire it. The
-	// nil check keeps a SetupTest failure before the controller assignment
-	// from panicking here and masking the original error.
+	// Release the controller ownership so the next test can acquire it; the
+	// controller is nil when SetupTest failed early.
 	if suite.controller != nil {
 		suite.Require().NoError(suite.controller.Stop())
 	}

--- a/tests/integrations/mcs/resourcemanager/service_limit_test.go
+++ b/tests/integrations/mcs/resourcemanager/service_limit_test.go
@@ -87,6 +87,8 @@ func (suite *serviceLimitTestSuite) SetupTest() {
 }
 
 func (suite *serviceLimitTestSuite) TearDownTest() {
+	// Release the controller ownership so the next test can acquire it.
+	suite.Require().NoError(suite.controller.Stop())
 	suite.cancel()
 	suite.cluster.Destroy()
 }

--- a/tests/integrations/mcs/resourcemanager/service_limit_test.go
+++ b/tests/integrations/mcs/resourcemanager/service_limit_test.go
@@ -87,8 +87,12 @@ func (suite *serviceLimitTestSuite) SetupTest() {
 }
 
 func (suite *serviceLimitTestSuite) TearDownTest() {
-	// Release the controller ownership so the next test can acquire it.
-	suite.Require().NoError(suite.controller.Stop())
+	// Release the controller ownership so the next test can acquire it. The
+	// nil check keeps a SetupTest failure before the controller assignment
+	// from panicking here and masking the original error.
+	if suite.controller != nil {
+		suite.Require().NoError(suite.controller.Stop())
+	}
 	suite.cancel()
 	suite.cluster.Destroy()
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #11080

Current TiDB production code creates one `ResourceGroupsController` per process, and several process-global integrations (Prometheus collectors without controller identity, the `enableControllerTraceLog` flag, client-go's global resource-control interceptor) already assume a unique controller owner. However, `pd/client` did not enforce this: the public API allowed multiple controllers to be constructed and started in one process, leaving an unsupported state reachable by future callers.

### What is changed and how does it work?

This PR implements the pd/client side of the contract described in #11080. The TiDB companion changes (Domain.Close release, initialization error cleanup, bootstrap handoff serialization) are implemented in pingcap/tidb#70456 (tracked by pingcap/tidb#70455). The TiDB changes are compatible with the current pd/client version and do not depend on this PR landing first; conversely, once TiDB picks up this PR through a client upgrade, the explicit release in Domain.Close becomes load-bearing for Domain replacement scenarios.

```commit-message
Several process-global integrations around the resource group
controller assume a unique controller owner: the resource-control
Prometheus collectors carry no controller identity (one controller's
shutdown resets the global status gauge and cleans up shared label
sets), the constructor overwrites the process-global trace-log flag,
and client-go installs the controller into a single global interceptor
pointer. The public API still allowed multiple controllers to be
constructed and started in one process, leaving this unsupported state
reachable by future callers.

Make the single-controller model an explicit lifecycle contract:

- NewResourceGroupController reserves a process-wide ownership slot
  before any side effect and fails a second acquisition with
  ErrClientResourceGroupControllerAlreadyExists; the slot is released
  on every failed initialization path.
- Stop is now idempotent, also valid on a controller that was never
  started, and releases ownership exactly once. Only the current owner
  can release the slot, so a stale controller's Stop cannot release a
  newer controller's slot. A stopped controller can no longer be
  started.
- Existing multi-controller integration tests are converted to
  sequential coverage, and new contract tests cover rejection,
  replacement, release on failed initialization, and concurrent
  acquire/stop.
```

Notes for reviewers:

- The ownership slot is reserved before `loadServerConfig` so that a rejected second acquisition performs no network I/O and does not overwrite the process-global trace-log flag.
- `Stop` no longer returns an error for a controller that was never started; it releases ownership and succeeds idempotently, so callers have a single cleanup path regardless of how far initialization progressed.
- Canceling the context passed to `Start` stops the run loop but does not release ownership; `Stop` must be called explicitly. `serviceLimitTestSuite.TearDownTest` relied on context cancellation only and now calls `Stop`.
- Test migration follows the plan in #11080: `TestWatchWithSingleGroupByKeyspace` and `TestResourceGroupControllerConfigChanged` are split into sequential phases; `TestLoadAndWatchWithDifferentKeyspace` is replaced with sequential per-keyspace coverage, deliberately dropping unsupported same-process multi-controller coexistence coverage while retaining keyspace isolation coverage.

### Check List

Tests

- Unit test
- Integration test

Side effects

- Breaking backward compatibility: constructing a second `ResourceGroupsController` in the same process now returns `ErrClientResourceGroupControllerAlreadyExists` until the previous one is stopped. No known production caller constructs more than one controller per process.

### Release note

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Resource-group controllers now enforce exclusive process-wide ownership.
  - Added a clear error when a controller is already active.
  - Controllers can be safely stopped before starting, and repeated stops are supported.

- **Bug Fixes**
  - Improved cleanup after initialization failures and shutdown.
  - Prevented stale controllers from affecting newer active controllers.
  - Ensured controller metrics are cleaned up reliably during shutdown.

- **Tests**
  - Expanded coverage for ownership conflicts, lifecycle races, cancellation, and metric cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->