### PR TITLE
*: publish and clear the leader identity away from blocking calls

### DIFF
--- a/pkg/election/lease.go
+++ b/pkg/election/lease.go
@@ -149,6 +149,18 @@ func (l *Lease) Close() error {
 	localTTLRemaining.unregister(l)
 	// Reset expire time.
 	l.expireTime.Store(typeutil.ZeroTime)
+	// Everything below here talks to etcd or logs, so it can block for an
+	// unbounded time when the volume holding the data directory stops completing
+	// writes. This failpoint stands in for that, so a test can assert that the
+	// caller has already given up its identity in memory by the time it gets here.
+	// The pause is bounded rather than open-ended because Server.Close stops the
+	// server loop before it closes the election client, so a wait that only ends
+	// with the client would deadlock the shutdown it is meant to outlive.
+	failpoint.Inject("blockLeaseClose", func(val failpoint.Value) {
+		if l.matchesFailpointTarget(val) {
+			time.Sleep(10 * time.Second)
+		}
+	})
 	// Try to revoke lease to make subsequent elections faster.
 	ctx, cancel := context.WithTimeout(l.client.Ctx(), revokeLeaseTimeout)
 	defer cancel()

--- a/pkg/mcs/resourcemanager/server/server.go
+++ b/pkg/mcs/resourcemanager/server/server.go
@@ -233,11 +233,14 @@ func (s *Server) campaignLeader(expectedPrimary string) bool {
 	// Start keepalive the leadership and enable Resource Manager service.
 	ctx, cancel := context.WithCancel(s.serverLoopCtx)
 	var resetLeaderOnce sync.Once
-	defer resetLeaderOnce.Do(func() {
+	// A named function rather than an inline defer because the step-down branch
+	// below calls it before it logs; see the comment there.
+	resetLeader := func() {
 		cancel()
 		s.participant.Resign()
 		member.ServiceMemberGauge.WithLabelValues(serviceName).Set(0)
-	})
+	}
+	defer resetLeaderOnce.Do(resetLeader)
 
 	// maintain the leadership, after this, Resource Manager could be ready to provide service.
 	s.participant.GetLeadership().Keep(ctx)
@@ -258,9 +261,12 @@ func (s *Server) campaignLeader(expectedPrimary string) bool {
 			return true
 		}
 	}
+	// The ready log is written before the promotion for the same reason as in
+	// PD's campaignLeader: between the promotion and the loop below nothing
+	// checks the lease, so nothing that can block may sit there.
+	log.Info("resource manager primary is ready to serve", zap.String("resource-manager-primary-name", s.participant.Name()))
 	s.participant.PromoteSelf()
 	member.ServiceMemberGauge.WithLabelValues(serviceName).Set(1)
-	log.Info("resource manager primary is ready to serve", zap.String("resource-manager-primary-name", s.participant.Name()))
 
 	leaderTicker := time.NewTicker(constant.LeaderTickInterval)
 	defer leaderTicker.Stop()
@@ -272,11 +278,19 @@ func (s *Server) campaignLeader(expectedPrimary string) bool {
 			// expiration and a `{service}/primary/transfer` API call, which resigns
 			// this primary by revoking its leader lease.
 			if !s.participant.IsServing() {
+				// Resign before logging, not in the deferred reset above. The
+				// log can block for an unbounded time on a stalled volume, and
+				// the primary is reported through GetServingUrls without
+				// consulting IsServing, so a primary that is still waiting on
+				// that log would keep being handed out.
+				resetLeaderOnce.Do(resetLeader)
 				log.Info("no longer a primary/leader because lease has expired or transferred, the resource manager primary/leader will step down")
 				return false
 			}
 		case <-ctx.Done():
-			// Server is closed and it should return nil.
+			// Server is closed. A shutdown log can block just as long as a
+			// step-down log, so the resign comes first here too.
+			resetLeaderOnce.Do(resetLeader)
 			log.Info("server is closed")
 			return false
 		}

--- a/pkg/mcs/resourcemanager/server/server.go
+++ b/pkg/mcs/resourcemanager/server/server.go
@@ -232,15 +232,15 @@ func (s *Server) campaignLeader(expectedPrimary string) bool {
 
 	// Start keepalive the leadership and enable Resource Manager service.
 	ctx, cancel := context.WithCancel(s.serverLoopCtx)
-	var once sync.Once
-	resetLeaderOnce := func() {
-		once.Do(func() {
-			cancel()
-			s.participant.Resign()
-			member.ServiceMemberGauge.WithLabelValues(serviceName).Set(0)
-		})
+	var resetLeaderOnce sync.Once
+	// A named function rather than an inline defer because the step-down branch
+	// below calls it before it logs; see the comment there.
+	resetLeader := func() {
+		cancel()
+		s.participant.Resign()
+		member.ServiceMemberGauge.WithLabelValues(serviceName).Set(0)
 	}
-	defer resetLeaderOnce()
+	defer resetLeaderOnce.Do(resetLeader)
 
 	// maintain the leadership, after this, Resource Manager could be ready to provide service.
 	s.participant.GetLeadership().Keep(ctx)
@@ -283,14 +283,14 @@ func (s *Server) campaignLeader(expectedPrimary string) bool {
 				// the primary is reported through GetServingUrls without
 				// consulting IsServing, so a primary that is still waiting on
 				// that log would keep being handed out.
-				resetLeaderOnce()
+				resetLeaderOnce.Do(resetLeader)
 				log.Info("no longer a primary/leader because lease has expired or transferred, the resource manager primary/leader will step down")
 				return false
 			}
 		case <-ctx.Done():
 			// Server is closed. A shutdown log can block just as long as a
 			// step-down log, so the resign comes first here too.
-			resetLeaderOnce()
+			resetLeaderOnce.Do(resetLeader)
 			log.Info("server is closed")
 			return false
 		}

--- a/pkg/mcs/resourcemanager/server/server.go
+++ b/pkg/mcs/resourcemanager/server/server.go
@@ -232,15 +232,15 @@ func (s *Server) campaignLeader(expectedPrimary string) bool {
 
 	// Start keepalive the leadership and enable Resource Manager service.
 	ctx, cancel := context.WithCancel(s.serverLoopCtx)
-	var resetLeaderOnce sync.Once
-	// A named function rather than an inline defer because the step-down branch
-	// below calls it before it logs; see the comment there.
-	resetLeader := func() {
-		cancel()
-		s.participant.Resign()
-		member.ServiceMemberGauge.WithLabelValues(serviceName).Set(0)
+	var once sync.Once
+	resetLeaderOnce := func() {
+		once.Do(func() {
+			cancel()
+			s.participant.Resign()
+			member.ServiceMemberGauge.WithLabelValues(serviceName).Set(0)
+		})
 	}
-	defer resetLeaderOnce.Do(resetLeader)
+	defer resetLeaderOnce()
 
 	// maintain the leadership, after this, Resource Manager could be ready to provide service.
 	s.participant.GetLeadership().Keep(ctx)
@@ -283,14 +283,14 @@ func (s *Server) campaignLeader(expectedPrimary string) bool {
 				// the primary is reported through GetServingUrls without
 				// consulting IsServing, so a primary that is still waiting on
 				// that log would keep being handed out.
-				resetLeaderOnce.Do(resetLeader)
+				resetLeaderOnce()
 				log.Info("no longer a primary/leader because lease has expired or transferred, the resource manager primary/leader will step down")
 				return false
 			}
 		case <-ctx.Done():
 			// Server is closed. A shutdown log can block just as long as a
 			// step-down log, so the resign comes first here too.
-			resetLeaderOnce.Do(resetLeader)
+			resetLeaderOnce()
 			log.Info("server is closed")
 			return false
 		}

--- a/pkg/mcs/scheduling/server/server.go
+++ b/pkg/mcs/scheduling/server/server.go
@@ -306,11 +306,14 @@ func (s *Server) campaignPrimary(expectedPrimary string) {
 	// Start keepalive the leadership and enable Scheduling service.
 	ctx, cancel := context.WithCancel(s.serverLoopCtx)
 	var resetPrimaryOnce sync.Once
-	defer resetPrimaryOnce.Do(func() {
+	// A named function rather than an inline defer because the step-down branch
+	// below calls it before it logs; see the comment there.
+	resetPrimary := func() {
 		cancel()
 		s.participant.Resign()
 		member.ServiceMemberGauge.WithLabelValues(serviceName).Set(0)
-	})
+	}
+	defer resetPrimaryOnce.Do(resetPrimary)
 
 	// maintain the leadership, after this, Scheduling could be ready to provide service.
 	s.participant.GetLeadership().Keep(ctx)
@@ -333,10 +336,13 @@ func (s *Server) campaignPrimary(expectedPrimary string) {
 			cb()
 		}
 	}()
+	// The ready log is written before the promotion for the same reason as in
+	// PD's campaignLeader: between the promotion and the loop below nothing
+	// checks the lease, so nothing that can block may sit there.
+	log.Info("scheduling primary is ready to serve", zap.String("scheduling-primary-name", s.participant.Name()))
 	s.participant.PromoteSelf()
 
 	member.ServiceMemberGauge.WithLabelValues(serviceName).Set(1)
-	log.Info("scheduling primary is ready to serve", zap.String("scheduling-primary-name", s.participant.Name()))
 
 	primaryTicker := time.NewTicker(constant.PrimaryTickInterval)
 	defer primaryTicker.Stop()
@@ -348,11 +354,19 @@ func (s *Server) campaignPrimary(expectedPrimary string) {
 			// expiration and a `{service}/primary/transfer` API call, which resigns
 			// this primary by revoking its leader lease.
 			if !s.participant.IsServing() {
+				// Resign before logging, not in the deferred reset above. The
+				// log can block for an unbounded time on a stalled volume, and
+				// the primary is reported through GetServingUrls without
+				// consulting IsServing, so a primary that is still waiting on
+				// that log would keep being handed out.
+				resetPrimaryOnce.Do(resetPrimary)
 				log.Info("no longer a primary because lease has expired or transferred, the scheduling primary will step down")
 				return
 			}
 		case <-ctx.Done():
-			// Server is closed and it should return nil.
+			// Server is closed. A shutdown log can block just as long as a
+			// step-down log, so the resign comes first here too.
+			resetPrimaryOnce.Do(resetPrimary)
 			log.Info("server is closed")
 			return
 		}

--- a/pkg/mcs/scheduling/server/server.go
+++ b/pkg/mcs/scheduling/server/server.go
@@ -305,15 +305,15 @@ func (s *Server) campaignPrimary(expectedPrimary string) {
 
 	// Start keepalive the leadership and enable Scheduling service.
 	ctx, cancel := context.WithCancel(s.serverLoopCtx)
-	var once sync.Once
-	resetPrimaryOnce := func() {
-		once.Do(func() {
-			cancel()
-			s.participant.Resign()
-			member.ServiceMemberGauge.WithLabelValues(serviceName).Set(0)
-		})
+	var resetPrimaryOnce sync.Once
+	// A named function rather than an inline defer because the step-down branch
+	// below calls it before it logs; see the comment there.
+	resetPrimary := func() {
+		cancel()
+		s.participant.Resign()
+		member.ServiceMemberGauge.WithLabelValues(serviceName).Set(0)
 	}
-	defer resetPrimaryOnce()
+	defer resetPrimaryOnce.Do(resetPrimary)
 
 	// maintain the leadership, after this, Scheduling could be ready to provide service.
 	s.participant.GetLeadership().Keep(ctx)
@@ -359,14 +359,14 @@ func (s *Server) campaignPrimary(expectedPrimary string) {
 				// the primary is reported through GetServingUrls without
 				// consulting IsServing, so a primary that is still waiting on
 				// that log would keep being handed out.
-				resetPrimaryOnce()
+				resetPrimaryOnce.Do(resetPrimary)
 				log.Info("no longer a primary because lease has expired or transferred, the scheduling primary will step down")
 				return
 			}
 		case <-ctx.Done():
 			// Server is closed. A shutdown log can block just as long as a
 			// step-down log, so the resign comes first here too.
-			resetPrimaryOnce()
+			resetPrimaryOnce.Do(resetPrimary)
 			log.Info("server is closed")
 			return
 		}

--- a/pkg/mcs/scheduling/server/server.go
+++ b/pkg/mcs/scheduling/server/server.go
@@ -305,15 +305,15 @@ func (s *Server) campaignPrimary(expectedPrimary string) {
 
 	// Start keepalive the leadership and enable Scheduling service.
 	ctx, cancel := context.WithCancel(s.serverLoopCtx)
-	var resetPrimaryOnce sync.Once
-	// A named function rather than an inline defer because the step-down branch
-	// below calls it before it logs; see the comment there.
-	resetPrimary := func() {
-		cancel()
-		s.participant.Resign()
-		member.ServiceMemberGauge.WithLabelValues(serviceName).Set(0)
+	var once sync.Once
+	resetPrimaryOnce := func() {
+		once.Do(func() {
+			cancel()
+			s.participant.Resign()
+			member.ServiceMemberGauge.WithLabelValues(serviceName).Set(0)
+		})
 	}
-	defer resetPrimaryOnce.Do(resetPrimary)
+	defer resetPrimaryOnce()
 
 	// maintain the leadership, after this, Scheduling could be ready to provide service.
 	s.participant.GetLeadership().Keep(ctx)
@@ -359,14 +359,14 @@ func (s *Server) campaignPrimary(expectedPrimary string) {
 				// the primary is reported through GetServingUrls without
 				// consulting IsServing, so a primary that is still waiting on
 				// that log would keep being handed out.
-				resetPrimaryOnce.Do(resetPrimary)
+				resetPrimaryOnce()
 				log.Info("no longer a primary because lease has expired or transferred, the scheduling primary will step down")
 				return
 			}
 		case <-ctx.Done():
 			// Server is closed. A shutdown log can block just as long as a
 			// step-down log, so the resign comes first here too.
-			resetPrimaryOnce.Do(resetPrimary)
+			resetPrimaryOnce()
 			log.Info("server is closed")
 			return
 		}

--- a/pkg/member/member.go
+++ b/pkg/member/member.go
@@ -274,9 +274,18 @@ func (m *Member) WatchLeader(ctx context.Context, leader *pdpb.Member, revision 
 
 // Resign is used to reset the PD member's current leadership.
 // Basically it will reset the leader lease and unset leader info.
+//
+// unsetLeader runs first, and the order matters. It is a plain in-memory store,
+// while Reset revokes the lease against the local etcd and logs on failure - both
+// of which can block for an unbounded time when the volume holding the data
+// directory stops completing writes. Two paths report leadership without
+// consulting IsServing: GetMembers reads GetLeader directly, and the v1
+// redirector handles a request locally when `leader.GetName() == self`. Clearing
+// the identity before anything that can block is what keeps a member that is no
+// longer serving from still answering as the leader.
 func (m *Member) Resign() {
-	m.leadership.Reset()
 	m.unsetLeader()
+	m.leadership.Reset()
 }
 
 // CheckPriority checks whether the etcd leader should be moved according to the priority.

--- a/pkg/member/participant.go
+++ b/pkg/member/participant.go
@@ -262,9 +262,15 @@ func (p *Participant) WatchLeader(ctx context.Context, primary participant, revi
 
 // Resign is used to reset the participant's current leadership.
 // Basically it will reset the primary lease and unset primary info.
+//
+// unsetPrimary runs first for the same reason as in Member.Resign: it is a plain
+// in-memory store, while Reset can block for an unbounded time on a stalled
+// volume. The microservice redirector gates purely on IsServing and so has no
+// equivalent of the v1 self-serve branch, but keeping the two implementations in
+// the same order is what stops the difference from becoming load-bearing.
 func (p *Participant) Resign() {
-	p.leadership.Reset()
 	p.unsetPrimary()
+	p.leadership.Reset()
 }
 
 // isSamePrimary checks whether a server is the primary itself.

--- a/pkg/tso/allocator.go
+++ b/pkg/tso/allocator.go
@@ -202,9 +202,13 @@ func (a *Allocator) handleTSOUpdateFailure(stateIDBeforeUpdate uint64, err error
 			append(a.logFields, errs.ZapError(err))...)
 		return
 	}
+	// Reset before logging, for the same reason the step-down branches in
+	// campaignLeader do: the reset gives the leadership up, and on a stalled
+	// volume the log below can block for an unbounded time, leaving a member
+	// that no longer serves still answering as the primary.
+	a.resetAllocatorLocked(true)
 	log.Warn("failed to update allocator's timestamp, resetting the TSO allocator with leadership resignation",
 		append(a.logFields, errs.ZapError(err))...)
-	a.resetAllocatorLocked(true)
 }
 
 // SetTSO sets the physical part with given TSO.
@@ -233,13 +237,17 @@ func (a *Allocator) Reset(resetLeadership bool) {
 
 // resetAllocatorLocked resets the allocator. The caller must hold timestampStateMu.
 func (a *Allocator) resetAllocatorLocked(resetLeadership bool) {
-	a.timestampStateID++
-	a.tsoAllocatorRoleGauge.Set(0)
-	a.timestampOracle.resetTimestamp()
-	// Reset if it still has the leadership. Otherwise the data race may occur because of the re-campaigning.
+	// Resign first if it still has the leadership. (Only then - otherwise the
+	// data race may occur because of the re-campaigning.) Resign clears the
+	// in-memory identity before anything else it does, while resetTimestamp
+	// below logs synchronously, so the other order leaves a blocked log sink
+	// holding the identity up.
 	if resetLeadership && a.isServing() {
 		a.member.Resign()
 	}
+	a.timestampStateID++
+	a.tsoAllocatorRoleGauge.Set(0)
+	a.timestampOracle.resetTimestamp()
 }
 
 // The PD server will conduct its own leadership election independently of the TSO allocator,
@@ -362,17 +370,22 @@ func (a *Allocator) campaignPrimary(expectedPrimary string) {
 		a.Reset(false)
 	}()
 
+	// The ready log is written before the promotion for the same reason as in
+	// campaignLeader: between the promotion and the loop below nothing checks
+	// the lease, so nothing that can block may sit there.
+	log.Info("tso primary is ready to serve", a.logFields...)
 	a.member.PromoteSelf()
 
 	tsoLabel := fmt.Sprintf("TSO Service Group %d", a.keyspaceGroupID)
 	member.ServiceMemberGauge.WithLabelValues(tsoLabel).Set(1)
-	defer resetPrimaryOnce.Do(func() {
+	// A named function rather than an inline defer because the step-down branch
+	// below calls it before it logs; see the comment there.
+	resetPrimary := func() {
 		cancel()
 		a.member.Resign()
 		member.ServiceMemberGauge.WithLabelValues(tsoLabel).Set(0)
-	})
-
-	log.Info("tso primary is ready to serve", a.logFields...)
+	}
+	defer resetPrimaryOnce.Do(resetPrimary)
 
 	primaryTicker := time.NewTicker(constant.PrimaryTickInterval)
 	defer primaryTicker.Stop()
@@ -384,11 +397,19 @@ func (a *Allocator) campaignPrimary(expectedPrimary string) {
 			// expiration and a `{service}/primary/transfer` API call, which resigns
 			// this primary by revoking its leader lease.
 			if !a.isServing() {
+				// Resign before logging, not in the deferred reset below. The
+				// log can block for an unbounded time on a stalled volume, and
+				// GetPrimaryAddr reports this member through GetServingUrls
+				// without consulting isServing, so a primary that is still
+				// waiting on that log would keep being handed out.
+				resetPrimaryOnce.Do(resetPrimary)
 				log.Info("no longer a primary because lease has expired or transferred, the tso primary will step down", a.logFields...)
 				return
 			}
 		case <-ctx.Done():
-			// Server is closed and it should return nil.
+			// Server is closed. A shutdown log can block just as long as a
+			// step-down log, so the resign comes first here too.
+			resetPrimaryOnce.Do(resetPrimary)
 			log.Info("exit primary campaign", a.logFields...)
 			return
 		}

--- a/pkg/tso/allocator.go
+++ b/pkg/tso/allocator.go
@@ -345,8 +345,8 @@ func (a *Allocator) campaignPrimary(expectedPrimary string) {
 	//   1. lease based approach is not affected by thread pause, slow runtime schedule, etc.
 	//   2. load region could be slow. Based on lease we can recover TSO service faster.
 	ctx, cancel := context.WithCancel(a.ctx)
-	var once sync.Once
-	defer once.Do(func() {
+	var resetPrimaryOnce sync.Once
+	defer resetPrimaryOnce.Do(func() {
 		cancel()
 		a.member.Resign()
 	})
@@ -366,7 +366,7 @@ func (a *Allocator) campaignPrimary(expectedPrimary string) {
 		return
 	}
 	defer func() {
-		// Primary will be reset by the deferred resignation.
+		// Primary will be reset in `resetPrimaryOnce` later.
 		a.Reset(false)
 	}()
 
@@ -378,14 +378,14 @@ func (a *Allocator) campaignPrimary(expectedPrimary string) {
 
 	tsoLabel := fmt.Sprintf("TSO Service Group %d", a.keyspaceGroupID)
 	member.ServiceMemberGauge.WithLabelValues(tsoLabel).Set(1)
-	resetPrimaryOnce := func() {
-		once.Do(func() {
-			cancel()
-			a.member.Resign()
-			member.ServiceMemberGauge.WithLabelValues(tsoLabel).Set(0)
-		})
+	// A named function rather than an inline defer because the step-down branch
+	// below calls it before it logs; see the comment there.
+	resetPrimary := func() {
+		cancel()
+		a.member.Resign()
+		member.ServiceMemberGauge.WithLabelValues(tsoLabel).Set(0)
 	}
-	defer resetPrimaryOnce()
+	defer resetPrimaryOnce.Do(resetPrimary)
 
 	primaryTicker := time.NewTicker(constant.PrimaryTickInterval)
 	defer primaryTicker.Stop()
@@ -402,14 +402,14 @@ func (a *Allocator) campaignPrimary(expectedPrimary string) {
 				// GetPrimaryAddr reports this member through GetServingUrls
 				// without consulting isServing, so a primary that is still
 				// waiting on that log would keep being handed out.
-				resetPrimaryOnce()
+				resetPrimaryOnce.Do(resetPrimary)
 				log.Info("no longer a primary because lease has expired or transferred, the tso primary will step down", a.logFields...)
 				return
 			}
 		case <-ctx.Done():
 			// Server is closed. A shutdown log can block just as long as a
 			// step-down log, so the resign comes first here too.
-			resetPrimaryOnce()
+			resetPrimaryOnce.Do(resetPrimary)
 			log.Info("exit primary campaign", a.logFields...)
 			return
 		}

--- a/pkg/tso/allocator.go
+++ b/pkg/tso/allocator.go
@@ -345,8 +345,8 @@ func (a *Allocator) campaignPrimary(expectedPrimary string) {
 	//   1. lease based approach is not affected by thread pause, slow runtime schedule, etc.
 	//   2. load region could be slow. Based on lease we can recover TSO service faster.
 	ctx, cancel := context.WithCancel(a.ctx)
-	var resetPrimaryOnce sync.Once
-	defer resetPrimaryOnce.Do(func() {
+	var once sync.Once
+	defer once.Do(func() {
 		cancel()
 		a.member.Resign()
 	})
@@ -366,7 +366,7 @@ func (a *Allocator) campaignPrimary(expectedPrimary string) {
 		return
 	}
 	defer func() {
-		// Primary will be reset in `resetPrimaryOnce` later.
+		// Primary will be reset by the deferred resignation.
 		a.Reset(false)
 	}()
 
@@ -378,14 +378,14 @@ func (a *Allocator) campaignPrimary(expectedPrimary string) {
 
 	tsoLabel := fmt.Sprintf("TSO Service Group %d", a.keyspaceGroupID)
 	member.ServiceMemberGauge.WithLabelValues(tsoLabel).Set(1)
-	// A named function rather than an inline defer because the step-down branch
-	// below calls it before it logs; see the comment there.
-	resetPrimary := func() {
-		cancel()
-		a.member.Resign()
-		member.ServiceMemberGauge.WithLabelValues(tsoLabel).Set(0)
+	resetPrimaryOnce := func() {
+		once.Do(func() {
+			cancel()
+			a.member.Resign()
+			member.ServiceMemberGauge.WithLabelValues(tsoLabel).Set(0)
+		})
 	}
-	defer resetPrimaryOnce.Do(resetPrimary)
+	defer resetPrimaryOnce()
 
 	primaryTicker := time.NewTicker(constant.PrimaryTickInterval)
 	defer primaryTicker.Stop()
@@ -402,14 +402,14 @@ func (a *Allocator) campaignPrimary(expectedPrimary string) {
 				// GetPrimaryAddr reports this member through GetServingUrls
 				// without consulting isServing, so a primary that is still
 				// waiting on that log would keep being handed out.
-				resetPrimaryOnce.Do(resetPrimary)
+				resetPrimaryOnce()
 				log.Info("no longer a primary because lease has expired or transferred, the tso primary will step down", a.logFields...)
 				return
 			}
 		case <-ctx.Done():
 			// Server is closed. A shutdown log can block just as long as a
 			// step-down log, so the resign comes first here too.
-			resetPrimaryOnce.Do(resetPrimary)
+			resetPrimaryOnce()
 			log.Info("exit primary campaign", a.logFields...)
 			return
 		}

--- a/pkg/tso/tso.go
+++ b/pkg/tso/tso.go
@@ -343,6 +343,9 @@ func (t *timestampOracle) updateTimestamp(purpose updatePurpose) (bool, error) {
 	}
 	prevPhysical, prevLogical := t.getTSO()
 
+	failpoint.Inject("failedToUpdateTimestamp", func() {
+		failpoint.Return(false, errs.ErrEtcdTxnInternal)
+	})
 	now := time.Now()
 	failpoint.Inject("fallBackUpdate", func() {
 		now = now.Add(time.Hour)

--- a/server/server.go
+++ b/server/server.go
@@ -2033,10 +2033,32 @@ func (s *Server) campaignLeader() {
 	//   2. load region could be slow. Based on lease we can recover TSO service faster.
 	ctx, cancel := context.WithCancel(s.serverLoopCtx)
 	var resetLeaderOnce sync.Once
-	defer resetLeaderOnce.Do(func() {
+	// As soon as the leadership keepalive is cancelled, another member has a
+	// chance to become the new leader.
+	//
+	// This is a named function rather than an inline defer because the step-down
+	// branches below call it before they log. Logging writes to a file that may
+	// share a volume with the data directory, so on a stalled volume it can block
+	// for an unbounded time - long enough that a deferred resign would never run
+	// and the member would keep answering as the leader through the paths that do
+	// not consult IsServing. Resigning first bounds that to the in-memory stores
+	// at the top of Member.Resign.
+	resetLeader := func() {
 		cancel()
 		s.member.Resign()
-	})
+		member.ServiceMemberGauge.WithLabelValues(PD).Set(0)
+	}
+	defer resetLeaderOnce.Do(resetLeader)
+
+	// stepDownAndLog gives the leadership up before it writes down the reason.
+	// Every exit from the loop below goes through it, so that the ordering is a
+	// property of this function rather than something each branch has to
+	// remember: separating the two again would reintroduce the bug this exists
+	// to prevent.
+	stepDownAndLog := func(msg string, fields ...zap.Field) {
+		resetLeaderOnce.Do(resetLeader)
+		log.Info(msg, fields...)
+	}
 
 	// maintain the PD leadership, after this, TSO can be service.
 	log.Info("start to keep leader lease")
@@ -2101,26 +2123,38 @@ func (s *Server) campaignLeader() {
 	}
 	rebaseDuration := time.Since(rebaseStart)
 	log.Info("sync id from etcd completed", zap.Duration("cost", rebaseDuration))
-	// PromoteSelf to accept the remaining service, such as GetStore, GetRegion.
-	enableLeaderStart := time.Now()
-	s.member.PromoteSelf()
-	enableLeaderDuration := time.Since(enableLeaderStart)
-	member.ServiceMemberGauge.WithLabelValues(PD).Set(1)
-	totalDuration := time.Since(leaderReadyStart)
-	defer resetLeaderOnce.Do(func() {
-		// as soon as cancel the leadership keepalive, then other member have chance
-		// to be new leader.
-		cancel()
-		s.member.Resign()
-		member.ServiceMemberGauge.WithLabelValues(PD).Set(0)
-	})
-
 	CheckPDVersionWithClusterVersion(s.persistOptions)
+	totalDuration := time.Since(leaderReadyStart)
+	// The ready log is written before the promotion on purpose. It is a
+	// synchronous file write, and between the promotion and the loop below
+	// nothing checks the lease - a member that promoted first and then blocked
+	// on this log would keep reporting itself as the leader for as long as a
+	// stalled volume holds the write, with no step-down path running yet. The
+	// failpoint stands in for that blocked write; the pause is bounded for the
+	// same reason as in Lease.Close.
+	failpoint.Inject("blockReadyToServe", func(val failpoint.Value) {
+		if memberFailpointEnabled(val, s.member.ID()) {
+			time.Sleep(10 * time.Second)
+		}
+	})
 	log.Info("PD leader is ready to serve",
 		zap.String("leader-name", s.Name()),
-		zap.Duration("total-cost", totalDuration),
-		zap.Duration("cost", enableLeaderDuration))
+		zap.Duration("total-cost", totalDuration))
+	// Capturing the cleanup term needs only the leadership and its lease, both
+	// in place since Campaign, so this may run ahead of the promotion.
 	s.scheduleMicroserviceMetadataCleanup(ctx)
+	// PromoteSelf to accept the remaining service, such as GetStore, GetRegion.
+	// It is the last step of stepping up: from here on only the loop below
+	// notices an expired lease, so nothing that can block may sit between it
+	// and the loop.
+	s.member.PromoteSelf()
+	member.ServiceMemberGauge.WithLabelValues(PD).Set(1)
+	// Registered a second time on purpose, and it is not dead code: deferred
+	// calls run last in first out, so this one runs before the stopRaftCluster
+	// defer above, which waits on background jobs that can take an unbounded
+	// time. The leadership has to be gone before that wait starts.
+	// `resetLeaderOnce` is what makes the duplicate invocation harmless.
+	defer resetLeaderOnce.Do(resetLeader)
 	leaderTicker := time.NewTicker(mcs.LeaderTickInterval)
 	defer leaderTicker.Stop()
 
@@ -2128,25 +2162,28 @@ func (s *Server) campaignLeader() {
 		select {
 		case <-leaderTicker.C:
 			if !s.member.IsServing() {
-				log.Info("no longer a leader because lease has expired, PD leader will step down")
+				stepDownAndLog("no longer a leader because lease has expired, PD leader will step down")
 				return
 			}
 			// add failpoint to test exit leader, failpoint judge the member is the give value, then break
 			failpoint.Inject("exitCampaignLeader", func(val failpoint.Value) {
 				if memberFailpointEnabled(val, s.member.ID()) {
-					log.Info("exit PD leader")
+					stepDownAndLog("exit PD leader")
 					failpoint.Return()
 				}
 			})
 
 			etcdLeader := s.member.GetEtcdLeader()
 			if etcdLeader != s.member.ID() {
-				log.Info("etcd leader changed, resigns pd leadership", zap.String("old-pd-leader-name", s.Name()))
+				stepDownAndLog("etcd leader changed, resigns pd leadership", zap.String("old-pd-leader-name", s.Name()))
 				return
 			}
 		case <-ctx.Done():
-			// Server is closed and it should return nil.
-			log.Info("server is closed")
+			// Server is closed and it should return nil. This is a shutdown
+			// rather than a step-down, but it reaches the same deferred resign
+			// through a log call that can block just as long, so it gives the
+			// leadership up first for the same reason.
+			stepDownAndLog("server is closed")
 			return
 		}
 	}

--- a/tests/server/member/member_test.go
+++ b/tests/server/member/member_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -33,6 +34,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/pdpb"
+	"github.com/pingcap/log"
 
 	"github.com/tikv/pd/pkg/utils/testutil"
 	"github.com/tikv/pd/pkg/utils/typeutil"
@@ -542,4 +544,314 @@ func TestPDLeaderStepsDownWhenRenewalsFail(t *testing.T) {
 		return !oldLeader.IsServing()
 	}, testutil.WithWaitFor(30*time.Second))
 	re.NotEqual(oldLeaderName, waitLeaderChange(re, cluster, oldLeaderName))
+}
+
+// TestPDLeaderClearsIdentityBeforeBlockingCleanup asserts the ordering inside the
+// step-down path: the in-memory leader identity is dropped before anything that
+// can block for an unbounded time.
+//
+// Two paths report leadership without consulting IsServing - GetMembers reads
+// GetLeader directly, and the v1 redirector handles a request locally when the
+// cached leader name is its own - so a member whose cleanup never finishes would
+// otherwise keep answering as the leader for as long as a storage stall lasts.
+func TestPDLeaderClearsIdentityBeforeBlockingCleanup(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// One member is enough: everything asserted below is this member's own
+	// in-memory state, and no peer has to take over for the assertions to mean
+	// what they say.
+	cluster, err := tests.NewTestCluster(ctx, 1)
+	re.NoError(err)
+	defer cluster.Destroy()
+	re.NoError(cluster.RunInitialServers())
+
+	leaderName := cluster.WaitLeader()
+	re.NotEmpty(leaderName)
+	leaderServer := cluster.GetServer(leaderName).GetServer()
+	re.True(leaderServer.IsServing())
+
+	// The lease this member currently holds. Its ID is what pins the assertion
+	// below to the term being given up here; see the comment on the conjunction.
+	oldLease := leaderServer.GetMember().GetLeadership().GetLease()
+	re.NotNil(oldLease)
+	oldLeaseID := oldLease.GetID()
+	re.NotEqual(clientv3.NoLease, oldLeaseID)
+
+	// Stand in for the part of the cleanup that can block. Everything in
+	// Lease.Close past this point either talks to the local etcd or logs, and on
+	// a stalled volume neither of those returns.
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/election/blockLeaseClose",
+		fmt.Sprintf("return(\"leader election@%s\")", leaderName)))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/election/blockLeaseClose"))
+	}()
+	// Fail renewals so the local deadline is what ends the term.
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/election/keepAliveFailed",
+		fmt.Sprintf("return(\"leader election@%s\")", leaderName)))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/election/keepAliveFailed"))
+	}()
+
+	// All four have to hold at the same instant, and that conjunction is the
+	// whole point of the test:
+	//
+	//   - the leader is already nil;
+	//   - the leader value is still set, which Leadership.Reset clears only after
+	//     Lease.Close returns, so the cleanup is provably still blocked;
+	//   - the lease reads as expired, so this is a term being given up rather
+	//     than one being campaigned for;
+	//   - and it is still the *same* lease, which is what makes the previous two
+	//     mean what they appear to mean.
+	//
+	// That last conjunct is what makes the first three mean what they appear to.
+	// Leadership.Campaign stores a non-empty leader value and installs a fresh
+	// lease before it grants that lease, and a fresh lease has no expire time and
+	// so reads as expired - so the first three are also satisfied while a
+	// campaign is in flight, and go on being satisfied indefinitely after one
+	// fails, since campaignLeader returns on a failed Campaign before it sets up
+	// the resign at all. Neither case arises in this one-member cluster, where
+	// Campaign does not fail and the in-flight window is a single local Grant
+	// wide, so the lease ID is not what makes the test fail today under a
+	// reversed Member.Resign. It is what keeps the assertion honest if the test
+	// grows back to several members, and what stops the failed-campaign state
+	// from ever standing in for a step-down. Reset never replaces the lease and
+	// Close never clears its ID, so the ID stays put through the blocked close,
+	// while every campaign installs a lease whose ID is either zero or newly
+	// assigned by etcd.
+	testutil.Eventually(re, func() bool {
+		m := leaderServer.GetMember()
+		return m.GetLeader() == nil &&
+			m.GetLeadership().GetLeaderValue() != "" &&
+			!m.GetLeadership().Check() &&
+			m.GetLeadership().GetLease().GetID() == oldLeaseID
+	}, testutil.WithWaitFor(30*time.Second))
+}
+
+// TestPDLeaderResignsBeforeLoggingStepDown covers the other half of the same
+// ordering, the one inside campaignLeader: the leadership is given up before the
+// line explaining why it was given up is written.
+//
+// The two are separate because they can be reversed separately. Member.Resign
+// puts the in-memory stores ahead of the lease teardown; campaignLeader puts the
+// whole resign ahead of its own log call. Logging is not obviously blocking, but
+// it writes to a file that can share a volume with the data directory, and on a
+// stalled volume it does not return - which is exactly when the member must not
+// still be answering as the leader.
+func TestPDLeaderResignsBeforeLoggingStepDown(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cluster, err := tests.NewTestCluster(ctx, 1)
+	re.NoError(err)
+	defer cluster.Destroy()
+	re.NoError(cluster.RunInitialServers())
+
+	leaderName := cluster.WaitLeader()
+	re.NotEmpty(leaderName)
+	leaderServer := cluster.GetServer(leaderName).GetServer()
+	re.True(leaderServer.IsServing())
+
+	oldLease := leaderServer.GetMember().GetLeadership().GetLease()
+	re.NotNil(oldLease)
+	oldLeaseID := oldLease.GetID()
+	re.NotEqual(clientv3.NoLease, oldLeaseID)
+
+	// Capture the log after the cluster is up, so that this replacement is the
+	// one that sticks, and put the previous global logger back afterwards: the
+	// file is deleted when this test returns, and anything still writing to the
+	// replacement would be writing into a deleted file.
+	logCfg := &log.Config{Level: "info"}
+	logFile, err := os.CreateTemp("", "pd_tests")
+	re.NoError(err)
+	fname := logFile.Name()
+	re.NoError(logFile.Close())
+	logCfg.File.Filename = fname
+	lg, props, err := log.InitLogger(logCfg)
+	re.NoError(err)
+	restoreLogger := log.ReplaceGlobals(lg, props)
+	defer func() {
+		restoreLogger()
+		os.RemoveAll(fname)
+	}()
+
+	// Hold the step-down open inside Lease.Close, so that there is a window in
+	// which the resign has started but has not finished. Without it the log line
+	// would follow the resign too closely to observe either way.
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/election/blockLeaseClose",
+		fmt.Sprintf("return(\"leader election@%s\")", leaderName)))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/election/blockLeaseClose"))
+	}()
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/election/keepAliveFailed",
+		fmt.Sprintf("return(\"leader election@%s\")", leaderName)))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/election/keepAliveFailed"))
+	}()
+
+	const stepDownMsg = "no longer a leader because lease has expired"
+
+	// Wait for the member to be inside the blocked close of the term it started
+	// with, exactly as in the test above.
+	testutil.Eventually(re, func() bool {
+		m := leaderServer.GetMember()
+		return m.GetLeader() == nil &&
+			m.GetLeadership().GetLeaderValue() != "" &&
+			!m.GetLeadership().Check() &&
+			m.GetLeadership().GetLease().GetID() == oldLeaseID
+	}, testutil.WithWaitFor(30*time.Second))
+
+	// The identity is gone, and the reason has not been written yet. Reverse the
+	// two in campaignLeader and the line is already there by the time the resign
+	// it precedes has cleared the leader.
+	content, err := os.ReadFile(fname)
+	re.NoError(err)
+	re.NotContains(string(content), stepDownMsg)
+
+	// And the line does arrive once the blocked close finishes. This is what
+	// keeps the assertion above from passing merely because nothing was ever
+	// captured.
+	testutil.Eventually(re, func() bool {
+		content, err := os.ReadFile(fname)
+		re.NoError(err)
+		return strings.Contains(string(content), stepDownMsg)
+	}, testutil.WithWaitFor(30*time.Second))
+}
+
+// TestPDLeaderPublishesIdentityLastOnStepUp covers the step-up side of the same
+// ordering: the identity is published only once nothing between it and the
+// watchdog loop can block. The ready-to-serve log is a synchronous file write;
+// were the promotion to come first, a member blocked on that write would keep
+// reporting itself as the leader after its lease expired, with no step-down
+// path running yet. blockReadyToServe stands in for the blocked write.
+func TestPDLeaderPublishesIdentityLastOnStepUp(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cluster, err := tests.NewTestCluster(ctx, 1)
+	re.NoError(err)
+	defer cluster.Destroy()
+	re.NoError(cluster.RunInitialServers())
+
+	leaderName := cluster.WaitLeader()
+	re.NotEmpty(leaderName)
+	svr := cluster.GetServer(leaderName).GetServer()
+	memberID := svr.GetMember().ID()
+
+	// The lease of the current term; the assertion below is about the term
+	// after this one.
+	oldLease := svr.GetMember().GetLeadership().GetLease()
+	re.NotNil(oldLease)
+	oldLeaseID := oldLease.GetID()
+	re.NotEqual(clientv3.NoLease, oldLeaseID)
+
+	re.NoError(failpoint.Enable("github.com/tikv/pd/server/blockReadyToServe",
+		fmt.Sprintf("return(\"%d\")", memberID)))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/server/blockReadyToServe"))
+	}()
+	// Failing renewals does two things: it ends the current term through the
+	// step-down path, which starts the campaign that blocks on the failpoint
+	// above, and it then expires the lease of that blocked campaign.
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/election/keepAliveFailed",
+		fmt.Sprintf("return(\"leader election@%s\")", leaderName)))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/election/keepAliveFailed"))
+	}()
+
+	// A fresh, granted lease that already reads as expired, with the leader
+	// value in place, is a campaign that won and is now stuck ahead of its
+	// watchdog loop - the loop that would notice the expiry does not exist
+	// until the blocked write returns.
+	testutil.Eventually(re, func() bool {
+		m := svr.GetMember()
+		l := m.GetLeadership().GetLease()
+		return l != nil && l.GetID() != oldLeaseID && l.GetID() != clientv3.NoLease &&
+			m.GetLeadership().GetLeaderValue() != "" &&
+			!m.GetLeadership().Check()
+	}, testutil.WithWaitFor(30*time.Second))
+
+	// At that instant the identity must not have been published yet. With the
+	// promotion moved back ahead of the blocked write, this returns the member.
+	re.Nil(svr.GetMember().GetLeader())
+}
+
+// TestTSOAllocatorResignsBeforeBlockingReset pins the ordering inside
+// resetAllocatorLocked: the resign, whose first action is the in-memory
+// identity store, runs before resetTimestamp, whose synchronous log can block
+// on a stalled volume. With the two reversed, the reset line is already on
+// disk by the time the resign has cleared the leader.
+func TestTSOAllocatorResignsBeforeBlockingReset(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cluster, err := tests.NewTestCluster(ctx, 1)
+	re.NoError(err)
+	defer cluster.Destroy()
+	re.NoError(cluster.RunInitialServers())
+
+	leaderName := cluster.WaitLeader()
+	re.NotEmpty(leaderName)
+	svr := cluster.GetServer(leaderName).GetServer()
+
+	oldLease := svr.GetMember().GetLeadership().GetLease()
+	re.NotNil(oldLease)
+	oldLeaseID := oldLease.GetID()
+	re.NotEqual(clientv3.NoLease, oldLeaseID)
+
+	// Capture the log the same way TestPDLeaderResignsBeforeLoggingStepDown
+	// does, and for the same reasons.
+	logCfg := &log.Config{Level: "info"}
+	logFile, err := os.CreateTemp("", "pd_tests")
+	re.NoError(err)
+	fname := logFile.Name()
+	re.NoError(logFile.Close())
+	logCfg.File.Filename = fname
+	lg, props, err := log.InitLogger(logCfg)
+	re.NoError(err)
+	restoreLogger := log.ReplaceGlobals(lg, props)
+	defer func() {
+		restoreLogger()
+		os.RemoveAll(fname)
+	}()
+
+	const resetMsg = "reset the timestamp in memory"
+
+	// Hold the resign open inside Lease.Close, so that there is a window in
+	// which it has started but not finished.
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/election/blockLeaseClose",
+		fmt.Sprintf("return(\"leader election@%s\")", leaderName)))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/election/blockLeaseClose"))
+	}()
+	// Fail the periodic TSO update while the lease is still valid: that hands
+	// the step-down to the allocator rather than to the campaign loop, which is
+	// the path under test.
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/tso/failedToUpdateTimestamp", `return(true)`))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/tso/failedToUpdateTimestamp"))
+	}()
+
+	// The allocator's resign has started - the leader is gone while the term's
+	// own lease is still the one being closed.
+	testutil.Eventually(re, func() bool {
+		m := svr.GetMember()
+		return m.GetLeader() == nil &&
+			!m.GetLeadership().Check() &&
+			m.GetLeadership().GetLease().GetID() == oldLeaseID
+	}, testutil.WithWaitFor(30*time.Second))
+
+	// And the reset has not logged yet: the identity cleared first. With the
+	// resign after resetTimestamp, the line is already here.
+	content, err := os.ReadFile(fname)
+	re.NoError(err)
+	re.NotContains(string(content), resetMsg)
+
+	// The line does arrive once the blocked close returns, which is what keeps
+	// the assertion above from passing merely because nothing was captured.
+	testutil.Eventually(re, func() bool {
+		content, err := os.ReadFile(fname)
+		re.NoError(err)
+		return strings.Contains(string(content), resetMsg)
+	}, testutil.WithWaitFor(30*time.Second))
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #11106, close #10671, close #10746, ref #7780

