### PR TITLE
[DNM] test rate-limited Leader return to a restarted TiKV store

### DIFF
--- a/pkg/schedule/schedulers/balance_leader.go
+++ b/pkg/schedule/schedulers/balance_leader.go
@@ -18,13 +18,16 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"math"
 	"net/http"
 	"sort"
 	"strconv"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/unrolled/render"
 	"go.uber.org/zap"
+	"golang.org/x/time/rate"
 
 	"github.com/pingcap/log"
 
@@ -51,40 +54,60 @@ const (
 
 	transferIn  = "transfer-in"
 	transferOut = "transfer-out"
+
+	// inboundLeaderTransferBurst is intentionally fixed at one. The limiter is
+	// test-only and is meant to pace leader return instead of allowing a batch to
+	// arrive at a target store at once.
+	inboundLeaderTransferBurst = 1
 )
 
-var invalidBalanceLeaderBatchSizeMsg = "invalid batch size which should be an integer between 1 and " + strconv.Itoa(MaxBalanceLeaderBatchSize)
+var (
+	invalidBalanceLeaderBatchSizeMsg         = "invalid batch size which should be an integer between 1 and " + strconv.Itoa(MaxBalanceLeaderBatchSize)
+	invalidInboundLeaderTransferRateLimitMsg = "invalid inbound leader transfer rate limit: store ID and leaders per second must be positive, and burst must be 1"
+)
 
 type balanceLeaderSchedulerParam struct {
 	Ranges []keyutil.KeyRange `json:"ranges"`
 	// Batch is used to generate multiple operators by one scheduling
 	Batch int `json:"batch"`
+	// InboundLeaderTransferRateLimits limits balance-leader operators by their
+	// target store. The rate unit is leaders per second and the burst is fixed at
+	// one leader. An absent store ID means unlimited.
+	InboundLeaderTransferRateLimits map[uint64]inboundLeaderTransferRateLimit `json:"inbound-leader-transfer-rate-limits,omitempty"`
+}
+
+type inboundLeaderTransferRateLimit struct {
+	LeadersPerSecond float64 `json:"leaders-per-second"`
+	Burst            int     `json:"burst"`
 }
 
 type balanceLeaderSchedulerConfig struct {
 	baseDefaultSchedulerConfig
 	balanceLeaderSchedulerParam
+
+	// inboundLeaderTransferLimiters is runtime-only state derived lazily from
+	// InboundLeaderTransferRateLimits. It is protected by the embedded mutex.
+	inboundLeaderTransferLimiters map[uint64]*rate.Limiter
+	now                           func() time.Time
 }
 
 func (conf *balanceLeaderSchedulerConfig) update(data []byte) (int, any) {
 	conf.Lock()
 	defer conf.Unlock()
 
-	param := &conf.balanceLeaderSchedulerParam
-	oldConfig, _ := json.Marshal(param)
+	oldParam := conf.cloneLocked()
+	newParam := conf.cloneLocked()
+	oldConfig, _ := json.Marshal(oldParam)
 
-	if err := json.Unmarshal(data, param); err != nil {
+	if err := json.Unmarshal(data, newParam); err != nil {
 		return http.StatusInternalServerError, err.Error()
 	}
-	newConfig, _ := json.Marshal(param)
+	newConfig, _ := json.Marshal(newParam)
 	if !bytes.Equal(oldConfig, newConfig) {
-		if !conf.validateLocked() {
-			if err := json.Unmarshal(oldConfig, param); err != nil {
-				return http.StatusInternalServerError, err.Error()
-			}
-			return http.StatusBadRequest, invalidBalanceLeaderBatchSizeMsg
+		if errMsg := newParam.validateLocked(); errMsg != "" {
+			return http.StatusBadRequest, errMsg
 		}
-		conf.balanceLeaderSchedulerParam = *param
+		conf.balanceLeaderSchedulerParam = *newParam
 		if err := conf.save(); err != nil {
 			log.Warn("failed to save balance-leader-scheduler config", errs.ZapError(err))
 		}
@@ -95,26 +118,127 @@ func (conf *balanceLeaderSchedulerConfig) update(data []byte) (int, any) {
 	if err := json.Unmarshal(data, &m); err != nil {
 		return http.StatusInternalServerError, err.Error()
 	}
-	ok := reflectutil.FindSameFieldByJSON(param, m)
+	ok := reflectutil.FindSameFieldByJSON(newParam, m)
 	if ok {
 		return http.StatusOK, "Config is the same with origin, so do nothing."
 	}
 	return http.StatusBadRequest, "Config item is not found."
 }
 
-func (conf *balanceLeaderSchedulerParam) validateLocked() bool {
-	return conf.Batch >= 1 && conf.Batch <= MaxBalanceLeaderBatchSize
+func (conf *balanceLeaderSchedulerParam) validateLocked() string {
+	if conf.Batch < 1 || conf.Batch > MaxBalanceLeaderBatchSize {
+		return invalidBalanceLeaderBatchSizeMsg
+	}
+	for storeID, limit := range conf.InboundLeaderTransferRateLimits {
+		if storeID == 0 || limit.LeadersPerSecond <= 0 || math.IsNaN(limit.LeadersPerSecond) || math.IsInf(limit.LeadersPerSecond, 0) || limit.Burst != inboundLeaderTransferBurst {
+			return invalidInboundLeaderTransferRateLimitMsg
+		}
+	}
+	return ""
 }
 
 func (conf *balanceLeaderSchedulerConfig) clone() *balanceLeaderSchedulerParam {
 	conf.RLock()
 	defer conf.RUnlock()
+	return conf.cloneLocked()
+}
+
+func (conf *balanceLeaderSchedulerConfig) cloneLocked() *balanceLeaderSchedulerParam {
 	ranges := make([]keyutil.KeyRange, len(conf.Ranges))
 	copy(ranges, conf.Ranges)
-	return &balanceLeaderSchedulerParam{
-		Ranges: ranges,
-		Batch:  conf.Batch,
+	rateLimits := make(map[uint64]inboundLeaderTransferRateLimit, len(conf.InboundLeaderTransferRateLimits))
+	for storeID, limit := range conf.InboundLeaderTransferRateLimits {
+		rateLimits[storeID] = limit
 	}
+	return &balanceLeaderSchedulerParam{
+		Ranges:                          ranges,
+		Batch:                           conf.Batch,
+		InboundLeaderTransferRateLimits: rateLimits,
+	}
+}
+
+func (conf *balanceLeaderSchedulerConfig) currentTimeLocked() time.Time {
+	if conf.now != nil {
+		return conf.now()
+	}
+	return time.Now()
+}
+
+func (conf *balanceLeaderSchedulerConfig) getInboundLeaderTransferLimiterLocked(storeID uint64) (*rate.Limiter, bool) {
+	limit, ok := conf.InboundLeaderTransferRateLimits[storeID]
+	if !ok {
+		delete(conf.inboundLeaderTransferLimiters, storeID)
+		return nil, false
+	}
+	if conf.inboundLeaderTransferLimiters == nil {
+		conf.inboundLeaderTransferLimiters = make(map[uint64]*rate.Limiter)
+	}
+	limiter, ok := conf.inboundLeaderTransferLimiters[storeID]
+	now := conf.currentTimeLocked()
+	if !ok {
+		limiter = rate.NewLimiter(rate.Limit(limit.LeadersPerSecond), inboundLeaderTransferBurst)
+		conf.inboundLeaderTransferLimiters[storeID] = limiter
+	} else if limiter.Limit() != rate.Limit(limit.LeadersPerSecond) {
+		limiter.SetLimitAt(now, rate.Limit(limit.LeadersPerSecond))
+	}
+	return limiter, true
+}
+
+func (conf *balanceLeaderSchedulerConfig) isInboundLeaderTransferAllowed(storeID uint64) bool {
+	conf.Lock()
+	defer conf.Unlock()
+	limiter, limited := conf.getInboundLeaderTransferLimiterLocked(storeID)
+	return !limited || limiter.TokensAt(conf.currentTimeLocked()) >= 1
+}
+
+func (conf *balanceLeaderSchedulerConfig) takeInboundLeaderTransfer(storeID uint64) bool {
+	conf.Lock()
+	defer conf.Unlock()
+	limiter, limited := conf.getInboundLeaderTransferLimiterLocked(storeID)
+	return !limited || limiter.AllowN(conf.currentTimeLocked(), 1)
+}
+
+func (conf *balanceLeaderSchedulerConfig) setInboundLeaderTransferRate(storeID uint64, leadersPerSecond float64) (int, any) {
+	if storeID == 0 || leadersPerSecond <= 0 || math.IsNaN(leadersPerSecond) || math.IsInf(leadersPerSecond, 0) {
+		return http.StatusBadRequest, "store ID and leaders per second must be positive"
+	}
+	conf.Lock()
+	defer conf.Unlock()
+	if conf.InboundLeaderTransferRateLimits == nil {
+		conf.InboundLeaderTransferRateLimits = make(map[uint64]inboundLeaderTransferRateLimit)
+	}
+	newLimit := inboundLeaderTransferRateLimit{
+		LeadersPerSecond: leadersPerSecond,
+		Burst:            inboundLeaderTransferBurst,
+	}
+	if conf.InboundLeaderTransferRateLimits[storeID] == newLimit {
+		return http.StatusOK, "Config is the same with origin, so do nothing."
+	}
+	conf.InboundLeaderTransferRateLimits[storeID] = newLimit
+	if limiter, ok := conf.inboundLeaderTransferLimiters[storeID]; ok {
+		limiter.SetLimitAt(conf.currentTimeLocked(), rate.Limit(leadersPerSecond))
+	}
+	if err := conf.save(); err != nil {
+		log.Warn("failed to save balance-leader-scheduler config", errs.ZapError(err))
+	}
+	return http.StatusOK, "Config is updated."
+}
+
+func (conf *balanceLeaderSchedulerConfig) deleteInboundLeaderTransferRate(storeID uint64) (int, any) {
+	if storeID == 0 {
+		return http.StatusBadRequest, "store ID must be positive"
+	}
+	conf.Lock()
+	defer conf.Unlock()
+	if _, ok := conf.InboundLeaderTransferRateLimits[storeID]; !ok {
+		return http.StatusOK, "Config item does not exist, so do nothing."
+	}
+	delete(conf.InboundLeaderTransferRateLimits, storeID)
+	delete(conf.inboundLeaderTransferLimiters, storeID)
+	if err := conf.save(); err != nil {
+		log.Warn("failed to save balance-leader-scheduler config", errs.ZapError(err))
+	}
+	return http.StatusOK, "Config is updated."
 }
 
 func (conf *balanceLeaderSchedulerConfig) getBatch() int {
@@ -143,6 +267,8 @@ func newBalanceLeaderHandler(conf *balanceLeaderSchedulerConfig) http.Handler {
 	}
 	router := mux.NewRouter()
 	router.HandleFunc("/config", handler.updateConfig).Methods(http.MethodPost)
+	router.HandleFunc("/config/inbound-leader-transfer-rate", handler.setInboundLeaderTransferRate).Methods(http.MethodPost)
+	router.HandleFunc("/config/inbound-leader-transfer-rate/{storeID}", handler.deleteInboundLeaderTransferRate).Methods(http.MethodDelete)
 	router.HandleFunc("/list", handler.listConfig).Methods(http.MethodGet)
 	return router
 }
@@ -157,6 +283,29 @@ func (handler *balanceLeaderHandler) updateConfig(w http.ResponseWriter, r *http
 func (handler *balanceLeaderHandler) listConfig(w http.ResponseWriter, _ *http.Request) {
 	conf := handler.config.clone()
 	handler.rd.JSON(w, http.StatusOK, conf)
+}
+
+func (handler *balanceLeaderHandler) setInboundLeaderTransferRate(w http.ResponseWriter, r *http.Request) {
+	var input struct {
+		StoreID          uint64  `json:"store-id"`
+		LeadersPerSecond float64 `json:"leaders-per-second"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		handler.rd.JSON(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	httpCode, v := handler.config.setInboundLeaderTransferRate(input.StoreID, input.LeadersPerSecond)
+	handler.rd.JSON(w, httpCode, v)
+}
+
+func (handler *balanceLeaderHandler) deleteInboundLeaderTransferRate(w http.ResponseWriter, r *http.Request) {
+	storeID, err := strconv.ParseUint(mux.Vars(r)["storeID"], 10, 64)
+	if err != nil {
+		handler.rd.JSON(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	httpCode, v := handler.config.deleteInboundLeaderTransferRate(storeID)
+	handler.rd.JSON(w, httpCode, v)
 }
 
 type balanceLeaderScheduler struct {
@@ -221,6 +370,7 @@ func (s *balanceLeaderScheduler) ReloadConfig() error {
 	}
 	s.conf.Ranges = newCfg.Ranges
 	s.conf.Batch = newCfg.Batch
+	s.conf.InboundLeaderTransferRateLimits = newCfg.InboundLeaderTransferRateLimits
 	return nil
 }
 
@@ -353,7 +503,7 @@ func (s *balanceLeaderScheduler) Schedule(cluster sche.SchedulerCluster, dryRun 
 	for sourceCandidate.hasStore() || targetCandidate.hasStore() {
 		// first choose source
 		if sourceCandidate.hasStore() {
-			op := createTransferLeaderOperator(sourceCandidate, transferOut, s, solver, usedRegions, collector)
+			op := createTransferLeaderOperator(sourceCandidate, transferOut, s, solver, usedRegions, collector, dryRun)
 			if op != nil {
 				result = append(result, op)
 				if len(result) >= batch {
@@ -364,7 +514,7 @@ func (s *balanceLeaderScheduler) Schedule(cluster sche.SchedulerCluster, dryRun 
 		}
 		// next choose target
 		if targetCandidate.hasStore() {
-			op := createTransferLeaderOperator(targetCandidate, transferIn, s, solver, usedRegions, nil)
+			op := createTransferLeaderOperator(targetCandidate, transferIn, s, solver, usedRegions, nil, dryRun)
 			if op != nil {
 				result = append(result, op)
 				if len(result) >= batch {
@@ -379,12 +529,17 @@ func (s *balanceLeaderScheduler) Schedule(cluster sche.SchedulerCluster, dryRun 
 }
 
 func createTransferLeaderOperator(cs *candidateStores, dir string, s *balanceLeaderScheduler,
-	ssolver *solver, usedRegions map[uint64]struct{}, collector *plan.Collector) *operator.Operator {
+	ssolver *solver, usedRegions map[uint64]struct{}, collector *plan.Collector, dryRun bool) *operator.Operator {
 	store := cs.getStore()
+	if dir == transferIn && !dryRun && !s.conf.isInboundLeaderTransferAllowed(store.GetID()) {
+		balanceLeaderCounterWithEvent("inbound-target-rate-limited").Inc()
+		cs.next()
+		return nil
+	}
 	ssolver.Step++
 	defer func() { ssolver.Step-- }()
 	retryLimit := s.getLimit(store)
-	var creator func(*solver, *plan.Collector) *operator.Operator
+	var creator func(*solver, *plan.Collector, bool) *operator.Operator
 	switch dir {
 	case transferOut:
 		ssolver.Source, ssolver.Target = store, nil
@@ -395,10 +550,15 @@ func createTransferLeaderOperator(cs *candidateStores, dir string, s *balanceLea
 	}
 	var op *operator.Operator
 	for range retryLimit {
-		if op = creator(ssolver, collector); op != nil {
-			if _, ok := usedRegions[op.RegionID()]; !ok {
+		if op = creator(ssolver, collector, dryRun); op != nil {
+			if _, ok := usedRegions[op.RegionID()]; ok {
+				op = nil
+				continue
+			}
+			if dryRun || s.conf.takeInboundLeaderTransfer(ssolver.targetStoreID()) {
 				break
 			}
+			balanceLeaderCounterWithEvent("inbound-target-rate-limited").Inc()
 			op = nil
 		}
 	}
@@ -430,7 +590,7 @@ func makeInfluence(op *operator.Operator, plan *solver, usedRegions map[uint64]s
 // transferLeaderOut transfers leader from the source store.
 // It randomly selects a health region from the source store, then picks
 // the best follower peer and transfers the leader.
-func (s *balanceLeaderScheduler) transferLeaderOut(solver *solver, collector *plan.Collector) *operator.Operator {
+func (s *balanceLeaderScheduler) transferLeaderOut(solver *solver, collector *plan.Collector, dryRun bool) *operator.Operator {
 	rs := s.conf.getRanges()
 	if s.GetName() == types.BalanceLeaderScheduler.String() {
 		km := solver.GetKeyRangeManager()
@@ -470,7 +630,7 @@ func (s *balanceLeaderScheduler) transferLeaderOut(solver *solver, collector *pl
 		return targets[i].LeaderScore(leaderSchedulePolicy, iOp) < targets[j].LeaderScore(leaderSchedulePolicy, jOp)
 	})
 	for _, solver.Target = range targets {
-		if op := s.createOperator(solver, collector); op != nil {
+		if op := s.createOperator(solver, collector, dryRun); op != nil {
 			return op
 		}
 	}
@@ -482,7 +642,7 @@ func (s *balanceLeaderScheduler) transferLeaderOut(solver *solver, collector *pl
 // transferLeaderIn transfers leader to the target store.
 // It randomly selects a health region from the target store, then picks
 // the worst follower peer and transfers the leader.
-func (s *balanceLeaderScheduler) transferLeaderIn(solver *solver, collector *plan.Collector) *operator.Operator {
+func (s *balanceLeaderScheduler) transferLeaderIn(solver *solver, collector *plan.Collector, dryRun bool) *operator.Operator {
 	rs := s.conf.getRanges()
 	if s.GetName() == types.BalanceLeaderScheduler.String() {
 		km := solver.GetKeyRangeManager()
@@ -535,14 +695,14 @@ func (s *balanceLeaderScheduler) transferLeaderIn(solver *solver, collector *pla
 		balanceLeaderNoTargetStoreCounter.Inc()
 		return nil
 	}
-	return s.createOperator(solver, collector)
+	return s.createOperator(solver, collector, dryRun)
 }
 
 // createOperator creates the operator according to the source and target store.
 // If the region is hot or the difference between the two stores is tolerable, then
 // no new operator need to be created, otherwise create an operator that transfers
 // the leader from the source store to the target store for the region.
-func (s *balanceLeaderScheduler) createOperator(solver *solver, collector *plan.Collector) *operator.Operator {
+func (s *balanceLeaderScheduler) createOperator(solver *solver, collector *plan.Collector, dryRun bool) *operator.Operator {
 	solver.Step++
 	defer func() { solver.Step-- }()
 	solver.sourceScore, solver.targetScore = solver.sourceStoreScore(s.GetName()), solver.targetStoreScore(s.GetName())
@@ -551,6 +711,10 @@ func (s *balanceLeaderScheduler) createOperator(solver *solver, collector *plan.
 		if collector != nil {
 			collector.Collect(plan.SetStatus(plan.NewStatus(plan.StatusStoreScoreDisallowed)))
 		}
+		return nil
+	}
+	if !dryRun && !s.conf.isInboundLeaderTransferAllowed(solver.targetStoreID()) {
+		balanceLeaderCounterWithEvent("inbound-target-rate-limited").Inc()
 		return nil
 	}
 	solver.Step++

--- a/pkg/schedule/schedulers/balance_leader.go
+++ b/pkg/schedule/schedulers/balance_leader.go
@@ -110,6 +110,8 @@ func (conf *balanceLeaderSchedulerConfig) update(data []byte) (int, any) {
 		conf.balanceLeaderSchedulerParam = *newParam
 		if err := conf.save(); err != nil {
 			log.Warn("failed to save balance-leader-scheduler config", errs.ZapError(err))
+			conf.balanceLeaderSchedulerParam = *oldParam
+			return http.StatusInternalServerError, err.Error()
 		}
 		log.Info("balance-leader-scheduler config is updated", zap.ByteString("old", oldConfig), zap.ByteString("new", newConfig))
 		return http.StatusOK, "Config is updated."
@@ -204,6 +206,7 @@ func (conf *balanceLeaderSchedulerConfig) setInboundLeaderTransferRate(storeID u
 	}
 	conf.Lock()
 	defer conf.Unlock()
+	hadRateLimits := conf.InboundLeaderTransferRateLimits != nil
 	if conf.InboundLeaderTransferRateLimits == nil {
 		conf.InboundLeaderTransferRateLimits = make(map[uint64]inboundLeaderTransferRateLimit)
 	}
@@ -214,12 +217,21 @@ func (conf *balanceLeaderSchedulerConfig) setInboundLeaderTransferRate(storeID u
 	if conf.InboundLeaderTransferRateLimits[storeID] == newLimit {
 		return http.StatusOK, "Config is the same with origin, so do nothing."
 	}
+	oldLimit, hadLimit := conf.InboundLeaderTransferRateLimits[storeID]
 	conf.InboundLeaderTransferRateLimits[storeID] = newLimit
-	if limiter, ok := conf.inboundLeaderTransferLimiters[storeID]; ok {
-		limiter.SetLimitAt(conf.currentTimeLocked(), rate.Limit(leadersPerSecond))
-	}
 	if err := conf.save(); err != nil {
 		log.Warn("failed to save balance-leader-scheduler config", errs.ZapError(err))
+		if hadLimit {
+			conf.InboundLeaderTransferRateLimits[storeID] = oldLimit
+		} else if hadRateLimits {
+			delete(conf.InboundLeaderTransferRateLimits, storeID)
+		} else {
+			conf.InboundLeaderTransferRateLimits = nil
+		}
+		return http.StatusInternalServerError, err.Error()
+	}
+	if limiter, ok := conf.inboundLeaderTransferLimiters[storeID]; ok {
+		limiter.SetLimitAt(conf.currentTimeLocked(), rate.Limit(leadersPerSecond))
 	}
 	return http.StatusOK, "Config is updated."
 }
@@ -233,11 +245,14 @@ func (conf *balanceLeaderSchedulerConfig) deleteInboundLeaderTransferRate(storeI
 	if _, ok := conf.InboundLeaderTransferRateLimits[storeID]; !ok {
 		return http.StatusOK, "Config item does not exist, so do nothing."
 	}
+	oldLimit := conf.InboundLeaderTransferRateLimits[storeID]
 	delete(conf.InboundLeaderTransferRateLimits, storeID)
-	delete(conf.inboundLeaderTransferLimiters, storeID)
 	if err := conf.save(); err != nil {
 		log.Warn("failed to save balance-leader-scheduler config", errs.ZapError(err))
+		conf.InboundLeaderTransferRateLimits[storeID] = oldLimit
+		return http.StatusInternalServerError, err.Error()
 	}
+	delete(conf.inboundLeaderTransferLimiters, storeID)
 	return http.StatusOK, "Config is updated."
 }
 
@@ -476,10 +491,22 @@ func (cs *candidateStores) resortStoreWithPos(pos int) {
 }
 
 // Schedule implements the Scheduler interface.
-func (s *balanceLeaderScheduler) Schedule(cluster sche.SchedulerCluster, dryRun bool) ([]*operator.Operator, []plan.Plan) {
+func (s *balanceLeaderScheduler) Schedule(cluster sche.SchedulerCluster, collectDiagnostics bool) ([]*operator.Operator, []plan.Plan) {
+	return s.scheduleWithInboundLeaderTransferLimit(cluster, collectDiagnostics, false)
+}
+
+func (s *balanceLeaderScheduler) diagnoseDryRun(cluster sche.SchedulerCluster) ([]*operator.Operator, []plan.Plan) {
+	return s.scheduleWithInboundLeaderTransferLimit(cluster, true, true)
+}
+
+func (s *balanceLeaderScheduler) scheduleWithInboundLeaderTransferLimit(
+	cluster sche.SchedulerCluster,
+	collectDiagnostics bool,
+	bypassInboundLeaderTransferRateLimit bool,
+) ([]*operator.Operator, []plan.Plan) {
 	basePlan := plan.NewBalanceSchedulerPlan()
 	var collector *plan.Collector
-	if dryRun {
+	if collectDiagnostics {
 		collector = plan.NewCollector(basePlan)
 	}
 	defer s.filterCounter.Flush()
@@ -503,7 +530,7 @@ func (s *balanceLeaderScheduler) Schedule(cluster sche.SchedulerCluster, dryRun 
 	for sourceCandidate.hasStore() || targetCandidate.hasStore() {
 		// first choose source
 		if sourceCandidate.hasStore() {
-			op := createTransferLeaderOperator(sourceCandidate, transferOut, s, solver, usedRegions, collector, dryRun)
+			op := createTransferLeaderOperator(sourceCandidate, transferOut, s, solver, usedRegions, collector, bypassInboundLeaderTransferRateLimit)
 			if op != nil {
 				result = append(result, op)
 				if len(result) >= batch {
@@ -514,7 +541,7 @@ func (s *balanceLeaderScheduler) Schedule(cluster sche.SchedulerCluster, dryRun 
 		}
 		// next choose target
 		if targetCandidate.hasStore() {
-			op := createTransferLeaderOperator(targetCandidate, transferIn, s, solver, usedRegions, nil, dryRun)
+			op := createTransferLeaderOperator(targetCandidate, transferIn, s, solver, usedRegions, nil, bypassInboundLeaderTransferRateLimit)
 			if op != nil {
 				result = append(result, op)
 				if len(result) >= batch {
@@ -529,9 +556,9 @@ func (s *balanceLeaderScheduler) Schedule(cluster sche.SchedulerCluster, dryRun 
 }
 
 func createTransferLeaderOperator(cs *candidateStores, dir string, s *balanceLeaderScheduler,
-	ssolver *solver, usedRegions map[uint64]struct{}, collector *plan.Collector, dryRun bool) *operator.Operator {
+	ssolver *solver, usedRegions map[uint64]struct{}, collector *plan.Collector, bypassInboundLeaderTransferRateLimit bool) *operator.Operator {
 	store := cs.getStore()
-	if dir == transferIn && !dryRun && !s.conf.isInboundLeaderTransferAllowed(store.GetID()) {
+	if dir == transferIn && !bypassInboundLeaderTransferRateLimit && !s.conf.isInboundLeaderTransferAllowed(store.GetID()) {
 		balanceLeaderCounterWithEvent("inbound-target-rate-limited").Inc()
 		cs.next()
 		return nil
@@ -550,12 +577,12 @@ func createTransferLeaderOperator(cs *candidateStores, dir string, s *balanceLea
 	}
 	var op *operator.Operator
 	for range retryLimit {
-		if op = creator(ssolver, collector, dryRun); op != nil {
+		if op = creator(ssolver, collector, bypassInboundLeaderTransferRateLimit); op != nil {
 			if _, ok := usedRegions[op.RegionID()]; ok {
 				op = nil
 				continue
 			}
-			if dryRun || s.conf.takeInboundLeaderTransfer(ssolver.targetStoreID()) {
+			if bypassInboundLeaderTransferRateLimit || s.conf.takeInboundLeaderTransfer(ssolver.targetStoreID()) {
 				break
 			}
 			balanceLeaderCounterWithEvent("inbound-target-rate-limited").Inc()
@@ -590,7 +617,7 @@ func makeInfluence(op *operator.Operator, plan *solver, usedRegions map[uint64]s
 // transferLeaderOut transfers leader from the source store.
 // It randomly selects a health region from the source store, then picks
 // the best follower peer and transfers the leader.
-func (s *balanceLeaderScheduler) transferLeaderOut(solver *solver, collector *plan.Collector, dryRun bool) *operator.Operator {
+func (s *balanceLeaderScheduler) transferLeaderOut(solver *solver, collector *plan.Collector, bypassInboundLeaderTransferRateLimit bool) *operator.Operator {
 	rs := s.conf.getRanges()
 	if s.GetName() == types.BalanceLeaderScheduler.String() {
 		km := solver.GetKeyRangeManager()
@@ -630,7 +657,7 @@ func (s *balanceLeaderScheduler) transferLeaderOut(solver *solver, collector *pl
 		return targets[i].LeaderScore(leaderSchedulePolicy, iOp) < targets[j].LeaderScore(leaderSchedulePolicy, jOp)
 	})
 	for _, solver.Target = range targets {
-		if op := s.createOperator(solver, collector, dryRun); op != nil {
+		if op := s.createOperator(solver, collector, bypassInboundLeaderTransferRateLimit); op != nil {
 			return op
 		}
 	}
@@ -642,7 +669,7 @@ func (s *balanceLeaderScheduler) transferLeaderOut(solver *solver, collector *pl
 // transferLeaderIn transfers leader to the target store.
 // It randomly selects a health region from the target store, then picks
 // the worst follower peer and transfers the leader.
-func (s *balanceLeaderScheduler) transferLeaderIn(solver *solver, collector *plan.Collector, dryRun bool) *operator.Operator {
+func (s *balanceLeaderScheduler) transferLeaderIn(solver *solver, collector *plan.Collector, bypassInboundLeaderTransferRateLimit bool) *operator.Operator {
 	rs := s.conf.getRanges()
 	if s.GetName() == types.BalanceLeaderScheduler.String() {
 		km := solver.GetKeyRangeManager()
@@ -695,14 +722,14 @@ func (s *balanceLeaderScheduler) transferLeaderIn(solver *solver, collector *pla
 		balanceLeaderNoTargetStoreCounter.Inc()
 		return nil
 	}
-	return s.createOperator(solver, collector, dryRun)
+	return s.createOperator(solver, collector, bypassInboundLeaderTransferRateLimit)
 }
 
 // createOperator creates the operator according to the source and target store.
 // If the region is hot or the difference between the two stores is tolerable, then
 // no new operator need to be created, otherwise create an operator that transfers
 // the leader from the source store to the target store for the region.
-func (s *balanceLeaderScheduler) createOperator(solver *solver, collector *plan.Collector, dryRun bool) *operator.Operator {
+func (s *balanceLeaderScheduler) createOperator(solver *solver, collector *plan.Collector, bypassInboundLeaderTransferRateLimit bool) *operator.Operator {
 	solver.Step++
 	defer func() { solver.Step-- }()
 	solver.sourceScore, solver.targetScore = solver.sourceStoreScore(s.GetName()), solver.targetStoreScore(s.GetName())
@@ -713,7 +740,7 @@ func (s *balanceLeaderScheduler) createOperator(solver *solver, collector *plan.
 		}
 		return nil
 	}
-	if !dryRun && !s.conf.isInboundLeaderTransferAllowed(solver.targetStoreID()) {
+	if !bypassInboundLeaderTransferRateLimit && !s.conf.isInboundLeaderTransferAllowed(solver.targetStoreID()) {
 		balanceLeaderCounterWithEvent("inbound-target-rate-limited").Inc()
 		return nil
 	}

--- a/pkg/schedule/schedulers/balance_leader_test.go
+++ b/pkg/schedule/schedulers/balance_leader_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http/httptest"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/docker/go-units"
 	"github.com/stretchr/testify/require"
@@ -58,6 +59,9 @@ func TestBalanceLeaderSchedulerConfigClone(t *testing.T) {
 		balanceLeaderSchedulerParam: balanceLeaderSchedulerParam{
 			Ranges: keyRanges1,
 			Batch:  10,
+			InboundLeaderTransferRateLimits: map[uint64]inboundLeaderTransferRateLimit{
+				1: {LeadersPerSecond: 2, Burst: inboundLeaderTransferBurst},
+			},
 		},
 	}
 	conf2 := conf.clone()
@@ -69,6 +73,8 @@ func TestBalanceLeaderSchedulerConfigClone(t *testing.T) {
 	// update conf2
 	conf2.Ranges[1] = keyRanges2[1]
 	re.NotEqual(conf.Ranges, conf2.Ranges)
+	conf2.InboundLeaderTransferRateLimits[1] = inboundLeaderTransferRateLimit{LeadersPerSecond: 3, Burst: inboundLeaderTransferBurst}
+	re.NotEqual(conf.InboundLeaderTransferRateLimits, conf2.InboundLeaderTransferRateLimits)
 }
 
 func TestBalanceLeaderBatchLimit(t *testing.T) {
@@ -94,6 +100,194 @@ func TestBalanceLeaderBatchLimit(t *testing.T) {
 	lb.ServeHTTP(resp, req)
 	re.Equal(http.StatusBadRequest, resp.Code)
 	re.Equal(MaxBalanceLeaderBatchSize, lb.(*balanceLeaderScheduler).conf.getBatch())
+}
+
+func TestInboundLeaderTransferRateLimitConfig(t *testing.T) {
+	re := require.New(t)
+	storage := storage.NewStorageWithMemoryBackend()
+	now := time.Now()
+	conf := &balanceLeaderSchedulerConfig{
+		baseDefaultSchedulerConfig: newBaseDefaultSchedulerConfig(),
+		balanceLeaderSchedulerParam: balanceLeaderSchedulerParam{
+			Batch: BalanceLeaderBatchSize,
+		},
+		now: func() time.Time { return now },
+	}
+	conf.init(types.BalanceLeaderScheduler.String(), storage, conf)
+
+	// The default is unlimited, and a limit for one target does not affect
+	// other target stores.
+	for range 10 {
+		re.True(conf.takeInboundLeaderTransfer(1))
+	}
+	httpCode, _ := conf.setInboundLeaderTransferRate(1, 2)
+	re.Equal(http.StatusOK, httpCode)
+	re.True(conf.takeInboundLeaderTransfer(1))
+	re.False(conf.takeInboundLeaderTransfer(1))
+	re.True(conf.takeInboundLeaderTransfer(2))
+	re.True(conf.takeInboundLeaderTransfer(2))
+
+	// A two-leaders-per-second limiter with burst one refills one token after
+	// half a second.
+	now = now.Add(499 * time.Millisecond)
+	re.False(conf.takeInboundLeaderTransfer(1))
+	now = now.Add(time.Millisecond)
+	re.True(conf.takeInboundLeaderTransfer(1))
+	re.False(conf.takeInboundLeaderTransfer(1))
+
+	// Updating the rate preserves the bucket state and uses the new refill rate.
+	httpCode, _ = conf.setInboundLeaderTransferRate(1, 4)
+	re.Equal(http.StatusOK, httpCode)
+	now = now.Add(249 * time.Millisecond)
+	re.False(conf.takeInboundLeaderTransfer(1))
+	now = now.Add(time.Millisecond)
+	re.True(conf.takeInboundLeaderTransfer(1))
+
+	// Deleting the per-store config immediately restores unlimited behavior.
+	httpCode, _ = conf.deleteInboundLeaderTransferRate(1)
+	re.Equal(http.StatusOK, httpCode)
+	for range 10 {
+		re.True(conf.takeInboundLeaderTransfer(1))
+	}
+}
+
+func TestInboundLeaderTransferRateLimitHTTPReadback(t *testing.T) {
+	re := require.New(t)
+	cancel, _, _, oc := prepareSchedulersTest()
+	defer cancel()
+
+	storage := storage.NewStorageWithMemoryBackend()
+	lb, err := CreateScheduler(types.BalanceLeaderScheduler, oc, storage, ConfigSliceDecoder(types.BalanceLeaderScheduler, []string{"", ""}))
+	re.NoError(err)
+
+	body := bytes.NewBufferString(`{"store-id":42,"leaders-per-second":1.5}`)
+	req := httptest.NewRequest(http.MethodPost, "/config/inbound-leader-transfer-rate", body)
+	resp := httptest.NewRecorder()
+	lb.ServeHTTP(resp, req)
+	re.Equal(http.StatusOK, resp.Code)
+
+	req = httptest.NewRequest(http.MethodGet, "/list", nil)
+	resp = httptest.NewRecorder()
+	lb.ServeHTTP(resp, req)
+	re.Equal(http.StatusOK, resp.Code)
+	var got balanceLeaderSchedulerParam
+	re.NoError(json.Unmarshal(resp.Body.Bytes(), &got))
+	re.Equal(inboundLeaderTransferRateLimit{
+		LeadersPerSecond: 1.5,
+		Burst:            inboundLeaderTransferBurst,
+	}, got.InboundLeaderTransferRateLimits[42])
+
+	// Invalid generic updates are rejected without leaving a partial map entry.
+	body = bytes.NewBufferString(`{"inbound-leader-transfer-rate-limits":{"43":{"leaders-per-second":1,"burst":2}}}`)
+	req = httptest.NewRequest(http.MethodPost, "/config", body)
+	resp = httptest.NewRecorder()
+	lb.ServeHTTP(resp, req)
+	re.Equal(http.StatusBadRequest, resp.Code)
+	re.NotContains(lb.(*balanceLeaderScheduler).conf.clone().InboundLeaderTransferRateLimits, uint64(43))
+
+	persisted, err := storage.LoadSchedulerConfig(types.BalanceLeaderScheduler.String())
+	re.NoError(err)
+	re.Contains(persisted, `"42":{"leaders-per-second":1.5,"burst":1}`)
+
+	// ReloadConfig is also the path used by the scheduling service's scheduler
+	// config watcher.
+	var persistedConfig map[string]any
+	re.NoError(json.Unmarshal([]byte(persisted), &persistedConfig))
+	persistedConfig["inbound-leader-transfer-rate-limits"] = map[string]any{
+		"42": map[string]any{"leaders-per-second": 3.0, "burst": 1},
+	}
+	reloaded, err := json.Marshal(persistedConfig)
+	re.NoError(err)
+	re.NoError(storage.SaveSchedulerConfig(types.BalanceLeaderScheduler.String(), reloaded))
+	re.NoError(lb.ReloadConfig())
+	re.Equal(3.0, lb.(*balanceLeaderScheduler).conf.clone().InboundLeaderTransferRateLimits[42].LeadersPerSecond)
+
+	req = httptest.NewRequest(http.MethodDelete, "/config/inbound-leader-transfer-rate/42", nil)
+	resp = httptest.NewRecorder()
+	lb.ServeHTTP(resp, req)
+	re.Equal(http.StatusOK, resp.Code)
+
+	req = httptest.NewRequest(http.MethodGet, "/list", nil)
+	resp = httptest.NewRecorder()
+	lb.ServeHTTP(resp, req)
+	re.Equal(http.StatusOK, resp.Code)
+	got = balanceLeaderSchedulerParam{}
+	re.NoError(json.Unmarshal(resp.Body.Bytes(), &got))
+	re.NotContains(got.InboundLeaderTransferRateLimits, uint64(42))
+}
+
+func TestBalanceLeaderInboundTargetRateLimit(t *testing.T) {
+	re := require.New(t)
+	cancel, _, tc, oc := prepareSchedulersTest()
+	defer cancel()
+
+	tc.SetTolerantSizeRatio(0.1)
+	tc.AddLeaderStore(1, 20)
+	tc.AddLeaderStore(2, 0)
+	tc.AddLeaderStore(3, 20)
+	for i := 1; i <= 20; i++ {
+		tc.AddLeaderRegion(uint64(i), 1, 2, 3)
+	}
+
+	lb, err := CreateScheduler(types.BalanceLeaderScheduler, oc, storage.NewStorageWithMemoryBackend(), ConfigSliceDecoder(types.BalanceLeaderScheduler, []string{"", ""}))
+	re.NoError(err)
+	scheduler := lb.(*balanceLeaderScheduler)
+	now := time.Now()
+	scheduler.conf.now = func() time.Time { return now }
+	httpCode, _ := scheduler.conf.setInboundLeaderTransferRate(2, 1)
+	re.Equal(http.StatusOK, httpCode)
+
+	ops, _ := lb.Schedule(tc, false)
+	re.Len(ops, 1)
+	operatorutil.CheckTransferLeader(re, ops[0], operator.OpLeader, 1, 2)
+
+	// A canceled operator does not alter Region or peer state. The limiter only
+	// accounts for operator creation and continues refilling normally.
+	re.True(ops[0].Cancel(operator.AdminStop))
+	re.Empty(func() []*operator.Operator {
+		ops, _ := lb.Schedule(tc, false)
+		return ops
+	}())
+	now = now.Add(time.Second)
+	ops, _ = lb.Schedule(tc, false)
+	re.Len(ops, 1)
+	operatorutil.CheckTransferLeader(re, ops[0], operator.OpLeader, 1, 2)
+
+	// Diagnostic dry runs never consume a token.
+	now = now.Add(time.Second)
+	ops, _ = lb.Schedule(tc, true)
+	re.NotEmpty(ops)
+	ops, _ = lb.Schedule(tc, false)
+	re.Len(ops, 1)
+}
+
+func TestBalanceLeaderInboundTargetRateLimitFailedCandidate(t *testing.T) {
+	re := require.New(t)
+	cancel, _, tc, oc := prepareSchedulersTest()
+	defer cancel()
+
+	tc.SetTolerantSizeRatio(0.1)
+	tc.AddLeaderStore(1, 20)
+	tc.AddLeaderStore(2, 0)
+	tc.AddLeaderStore(3, 20)
+	// Store 2 is a learner, so no transfer-leader operator can be built for it.
+	tc.AddRegionWithLearner(1, 1, []uint64{3}, []uint64{2})
+
+	lb, err := CreateScheduler(types.BalanceLeaderScheduler, oc, storage.NewStorageWithMemoryBackend(), ConfigSliceDecoder(types.BalanceLeaderScheduler, []string{"", ""}))
+	re.NoError(err)
+	scheduler := lb.(*balanceLeaderScheduler)
+	scheduler.conf.now = time.Now
+	httpCode, _ := scheduler.conf.setInboundLeaderTransferRate(2, 1)
+	re.Equal(http.StatusOK, httpCode)
+	ops, _ := lb.Schedule(tc, false)
+	re.Empty(ops)
+
+	// Making store 2 a voter immediately allows the initial burst token. The
+	// failed candidate above did not consume or corrupt limiter state.
+	tc.AddLeaderRegion(1, 1, 2, 3)
+	ops, _ = lb.Schedule(tc, false)
+	re.Len(ops, 1)
+	operatorutil.CheckTransferLeader(re, ops[0], operator.OpLeader, 1, 2)
 }
 
 type balanceLeaderSchedulerTestSuite struct {

--- a/pkg/schedule/schedulers/balance_leader_test.go
+++ b/pkg/schedule/schedulers/balance_leader_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/goleak"
 
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/metapb"
 
 	"github.com/tikv/pd/pkg/core"
@@ -151,6 +152,58 @@ func TestInboundLeaderTransferRateLimitConfig(t *testing.T) {
 	}
 }
 
+func TestInboundLeaderTransferRateLimitPersistenceFailure(t *testing.T) {
+	re := require.New(t)
+	storage := storage.NewStorageWithMemoryBackend()
+	now := time.Now()
+	conf := &balanceLeaderSchedulerConfig{
+		baseDefaultSchedulerConfig: newBaseDefaultSchedulerConfig(),
+		balanceLeaderSchedulerParam: balanceLeaderSchedulerParam{
+			Batch: BalanceLeaderBatchSize,
+		},
+		now: func() time.Time { return now },
+	}
+	conf.init(types.BalanceLeaderScheduler.String(), storage, conf)
+
+	httpCode, _ := conf.setInboundLeaderTransferRate(1, 1)
+	re.Equal(http.StatusOK, httpCode)
+	re.True(conf.takeInboundLeaderTransfer(1))
+	re.Equal(1.0, float64(conf.inboundLeaderTransferLimiters[1].Limit()))
+
+	persistFail := "github.com/tikv/pd/pkg/schedule/schedulers/persistFail"
+	re.NoError(failpoint.Enable(persistFail, "return(true)"))
+	defer func() {
+		re.NoError(failpoint.Disable(persistFail))
+	}()
+
+	// Generic updates must roll back the parameter map when persistence fails.
+	httpCode, _ = conf.update([]byte(`{"inbound-leader-transfer-rate-limits":{"1":{"leaders-per-second":2,"burst":1}}}`))
+	re.Equal(http.StatusInternalServerError, httpCode)
+	re.Equal(1.0, conf.clone().InboundLeaderTransferRateLimits[1].LeadersPerSecond)
+
+	// Dedicated updates must preserve both the parameter and the live bucket.
+	httpCode, _ = conf.setInboundLeaderTransferRate(1, 2)
+	re.Equal(http.StatusInternalServerError, httpCode)
+	re.Equal(1.0, conf.clone().InboundLeaderTransferRateLimits[1].LeadersPerSecond)
+	re.Equal(1.0, float64(conf.inboundLeaderTransferLimiters[1].Limit()))
+
+	// A failed delete must keep the persisted setting and live bucket active.
+	httpCode, _ = conf.deleteInboundLeaderTransferRate(1)
+	re.Equal(http.StatusInternalServerError, httpCode)
+	re.Contains(conf.clone().InboundLeaderTransferRateLimits, uint64(1))
+	re.Contains(conf.inboundLeaderTransferLimiters, uint64(1))
+
+	persisted, err := storage.LoadSchedulerConfig(types.BalanceLeaderScheduler.String())
+	re.NoError(err)
+	re.Contains(persisted, `"1":{"leaders-per-second":1,"burst":1}`)
+
+	// The failed rate increase did not accelerate refill of the original bucket.
+	now = now.Add(500 * time.Millisecond)
+	re.False(conf.takeInboundLeaderTransfer(1))
+	now = now.Add(500 * time.Millisecond)
+	re.True(conf.takeInboundLeaderTransfer(1))
+}
+
 func TestInboundLeaderTransferRateLimitHTTPReadback(t *testing.T) {
 	re := require.New(t)
 	cancel, _, _, oc := prepareSchedulersTest()
@@ -253,12 +306,16 @@ func TestBalanceLeaderInboundTargetRateLimit(t *testing.T) {
 	re.Len(ops, 1)
 	operatorutil.CheckTransferLeader(re, ops[0], operator.OpLeader, 1, 2)
 
-	// Diagnostic dry runs never consume a token.
+	// A pure diagnostic dry run never consumes a token, while a normal
+	// diagnosable scheduling pass still does.
 	now = now.Add(time.Second)
-	ops, _ = lb.Schedule(tc, true)
+	scheduleController := NewScheduleController(context.Background(), tc, oc, lb)
+	defer scheduleController.Stop()
+	ops, _ = scheduleController.DiagnoseDryRun()
 	re.NotEmpty(ops)
-	ops, _ = lb.Schedule(tc, false)
+	ops = scheduleController.Schedule(true)
 	re.Len(ops, 1)
+	re.Empty(scheduleController.Schedule(true))
 }
 
 func TestBalanceLeaderInboundTargetRateLimitFailedCandidate(t *testing.T) {

--- a/pkg/schedule/schedulers/scheduler.go
+++ b/pkg/schedule/schedulers/scheduler.go
@@ -47,7 +47,9 @@ type Scheduler interface {
 	GetNextInterval(interval time.Duration) time.Duration
 	PrepareConfig(cluster sche.SchedulerCluster) error
 	CleanConfig(cluster sche.SchedulerCluster)
-	Schedule(cluster sche.SchedulerCluster, dryRun bool) ([]*operator.Operator, []plan.Plan)
+	// Schedule returns executable operators. collectDiagnostics only enables plan
+	// collection; it does not make the returned operators a dry run.
+	Schedule(cluster sche.SchedulerCluster, collectDiagnostics bool) ([]*operator.Operator, []plan.Plan)
 	IsScheduleAllowed(cluster sche.SchedulerCluster) bool
 	// IsDisable returns if the scheduler is disabled, it only works for default schedulers.
 	// - BalanceRegionScheduler

--- a/pkg/schedule/schedulers/scheduler_controller.go
+++ b/pkg/schedule/schedulers/scheduler_controller.go
@@ -39,6 +39,11 @@ import (
 
 const maxScheduleRetries = 10
 
+type diagnosticDryRunScheduler interface {
+	// diagnoseDryRun collects a plan without consuming scheduler admission state.
+	diagnoseDryRun(cluster sche.SchedulerCluster) ([]*operator.Operator, []plan.Plan)
+}
+
 var (
 	denySchedulersByLabelerCounter = labeler.LabelerEventCounter.WithLabelValues("schedulers", "deny")
 )
@@ -553,6 +558,9 @@ retry:
 // DiagnoseDryRun returns the operators and plans of a scheduler.
 func (s *ScheduleController) DiagnoseDryRun() ([]*operator.Operator, []plan.Plan) {
 	cacheCluster := newCacheCluster(s.cluster)
+	if scheduler, ok := s.Scheduler.(diagnosticDryRunScheduler); ok {
+		return scheduler.diagnoseDryRun(cacheCluster)
+	}
 	return s.Scheduler.Schedule(cacheCluster, true)
 }
 

--- a/tools/pd-ctl/pdctl/command/scheduler_command.go
+++ b/tools/pd-ctl/pdctl/command/scheduler_command.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"net/url"
 	"path"
@@ -577,9 +578,60 @@ func newConfigBalanceLeaderCommand() *cobra.Command {
 		Use:   "set <key> <value>",
 		Short: "set the config item",
 		Run:   func(cmd *cobra.Command, args []string) { postSchedulerConfigCommandFunc(cmd, c.Name(), args) },
+	}, &cobra.Command{
+		Use:   "set-inbound-leader-transfer-rate <store_id> <leaders_per_second>",
+		Short: "limit automatic balance-leader transfers into one store with burst 1",
+		Run:   func(cmd *cobra.Command, args []string) { setInboundLeaderTransferRateCommandFunc(cmd, c.Name(), args) },
+	}, &cobra.Command{
+		Use:   "delete-inbound-leader-transfer-rate <store_id>",
+		Short: "remove the automatic balance-leader inbound rate limit for one store",
+		Run: func(cmd *cobra.Command, args []string) {
+			deleteInboundLeaderTransferRateCommandFunc(cmd, c.Name(), args)
+		},
 	})
 
 	return c
+}
+
+func setInboundLeaderTransferRateCommandFunc(cmd *cobra.Command, schedulerName string, args []string) {
+	if len(args) != 2 {
+		cmd.Println(cmd.UsageString())
+		return
+	}
+	storeID, err := strconv.ParseUint(args[0], 10, 64)
+	if err != nil || storeID == 0 {
+		cmd.Println("store_id must be a positive integer")
+		return
+	}
+	leadersPerSecond, err := strconv.ParseFloat(args[1], 64)
+	if err != nil || leadersPerSecond <= 0 || math.IsNaN(leadersPerSecond) || math.IsInf(leadersPerSecond, 0) {
+		cmd.Println("leaders_per_second must be a positive number")
+		return
+	}
+	input := map[string]any{
+		"store-id":           storeID,
+		"leaders-per-second": leadersPerSecond,
+	}
+	postJSON(cmd, path.Join(schedulerConfigPrefix, schedulerName, "config/inbound-leader-transfer-rate"), input)
+}
+
+func deleteInboundLeaderTransferRateCommandFunc(cmd *cobra.Command, schedulerName string, args []string) {
+	if len(args) != 1 {
+		cmd.Println(cmd.UsageString())
+		return
+	}
+	storeID, err := strconv.ParseUint(args[0], 10, 64)
+	if err != nil || storeID == 0 {
+		cmd.Println("store_id must be a positive integer")
+		return
+	}
+	requestPath := path.Join(schedulerConfigPrefix, schedulerName, "config/inbound-leader-transfer-rate", args[0])
+	_, err = doRequest(cmd, requestPath, http.MethodDelete, http.Header{})
+	if err != nil {
+		cmd.Println(err)
+		return
+	}
+	cmd.Println("Success!")
 }
 
 func newConfigBalanceRangeCommand() *cobra.Command {


### PR DESCRIPTION
### What problem does this PR solve?

> [!WARNING]
> **DNM / test-only / do not merge.** This branch exists only for staging experiments for [tidbcloud/cloud-storage-engine#5774](https://github.com/tidbcloud/cloud-storage-engine/issues/5774).

Issue Number: N/A (DNM test PR)

After a TiKV restart and removal of `evict-leader`, automatic leader balancing can return many Leaders to the restarted target Store in a short interval. This makes it hard to separate delayed admission from paced admission when measuring cold working-set/runtime I/O, Prewrite latency, business tail latency, and QPS.

### What is changed and how does it work?

```commit-message
Add an opt-in leaders-per-second token bucket to balance-leader-scheduler, keyed by target store ID.

Keep the default unlimited, persist and hot-reload the per-target settings, expose exact readback, and add pd-ctl set/delete commands. Fix burst at one Leader so a configured target cannot receive a scheduler batch at once.
```

Configuration example:

```bash
pd-ctl scheduler config balance-leader-scheduler \
  set-inbound-leader-transfer-rate 42 2

pd-ctl scheduler config balance-leader-scheduler show

pd-ctl scheduler config balance-leader-scheduler \
  delete-inbound-leader-transfer-rate 42
```

Readback for the example:

```json
{
  "inbound-leader-transfer-rate-limits": {
    "42": {
      "leaders-per-second": 2,
      "burst": 1
    }
  }
}
```

Semantics and scope:

- Unit: successfully constructed automatic balance-leader transfer operators per second, aggregated by target `store_id`.
- Burst is fixed at 1. A newly configured target starts with one token; updates preserve bucket state; deletion restores unlimited behavior immediately.
- The default is fully disabled: an absent target Store entry follows existing behavior.
- Only `balance-leader-scheduler` automatic transfers are limited. Manual `admin-transfer-leader`, scatter/balance-range, hot-region, label/rule-checker, evict/grant/shuffle, and witness transfer paths bypass this test limiter.
- Both PD monolith and scheduling service/MCS use the same scheduler implementation. Scheduler config persists through the existing PD scheduler-config storage, and the MCS watcher reload path is covered by unit tests.
- Normal scheduling consumes target tokens even when diagnostic plan collection is enabled. Only an explicit diagnostic dry run bypasses token consumption.
- Failed/duplicate candidate construction does not consume tokens. A unique operator is charged when returned by the scheduler; later waiting-queue rejection or cancellation is not refunded, and normal token refill continues.
- No TiKV Raft message is dropped and no existing Leader, Region, or peer state is mutated by limiter rejection.

Staging comparison:

1. Delayed return: keep `evict-leader` until the readiness/I/O gate, then remove it with no per-target rate entry.
2. Delayed bulk return: same gate, then allow the current balance-leader scheduler speed without the limiter.
3. Delayed paced return: set the target Store rate before removing `evict-leader`, then verify readback and observe Leader count, runtime I/O, Prewrite/tail latency, and QPS.

This PR does not start or submit any staging/TCMS execution.

### Check List

Tests

- Unit test
  - default unlimited and per-target isolation
  - dynamic set/update/delete and persisted readback
  - token refill and fixed burst
  - diagnostic-enabled executable scheduling versus explicit dry-run behavior
  - persistence-failure rollback for set/update/delete
  - failed candidate and cancellation behavior
  - scheduler-level same-window target limiting
  - scheduling-service watcher `ReloadConfig` path
- Manual test
  - `make pd-ctl`
  - pd-ctl command help/readback shape

Code changes

- Has the configuration change
- Has HTTP APIs changed
- Has persistent data change

Side effects

- Increased code complexity

### Validation

- `make gotest GOTEST_ARGS=\"./pkg/schedule/schedulers -count=1\"`
- `make gotest GOTEST_ARGS=\"./pkg/schedule/schedulers -run TestInboundLeaderTransferRateLimit -count=1\"`
- `make gotest GOTEST_ARGS="./pkg/schedule/schedulers -run TestBalanceLeaderInboundTargetRateLimit -count=1"`
- `GOTOOLCHAIN=go1.25.12 go test -race ./pkg/schedule/schedulers -run TestBalanceLeaderInboundTargetRateLimit -count=1`
- root scheduler-package golangci-lint: 0 issues
- tools-module `make static GO_EFFECTIVE_TOOLCHAIN=go1.25.12`: 0 issues
- `GOTOOLCHAIN=go1.25.12 go test ./pd-ctl/pdctl/command -count=1`
- `make pd-ctl`
- `git diff --check`

### Release note

```release-note
None.
```
