### PR TITLE
[backport] resourcemanager: assign tokens to the slot whose ru tracker isn't initialized

### DIFF
--- a/pkg/mcs/resourcemanager/server/ru_tracker.go
+++ b/pkg/mcs/resourcemanager/server/ru_tracker.go
@@ -100,6 +100,12 @@ func (rt *ruTracker) getRUPerSec() float64 {
 	return rt.lastEMA
 }
 
+func (rt *ruTracker) isInitialized() bool {
+	rt.RLock()
+	defer rt.RUnlock()
+	return rt.initialized
+}
+
 // groupRUTracker is used to track the RU consumption of a resource group.
 // It matains a map of RU trackers for each client unique ID.
 type groupRUTracker struct {

--- a/pkg/mcs/resourcemanager/server/token_buckets.go
+++ b/pkg/mcs/resourcemanager/server/token_buckets.go
@@ -215,7 +215,8 @@ func (gtb *GroupTokenBucket) balanceSlotTokens(
 		extraDemandSum = 0.0
 	)
 	for clientUniqueID := range gtb.tokenSlots {
-		allocation := gtb.grt.getOrCreateRUTracker(clientUniqueID).getRUPerSec()
+		ruTracker := gtb.grt.getOrCreateRUTracker(clientUniqueID)
+		allocation := ruTracker.getRUPerSec()
 		// If the RU demand is greater than the basic fill rate, allocate the basic fill rate first.
 		if allocation > basicFillRate {
 			// Record the extra demand for the high demand slots.
@@ -223,6 +224,10 @@ func (gtb *GroupTokenBucket) balanceSlotTokens(
 			extraDemandSum += extra
 			extraDemand[clientUniqueID] = extra
 			// Allocate the basic fill rate.
+			allocation = basicFillRate
+		} else if !ruTracker.isInitialized() {
+			// If the RU tracker is not initialized, just allocate the basic fill rate.
+			// This is to avoid that the new slot can't get any fill rate.
 			allocation = basicFillRate
 		}
 		allocationMap[clientUniqueID] = allocation

--- a/pkg/mcs/resourcemanager/server/token_buckets_test.go
+++ b/pkg/mcs/resourcemanager/server/token_buckets_test.go
@@ -87,6 +87,40 @@ func TestGroupTokenBucketUpdateAndPatch(t *testing.T) {
 	re.LessOrEqual(math.Abs(tbSetting.Tokens-200000), 1e-7)
 }
 
+func TestGroupTokenBucketAssignBasicFillRateToUninitializedRUTracker(t *testing.T) {
+	re := require.New(t)
+	gtb := NewGroupTokenBucket(testResourceGroupName, &rmpb.TokenBucket{
+		Tokens: 0,
+		Settings: &rmpb.TokenLimitSettings{
+			FillRate:   100,
+			BurstLimit: 100,
+		},
+	})
+	gtb.grt = newGroupRUTracker()
+
+	now := time.Now()
+	targetPeriodMs := uint64((5 * time.Second) / time.Millisecond)
+	const highDemandClientID uint64 = 1
+	const newClientID uint64 = 2
+
+	// Create the first slot.
+	_, _ = gtb.request(now, 1, targetPeriodMs, highDemandClientID)
+	// Mock the first slot as a high-demand initialized RU tracker.
+	rt := gtb.grt.getOrCreateRUTracker(highDemandClientID)
+	rt.initialized = true
+	rt.lastSampleTime = now
+	rt.lastEMA = 100 // > basicFillRate (100 / 2)
+	// Request for a new slot whose RU tracker isn't initialized yet.
+	tb, trickle := gtb.request(now, 1, targetPeriodMs, newClientID)
+	re.NotNil(tb)
+	re.Equal(1.0, tb.Tokens)
+	re.Equal(int64(targetPeriodMs), trickle)
+
+	// The new slot must get the basic fill rate instead of 0.
+	re.Contains(gtb.tokenSlots, newClientID)
+	re.Equal(uint64(50), gtb.tokenSlots[newClientID].fillRate)
+}
+
 func TestGroupTokenBucketRequest(t *testing.T) {
 	re := require.New(t)
 	tbSetting := &rmpb.TokenBucket{


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #11148, close #10063

On `release-8.5`, a newly observed Resource Control client has an uninitialized RU tracker after its first demand sample. The demand-based token bucket allocator treats the resulting zero EMA as zero demand, which can assign the client a zero fill rate and burst limit when another client already has high demand.

### What is changed and how does it work?

This PR backports the uninitialized RU tracker fallback from #10181. An uninitialized tracker receives the basic fair-share fill rate until it has enough samples to calculate RU demand.

`release-8.5` stores RU trackers in `ru_tracker.go` and uses a different Resource Manager service layout. The backport maps the initialization check to that file and limits the change to the allocation fallback and its regression test.

```commit-message
Expose RU tracker initialization state and allocate the basic fill rate to a new client until its tracker has enough samples.
```

### Check List

Tests

- Unit test
  - `go test ./pkg/mcs/resourcemanager/server -count=1`
  - `make build`
  - `make check`

Related changes

- Source PR: #10181

### Release note

```release-note
None.
```

