### PR TITLE
resource_manager: remove resource group request body limit

### DIFF
--- a/pkg/mcs/resourcemanager/metadataapi/config_service.go
+++ b/pkg/mcs/resourcemanager/metadataapi/config_service.go
@@ -55,10 +55,6 @@ type ConfigStore interface {
 	LookupKeyspaceServiceLimit(uint32) (any, bool)
 }
 
-// Resource groups are small configuration objects. Keep malformed or
-// malicious requests from consuming unbounded memory during JSON decoding.
-const maxResourceGroupRequestBytes int64 = 1 << 20
-
 // ManagerStore adapts rmserver.Manager to ConfigStore.
 type ManagerStore struct {
 	manager *rmserver.Manager
@@ -155,8 +151,8 @@ func (s *ConfigService) Register(configEndpoint *gin.RouterGroup) {
 // PostResourceGroup handles POST /config/group.
 func (s *ConfigService) PostResourceGroup(c *gin.Context) {
 	var group rmpb.ResourceGroup
-	if err := decodeResourceGroup(c, &group); err != nil {
-		respondResourceGroupDecodeError(c, err)
+	if err := decodeResourceGroup(c.Request.Body, &group); err != nil {
+		c.String(http.StatusBadRequest, err.Error())
 		return
 	}
 	if err := s.configStore.AddResourceGroup(&group); err != nil {
@@ -169,8 +165,8 @@ func (s *ConfigService) PostResourceGroup(c *gin.Context) {
 // PutResourceGroup handles PUT /config/group.
 func (s *ConfigService) PutResourceGroup(c *gin.Context) {
 	var group rmpb.ResourceGroup
-	if err := decodeResourceGroup(c, &group); err != nil {
-		respondResourceGroupDecodeError(c, err)
+	if err := decodeResourceGroup(c.Request.Body, &group); err != nil {
+		c.String(http.StatusBadRequest, err.Error())
 		return
 	}
 	if err := s.configStore.ModifyResourceGroup(&group); err != nil {
@@ -180,17 +176,7 @@ func (s *ConfigService) PutResourceGroup(c *gin.Context) {
 	c.String(http.StatusOK, "Success!")
 }
 
-func respondResourceGroupDecodeError(c *gin.Context, err error) {
-	status := http.StatusBadRequest
-	var maxBytesError *http.MaxBytesError
-	if errors.As(err, &maxBytesError) {
-		status = http.StatusRequestEntityTooLarge
-	}
-	c.String(status, err.Error())
-}
-
-func decodeResourceGroup(c *gin.Context, group *rmpb.ResourceGroup) error {
-	body := http.MaxBytesReader(c.Writer, c.Request.Body, maxResourceGroupRequestBytes)
+func decodeResourceGroup(body io.Reader, group *rmpb.ResourceGroup) error {
 	data, err := io.ReadAll(body)
 	if err != nil {
 		return err

--- a/pkg/mcs/resourcemanager/metadataapi/config_service_test.go
+++ b/pkg/mcs/resourcemanager/metadataapi/config_service_test.go
@@ -217,13 +217,6 @@ func TestConfigServiceGroupCRUDAndErrorCodes(t *testing.T) {
 		re.Equal(http.StatusBadRequest, resp.Code)
 		re.NotContains(store.groups, groupKey(constant.NullKeyspaceID, "mixed_json_group"))
 	}
-
-	oversizedBody := bytes.Repeat([]byte("x"), int(maxResourceGroupRequestBytes)+1)
-	for _, method := range []string{http.MethodPost, http.MethodPut} {
-		resp = doRawResourceGroupRequest(handler, method, oversizedBody)
-		re.Equal(http.StatusRequestEntityTooLarge, resp.Code)
-		re.Contains(resp.Body.String(), "request body too large")
-	}
 }
 
 func TestConfigServiceControllerAllOrNothing(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Ref #11025

Resource Group metadata POST and PUT requests are currently limited to 1 MiB.
The hard-coded limit prevents larger valid resource group payloads from being
processed.

The limit was introduced while implementing the APIV3 compatibility work in
#11024. This follow-up only removes that route-specific guard; it does not
implement or close the broader APIV3 dependency tracking in #11025.

### What is changed and how does it work?

Remove the `http.MaxBytesReader` wrapper and pass the request body directly to
the existing Resource Group JSON decoder. JSON decoding failures continue to
return HTTP 400.

Remove the obsolete unit test that expected oversized POST and PUT requests to
return HTTP 413.

```commit-message
Remove the 1 MiB request body limit from Resource Group metadata POST and PUT
handlers. Keep the existing JSON compatibility decoder and error handling.
```

### Check List

Tests

- [x] Unit test
  - `make gotest GOTEST_ARGS="./pkg/mcs/resourcemanager/metadataapi -count=1"`
- [x] Target package lint
  - `golangci-lint run ./pkg/mcs/resourcemanager/metadataapi --allow-parallel-runners`

Code changes

- [x] Has HTTP APIs changed

Side effects

- [x] Possible performance regression

### Release note

```release-note
Remove the 1 MiB request body limit from the Resource Group metadata POST and PUT APIs.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resource-group creation and updates now return a consistent HTTP 400 response when request data cannot be decoded.
  * Removed the previous special handling for oversized request bodies, providing more consistent request validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->