A PD member reports itself as the leader until `unsetLeader` runs, regardless of whether it is still serving: `GetMembers` reads `GetLeader` directly, and the v1 redirector serves a request locally when the cached leader name matches its own. The microservice primary loops have the same exposure through `GetServingUrls`.

`unsetLeader` was reached only after a lease revoke against the local etcd server and the log calls surrounding it, which may block for an unbounded time on a stalled volume. This PR clears the identity first.

The same window exists on step-up and inside the TSO allocator's reset: the ready-to-serve log sat between the identity publication and the watchdog loop, and `resetTimestamp` logged ahead of the resign. Both now put the identity operation on the safe side of the log.

### What is changed and how does it work?

```commit-message
Member.Resign and Participant.Resign now unset the in-memory leader identity
before resetting the lease. In campaignLeader every exit from the loop goes
through one helper that resigns before it logs, including the shutdown exit;
the tso, scheduling and resource manager primary loops resign before logging
on their step-down and shutdown exits in the same way. The TSO allocator
resigns before resetting the timestamp, whose synchronous log otherwise runs
ahead of the identity stores.

The step-up side is mirrored: the ready-to-serve log is written before
PromoteSelf, in campaignLeader and in the three primary loops, so the
identity is published only once nothing between it and the watchdog loop can
block on a stalled volume.

Add four integration tests, one per ordering, and reversing any of the
orderings fails its test. The first waits for an instant at which the leader
is nil, the leader value is still set, the lease reads as expired, and the
lease ID is unchanged; that conjunction can hold only inside a blocked
Lease.Close. The second captures the log and asserts that the step-down
reason is absent at that instant and present once the blocked close returns.
The third holds the ready log of a fresh term whose lease expires behind it
and asserts the identity is still unpublished. The fourth fails the periodic
TSO update and asserts the reset has not logged by the time the resign has
cleared the leader.

Three failpoints support them: blockLeaseClose in Lease.Close, matched as
"<purpose>@<name>"; blockReadyToServe in campaignLeader, matched by member
ID; and failedToUpdateTimestamp in the timestamp oracle.

No additional waiting and no additional remote calls. A member that resigns
voluntarily stops reporting itself as the leader slightly earlier, and the
redirector waits for the successor instead.
```

### Check List

Tests

- Integration test

### Release note

```release-note
None.
```

### Scope and merge order

#11110 has merged and supplies the election-client documentation and tests. This PR supplies the identity ordering changes. #11177 builds on it to cancel RaftCluster work before the blocking resign path.

The tests exercise controlled blocking and ordering; they do not reproduce the production EBS stall or establish that all cleanup and in-flight effects have stopped.

Current head `27cb1a669` was re-reviewed and approved by lhy1024 on September 3. The remaining merge work is to resolve the failed `pull-unit-test-next-gen-3` check and obtain the remaining LGTM. Merge this PR before #11177.

### Latest verification

On `27cb1a669`, the failed subtest was run locally from `tests/integrations` with:

```sh
go test ./tso -tags=nextgen,without_dashboard -run TestLegacyTSOConsistencySuite/TestRequestTSOConcurrently -count=3
```

All three runs passed (73.298s), with failpoints enabled for the test and disabled afterwards. No code was changed. This does not establish that the CI failure is flaky; the failed CI job still needs a fresh result and further investigation if it recurs.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability**
  * Improved leadership transitions and failover handling to clear stale leader state and resign cleanly before shutdown or step-down.
  * Improved readiness sequencing so services report availability at the correct point during promotion.
  * Strengthened timestamp and lease failure handling for more predictable recovery.

* **Configuration**
  * Added support for updating individual schedule configuration items and applying schedule configuration changes transactionally.

* **Maintenance**
  * Improved cleanup of service metadata and deleted monitoring records during leadership changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->