### PR TITLE
mcs, etcdutil: reconcile placement rules after watch compaction

### DIFF
--- a/pkg/mcs/scheduling/server/rule/watcher.go
+++ b/pkg/mcs/scheduling/server/rule/watcher.go
@@ -265,6 +265,9 @@ func (rw *Watcher) reconcileRuleSnapshot(ctx context.Context) (int64, error) {
 				if err != nil {
 					return fmt.Errorf("failed to load placement rule group snapshot at key %q: %w", item.Key, err)
 				}
+				if !bytes.Equal([]byte(group.ID), item.Key[len(groupPrefix):]) {
+					return fmt.Errorf("placement rule group snapshot key does not match payload identity: %q", item.Key)
+				}
 				old := changes[i].old
 				if old != nil && old.ID == group.ID && old.Index == group.Index && old.Override == group.Override {
 					continue
@@ -341,6 +344,9 @@ func (rw *Watcher) reconcileRuleSnapshot(ctx context.Context) (int64, error) {
 				rule, err := placement.NewRuleFromJSON(item.Value)
 				if err != nil {
 					return fmt.Errorf("failed to load placement rule snapshot at key %q: %w", item.Key, err)
+				}
+				if !bytes.Equal([]byte(rule.StoreKey()), item.Key[len(rulePrefix):]) {
+					return fmt.Errorf("placement rule snapshot key does not match payload identity: %q", item.Key)
 				}
 				if err := rw.ruleManager.AdjustRule(rule, ""); err != nil {
 					return fmt.Errorf("failed to adjust placement rule snapshot at key %q: %w", item.Key, err)
@@ -475,9 +481,7 @@ func (rw *Watcher) initializeRuleWatcher() error {
 		defer rw.ruleManager.Unlock()
 		if err := rw.ruleManager.TryCommitPatchLocked(rw.patch); err != nil {
 			applyFailed = true
-			if len(events) > 0 {
-				rw.ruleRevisionContinuous = false
-			}
+			rw.ruleRevisionContinuous = false
 			log.Error("failed to commit patch", zap.Error(err))
 			return err
 		}

--- a/pkg/mcs/scheduling/server/rule/watcher.go
+++ b/pkg/mcs/scheduling/server/rule/watcher.go
@@ -479,8 +479,16 @@ func (rw *Watcher) initializeRuleWatcher() error {
 	}
 	postEventsFn := func(events []*clientv3.Event) error {
 		defer rw.ruleManager.Unlock()
+		if applyFailed {
+			rw.ruleRevisionContinuous = false
+			return errors.New("failed to apply placement rule events")
+		}
+		// A scheduling server can start before PD has persisted placement rules.
+		// Keep the empty local state until the watch receives the first rule.
+		if len(events) == 0 && maxLoadedRevision == 0 {
+			return nil
+		}
 		if err := rw.ruleManager.TryCommitPatchLocked(rw.patch); err != nil {
-			applyFailed = true
 			rw.ruleRevisionContinuous = false
 			log.Error("failed to commit patch", zap.Error(err))
 			return err
@@ -488,12 +496,8 @@ func (rw *Watcher) initializeRuleWatcher() error {
 		for _, kr := range suspectKeyRanges.Ranges() {
 			rw.checkerController.AddSuspectKeyRange(kr.StartKey, kr.EndKey)
 		}
-		if len(events) > 0 {
-			if applyFailed {
-				rw.ruleRevisionContinuous = false
-			} else if rw.ruleRevisionContinuous {
-				rw.ruleRevision = max(rw.ruleRevision, maxLoadedRevision)
-			}
+		if len(events) > 0 && rw.ruleRevisionContinuous {
+			rw.ruleRevision = max(rw.ruleRevision, maxLoadedRevision)
 		}
 		return nil
 	}

--- a/pkg/mcs/scheduling/server/rule/watcher.go
+++ b/pkg/mcs/scheduling/server/rule/watcher.go
@@ -158,7 +158,7 @@ func (rw *Watcher) scanRuleSnapshotKeys(
 			opts := []clientv3.OpOption{
 				clientv3.WithRange(endKey),
 				// etcd ranges are key-ascending by default.
-				clientv3.WithLimit(fetchBatchSize + 1),
+				clientv3.WithLimit(fetchBatchSize),
 				clientv3.WithKeysOnly(),
 			}
 			if revision > 0 {
@@ -177,8 +177,9 @@ func (rw *Watcher) scanRuleSnapshotKeys(
 				if len(page) == 0 {
 					return 0, errors.New("placement rule snapshot returned an empty page")
 				}
-				startKey = string(page[len(page)-1].Key)
-				page = page[:len(page)-1]
+				// Continue strictly after the last key while preserving keys for
+				// which the last key is a prefix.
+				startKey = string(append(page[len(page)-1].Key, 0))
 			}
 			if len(page) == 0 {
 				if err := handlePage(page, revision); err != nil {
@@ -215,9 +216,10 @@ func (rw *Watcher) loadRuleSnapshotValues(
 	revision int64,
 ) ([]*mvccpb.KeyValue, error) {
 	values := make([]*mvccpb.KeyValue, 0, len(metadata))
+	ops := make([]clientv3.Op, 0, min(len(metadata), etcdutil.MaxEtcdTxnOps))
 	for start := 0; start < len(metadata); start += etcdutil.MaxEtcdTxnOps {
 		end := min(start+etcdutil.MaxEtcdTxnOps, len(metadata))
-		ops := make([]clientv3.Op, 0, end-start)
+		ops = ops[:0]
 		for _, item := range metadata[start:end] {
 			ops = append(ops, clientv3.OpGet(string(item.Key), clientv3.WithRev(revision)))
 		}
@@ -269,11 +271,7 @@ func (rw *Watcher) reconcileRuleSnapshot(ctx context.Context) (int64, error) {
 	snapshotRevision, err := rw.scanRuleSnapshotKeys(
 		ctx, rw.ruleGroupPathPrefix, nil, 0, ruleSnapshotScanBatchSize, int(ruleSnapshotLoadBatchSize),
 		func(page []*mvccpb.KeyValue, revision int64) error {
-			type groupChange struct {
-				meta *mvccpb.KeyValue
-				old  *placement.RuleGroup
-			}
-			changes := make([]groupChange, 0)
+			oldGroups := make([]*placement.RuleGroup, 0)
 			metadata := make([]*mvccpb.KeyValue, 0)
 			for _, item := range page {
 				if !bytes.HasPrefix(item.Key, groupPrefix) {
@@ -292,7 +290,7 @@ func (rw *Watcher) reconcileRuleSnapshot(ctx context.Context) (int64, error) {
 				if old != nil && item.ModRevision <= rw.ruleRevision {
 					continue
 				}
-				changes = append(changes, groupChange{meta: item, old: old})
+				oldGroups = append(oldGroups, old)
 				metadata = append(metadata, item)
 			}
 
@@ -308,15 +306,12 @@ func (rw *Watcher) reconcileRuleSnapshot(ctx context.Context) (int64, error) {
 				if !bytes.Equal([]byte(group.ID), item.Key[len(groupPrefix):]) {
 					return fmt.Errorf("placement rule group snapshot key does not match payload identity: %q", item.Key)
 				}
-				old := changes[i].old
+				old := oldGroups[i]
 				if old != nil && old.ID == group.ID && old.Index == group.Index && old.Override == group.Override {
 					continue
 				}
 				patch.SetGroup(group)
 				changedGroups[group.ID] = struct{}{}
-				if old != nil {
-					changedGroups[old.ID] = struct{}{}
-				}
 				changed = true
 			}
 			return nil
@@ -347,33 +342,34 @@ func (rw *Watcher) reconcileRuleSnapshot(ctx context.Context) (int64, error) {
 		ctx, rw.rulesPathPrefix, ruleRangeEnds, snapshotRevision,
 		ruleSnapshotScanBatchSize, int(ruleSnapshotLoadBatchSize),
 		func(page []*mvccpb.KeyValue, revision int64) error {
-			type ruleChange struct {
-				meta *mvccpb.KeyValue
-				old  *placement.Rule
-			}
-			changes := make([]ruleChange, 0)
+			oldRules := make([]*placement.Rule, 0)
 			metadata := make([]*mvccpb.KeyValue, 0)
 			for _, item := range page {
 				if !bytes.HasPrefix(item.Key, rulePrefix) {
 					return fmt.Errorf("unexpected placement rule key %q", item.Key)
 				}
 				key := item.Key[len(rulePrefix):]
-				for ruleIndex < len(rules) && compareRuleKey(rules[ruleIndex], key) < 0 {
-					deleteRule(rules[ruleIndex])
-					ruleIndex++
-				}
 				var old *placement.Rule
-				if ruleIndex < len(rules) && compareRuleKey(rules[ruleIndex], key) == 0 {
-					old = rules[ruleIndex]
-					ruleIndex++
-					if _, ok := changedGroups[old.GroupID]; ok {
-						suspectKeyRanges.Append(old.StartKey, old.EndKey)
+				for ruleIndex < len(rules) {
+					comparison := compareRuleKey(rules[ruleIndex], key)
+					if comparison < 0 {
+						deleteRule(rules[ruleIndex])
+						ruleIndex++
+						continue
 					}
+					if comparison == 0 {
+						old = rules[ruleIndex]
+						ruleIndex++
+						if _, ok := changedGroups[old.GroupID]; ok {
+							suspectKeyRanges.Append(old.StartKey, old.EndKey)
+						}
+					}
+					break
 				}
 				if old != nil && item.ModRevision <= rw.ruleRevision {
 					continue
 				}
-				changes = append(changes, ruleChange{meta: item, old: old})
+				oldRules = append(oldRules, old)
 				metadata = append(metadata, item)
 			}
 
@@ -394,7 +390,7 @@ func (rw *Watcher) reconcileRuleSnapshot(ctx context.Context) (int64, error) {
 				}
 				patch.SetRule(rule)
 				suspectKeyRanges.Append(rule.StartKey, rule.EndKey)
-				if old := changes[i].old; old != nil {
+				if old := oldRules[i]; old != nil {
 					suspectKeyRanges.Append(old.StartKey, old.EndKey)
 				}
 				changed = true

--- a/pkg/mcs/scheduling/server/rule/watcher.go
+++ b/pkg/mcs/scheduling/server/rule/watcher.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"sync"
 
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
@@ -38,7 +39,18 @@ import (
 	"github.com/tikv/pd/pkg/utils/keyutil"
 )
 
-const ruleSnapshotLoadBatchSize = int64(10000)
+const (
+	// Keep value loading and patch construction bounded independently from the
+	// larger keys-only etcd range responses.
+	ruleSnapshotLoadBatchSize = int64(10000)
+
+	// Aim for 2-4 MiB keys-only responses. The initial batch matches the lower
+	// bound for the typical placement-rule key size and may grow up to 100k.
+	ruleSnapshotScanBatchSize        = int64(50000)
+	ruleSnapshotScanMaxBatchSize     = int64(100000)
+	ruleSnapshotScanMinResponseBytes = 2 * 1024 * 1024
+	ruleSnapshotScanMaxResponseBytes = 4 * 1024 * 1024
+)
 
 // Watcher is used to watch the PD for any Placement Rule changes.
 type Watcher struct {
@@ -116,16 +128,29 @@ func NewWatcher(
 	return rw, nil
 }
 
+func adjustRuleSnapshotScanBatchSize(current, minimum int64, responseBytes int) int64 {
+	switch {
+	case responseBytes < ruleSnapshotScanMinResponseBytes:
+		return min(current*2, ruleSnapshotScanMaxBatchSize)
+	case responseBytes > ruleSnapshotScanMaxResponseBytes:
+		return max(current/2, minimum)
+	default:
+		return current
+	}
+}
+
 func (rw *Watcher) scanRuleSnapshotKeys(
 	ctx context.Context,
 	prefix string,
 	rangeEnds []string,
 	revision int64,
-	pageSize int64,
+	fetchBatchSize int64,
+	processBatchSize int,
 	handlePage func([]*mvccpb.KeyValue, int64) error,
 ) (int64, error) {
 	startKey := prefix
 	prefixEnd := clientv3.GetPrefixRangeEnd(prefix)
+	minFetchBatchSize := min(fetchBatchSize, int64(processBatchSize))
 	for rangeIndex := 0; rangeIndex <= len(rangeEnds); rangeIndex++ {
 		endKey := prefixEnd
 		if rangeIndex < len(rangeEnds) {
@@ -135,7 +160,7 @@ func (rw *Watcher) scanRuleSnapshotKeys(
 			opts := []clientv3.OpOption{
 				clientv3.WithRange(endKey),
 				// etcd ranges are key-ascending by default.
-				clientv3.WithLimit(pageSize + 1),
+				clientv3.WithLimit(fetchBatchSize + 1),
 				clientv3.WithKeysOnly(),
 			}
 			if revision > 0 {
@@ -157,8 +182,25 @@ func (rw *Watcher) scanRuleSnapshotKeys(
 				startKey = string(page[len(page)-1].Key)
 				page = page[:len(page)-1]
 			}
-			if err := handlePage(page, revision); err != nil {
-				return 0, err
+			if len(page) == 0 {
+				if err := handlePage(page, revision); err != nil {
+					return 0, err
+				}
+			} else {
+				for start := 0; start < len(page); start += processBatchSize {
+					end := min(start+processBatchSize, len(page))
+					if err := handlePage(page[start:end], revision); err != nil {
+						return 0, err
+					}
+				}
+			}
+			responseBytes := (*etcdserverpb.RangeResponse)(resp).Size()
+			if resp.More || responseBytes > ruleSnapshotScanMaxResponseBytes {
+				fetchBatchSize = adjustRuleSnapshotScanBatchSize(
+					fetchBatchSize,
+					minFetchBatchSize,
+					responseBytes,
+				)
 			}
 			if !resp.More {
 				break
@@ -227,7 +269,7 @@ func (rw *Watcher) reconcileRuleSnapshot(ctx context.Context) (int64, error) {
 
 	groupPrefix := []byte(rw.ruleGroupPathPrefix)
 	snapshotRevision, err := rw.scanRuleSnapshotKeys(
-		ctx, rw.ruleGroupPathPrefix, nil, 0, ruleSnapshotLoadBatchSize,
+		ctx, rw.ruleGroupPathPrefix, nil, 0, ruleSnapshotScanBatchSize, int(ruleSnapshotLoadBatchSize),
 		func(page []*mvccpb.KeyValue, revision int64) error {
 			type groupChange struct {
 				meta *mvccpb.KeyValue
@@ -299,12 +341,13 @@ func (rw *Watcher) reconcileRuleSnapshot(ctx context.Context) (int64, error) {
 	}
 	// Bound each etcd range with the already sorted local rule keys. etcd
 	// computes the count over the whole requested range even when a limit is set.
-	ruleRangeEnds := make([]string, 0, len(rules)/int(ruleSnapshotLoadBatchSize))
-	for i := int(ruleSnapshotLoadBatchSize); i < len(rules); i += int(ruleSnapshotLoadBatchSize) {
+	ruleRangeEnds := make([]string, 0, len(rules)/int(ruleSnapshotScanBatchSize))
+	for i := int(ruleSnapshotScanBatchSize); i < len(rules); i += int(ruleSnapshotScanBatchSize) {
 		ruleRangeEnds = append(ruleRangeEnds, rw.rulesPathPrefix+rules[i].StoreKey())
 	}
 	_, err = rw.scanRuleSnapshotKeys(
-		ctx, rw.rulesPathPrefix, ruleRangeEnds, snapshotRevision, ruleSnapshotLoadBatchSize,
+		ctx, rw.rulesPathPrefix, ruleRangeEnds, snapshotRevision,
+		ruleSnapshotScanBatchSize, int(ruleSnapshotLoadBatchSize),
 		func(page []*mvccpb.KeyValue, revision int64) error {
 			type ruleChange struct {
 				meta *mvccpb.KeyValue

--- a/pkg/mcs/scheduling/server/rule/watcher.go
+++ b/pkg/mcs/scheduling/server/rule/watcher.go
@@ -119,45 +119,54 @@ func NewWatcher(
 func (rw *Watcher) scanRuleSnapshotKeys(
 	ctx context.Context,
 	prefix string,
+	rangeEnds []string,
 	revision int64,
+	pageSize int64,
 	handlePage func([]*mvccpb.KeyValue, int64) error,
 ) (int64, error) {
 	startKey := prefix
-	endKey := clientv3.GetPrefixRangeEnd(prefix)
-	for {
-		opts := []clientv3.OpOption{
-			clientv3.WithRange(endKey),
-			// etcd ranges are already ordered by key. WithSort would make etcd
-			// fetch and sort the whole range before applying the page limit.
-			clientv3.WithLimit(ruleSnapshotLoadBatchSize + 1),
-			clientv3.WithKeysOnly(),
+	prefixEnd := clientv3.GetPrefixRangeEnd(prefix)
+	for rangeIndex := 0; rangeIndex <= len(rangeEnds); rangeIndex++ {
+		endKey := prefixEnd
+		if rangeIndex < len(rangeEnds) {
+			endKey = rangeEnds[rangeIndex]
 		}
-		if revision > 0 {
-			opts = append(opts, clientv3.WithRev(revision))
-		}
-		resp, err := etcdutil.EtcdKVGetWithContext(ctx, rw.etcdClient, startKey, opts...)
-		if err != nil {
-			return 0, err
-		}
-		if revision == 0 {
-			revision = resp.Header.Revision
-		}
-
-		page := resp.Kvs
-		if resp.More {
-			if len(page) == 0 {
-				return 0, errors.New("placement rule snapshot returned an empty page")
+		for {
+			opts := []clientv3.OpOption{
+				clientv3.WithRange(endKey),
+				// etcd ranges are key-ascending by default.
+				clientv3.WithLimit(pageSize + 1),
+				clientv3.WithKeysOnly(),
 			}
-			startKey = string(page[len(page)-1].Key)
-			page = page[:len(page)-1]
+			if revision > 0 {
+				opts = append(opts, clientv3.WithRev(revision))
+			}
+			resp, err := etcdutil.EtcdKVGetWithContext(ctx, rw.etcdClient, startKey, opts...)
+			if err != nil {
+				return 0, err
+			}
+			if revision == 0 {
+				revision = resp.Header.Revision
+			}
+
+			page := resp.Kvs
+			if resp.More {
+				if len(page) == 0 {
+					return 0, errors.New("placement rule snapshot returned an empty page")
+				}
+				startKey = string(page[len(page)-1].Key)
+				page = page[:len(page)-1]
+			}
+			if err := handlePage(page, revision); err != nil {
+				return 0, err
+			}
+			if !resp.More {
+				break
+			}
 		}
-		if err := handlePage(page, revision); err != nil {
-			return 0, err
-		}
-		if !resp.More {
-			return revision, nil
-		}
+		startKey = endKey
 	}
+	return revision, nil
 }
 
 func (rw *Watcher) loadRuleSnapshotValues(
@@ -218,7 +227,8 @@ func (rw *Watcher) reconcileRuleSnapshot(ctx context.Context) (int64, error) {
 	}
 
 	groupPrefix := []byte(rw.ruleGroupPathPrefix)
-	snapshotRevision, err := rw.scanRuleSnapshotKeys(ctx, rw.ruleGroupPathPrefix, 0,
+	snapshotRevision, err := rw.scanRuleSnapshotKeys(
+		ctx, rw.ruleGroupPathPrefix, nil, 0, ruleSnapshotLoadBatchSize,
 		func(page []*mvccpb.KeyValue, revision int64) error {
 			type groupChange struct {
 				meta *mvccpb.KeyValue
@@ -288,7 +298,14 @@ func (rw *Watcher) reconcileRuleSnapshot(ctx context.Context) (int64, error) {
 		ruleKeyBuffer = hex.AppendEncode(ruleKeyBuffer, []byte(rule.ID))
 		return bytes.Compare(ruleKeyBuffer, key)
 	}
-	_, err = rw.scanRuleSnapshotKeys(ctx, rw.rulesPathPrefix, snapshotRevision,
+	// Bound each etcd range with the already sorted local rule keys. etcd
+	// computes the count over the whole requested range even when a limit is set.
+	ruleRangeEnds := make([]string, 0, len(rules)/int(ruleSnapshotLoadBatchSize))
+	for i := int(ruleSnapshotLoadBatchSize); i < len(rules); i += int(ruleSnapshotLoadBatchSize) {
+		ruleRangeEnds = append(ruleRangeEnds, rw.rulesPathPrefix+rules[i].StoreKey())
+	}
+	_, err = rw.scanRuleSnapshotKeys(
+		ctx, rw.rulesPathPrefix, ruleRangeEnds, snapshotRevision, ruleSnapshotLoadBatchSize,
 		func(page []*mvccpb.KeyValue, revision int64) error {
 			type ruleChange struct {
 				meta *mvccpb.KeyValue

--- a/pkg/mcs/scheduling/server/rule/watcher.go
+++ b/pkg/mcs/scheduling/server/rule/watcher.go
@@ -15,8 +15,11 @@
 package rule
 
 import (
+	"bytes"
 	"context"
+	"encoding/hex"
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
 
@@ -34,6 +37,8 @@ import (
 	"github.com/tikv/pd/pkg/utils/keypath"
 	"github.com/tikv/pd/pkg/utils/keyutil"
 )
+
+const ruleSnapshotLoadBatchSize = int64(10000)
 
 // Watcher is used to watch the PD for any Placement Rule changes.
 type Watcher struct {
@@ -66,6 +71,11 @@ type Watcher struct {
 
 	ruleWatcher  *etcdutil.LoopWatcher
 	labelWatcher *etcdutil.LoopWatcher
+
+	// ruleRevision remains a safe applied lower bound after a callback failure.
+	// A gap stops live events from advancing it until snapshot reconciliation.
+	ruleRevision           int64
+	ruleRevisionContinuous bool
 
 	// patch is used to cache the placement rule changes.
 	patch *placement.RuleConfigPatch
@@ -106,14 +116,276 @@ func NewWatcher(
 	return rw, nil
 }
 
+func (rw *Watcher) scanRuleSnapshotKeys(
+	ctx context.Context,
+	prefix string,
+	revision int64,
+	handlePage func([]*mvccpb.KeyValue, int64) error,
+) (int64, error) {
+	startKey := prefix
+	endKey := clientv3.GetPrefixRangeEnd(prefix)
+	for {
+		opts := []clientv3.OpOption{
+			clientv3.WithRange(endKey),
+			clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend),
+			clientv3.WithLimit(ruleSnapshotLoadBatchSize + 1),
+			clientv3.WithKeysOnly(),
+		}
+		if revision > 0 {
+			opts = append(opts, clientv3.WithRev(revision))
+		}
+		resp, err := etcdutil.EtcdKVGetWithContext(ctx, rw.etcdClient, startKey, opts...)
+		if err != nil {
+			return 0, err
+		}
+		if revision == 0 {
+			revision = resp.Header.Revision
+		}
+
+		page := resp.Kvs
+		if resp.More {
+			if len(page) == 0 {
+				return 0, errors.New("placement rule snapshot returned an empty page")
+			}
+			startKey = string(page[len(page)-1].Key)
+			page = page[:len(page)-1]
+		}
+		if err := handlePage(page, revision); err != nil {
+			return 0, err
+		}
+		if !resp.More {
+			return revision, nil
+		}
+	}
+}
+
+func (rw *Watcher) loadRuleSnapshotValues(
+	ctx context.Context,
+	metadata []*mvccpb.KeyValue,
+	revision int64,
+) ([]*mvccpb.KeyValue, error) {
+	values := make([]*mvccpb.KeyValue, 0, len(metadata))
+	for start := 0; start < len(metadata); start += etcdutil.MaxEtcdTxnOps {
+		end := min(start+etcdutil.MaxEtcdTxnOps, len(metadata))
+		ops := make([]clientv3.Op, 0, end-start)
+		for _, item := range metadata[start:end] {
+			ops = append(ops, clientv3.OpGet(string(item.Key), clientv3.WithRev(revision)))
+		}
+		txnCtx, cancel := context.WithTimeout(ctx, etcdutil.DefaultRequestTimeout)
+		resp, err := rw.etcdClient.Txn(txnCtx).Then(ops...).Commit()
+		cancel()
+		if err != nil {
+			return nil, err
+		}
+		if len(resp.Responses) != end-start {
+			return nil, errors.New("placement rule snapshot returned an incomplete value batch")
+		}
+		for i, response := range resp.Responses {
+			kvs := response.GetResponseRange().Kvs
+			meta := metadata[start+i]
+			if len(kvs) != 1 || !bytes.Equal(kvs[0].Key, meta.Key) || kvs[0].ModRevision != meta.ModRevision {
+				return nil, fmt.Errorf("placement rule snapshot changed at key %q", meta.Key)
+			}
+			values = append(values, kvs[0])
+		}
+	}
+	return values, nil
+}
+
+func (rw *Watcher) reconcileRuleSnapshot(ctx context.Context) (int64, error) {
+	if rw.checkerController == nil {
+		return 0, errors.New("checker controller is nil")
+	}
+
+	rules, groups := rw.ruleManager.GetRuleConfigForReconcile()
+	patch := rw.ruleManager.BeginPatch()
+	suspectKeyRanges := &keyutil.KeyRanges{}
+	changedGroups := make(map[string]struct{})
+	changed := false
+	snapshotApplyFailed := false
+	groupIndex, ruleIndex := 0, 0
+
+	deleteGroup := func(group *placement.RuleGroup) {
+		patch.DeleteGroup(group.ID)
+		changedGroups[group.ID] = struct{}{}
+		changed = true
+	}
+	deleteRule := func(rule *placement.Rule) {
+		patch.DeleteRule(rule.GroupID, rule.ID)
+		suspectKeyRanges.Append(rule.StartKey, rule.EndKey)
+		changed = true
+	}
+
+	groupPrefix := []byte(rw.ruleGroupPathPrefix)
+	snapshotRevision, err := rw.scanRuleSnapshotKeys(ctx, rw.ruleGroupPathPrefix, 0,
+		func(page []*mvccpb.KeyValue, revision int64) error {
+			type groupChange struct {
+				meta *mvccpb.KeyValue
+				old  *placement.RuleGroup
+			}
+			changes := make([]groupChange, 0)
+			metadata := make([]*mvccpb.KeyValue, 0)
+			for _, item := range page {
+				if !bytes.HasPrefix(item.Key, groupPrefix) {
+					return fmt.Errorf("unexpected placement rule group key %q", item.Key)
+				}
+				key := item.Key[len(groupPrefix):]
+				for groupIndex < len(groups) && bytes.Compare([]byte(groups[groupIndex].ID), key) < 0 {
+					deleteGroup(groups[groupIndex])
+					groupIndex++
+				}
+				var old *placement.RuleGroup
+				if groupIndex < len(groups) && bytes.Equal([]byte(groups[groupIndex].ID), key) {
+					old = groups[groupIndex]
+					groupIndex++
+				}
+				if old != nil && item.ModRevision <= rw.ruleRevision {
+					continue
+				}
+				changes = append(changes, groupChange{meta: item, old: old})
+				metadata = append(metadata, item)
+			}
+
+			values, err := rw.loadRuleSnapshotValues(ctx, metadata, revision)
+			if err != nil {
+				return err
+			}
+			for i, item := range values {
+				group, err := placement.NewRuleGroupFromJSON(item.Value)
+				if err != nil {
+					snapshotApplyFailed = true
+					log.Error("failed to load placement rule group snapshot",
+						zap.ByteString("key", item.Key), zap.Error(err))
+					continue
+				}
+				old := changes[i].old
+				if old != nil && old.ID == group.ID && old.Index == group.Index && old.Override == group.Override {
+					continue
+				}
+				patch.SetGroup(group)
+				changedGroups[group.ID] = struct{}{}
+				if old != nil {
+					changedGroups[old.ID] = struct{}{}
+				}
+				changed = true
+			}
+			return nil
+		})
+	if err != nil {
+		return 0, err
+	}
+	for groupIndex < len(groups) {
+		deleteGroup(groups[groupIndex])
+		groupIndex++
+	}
+
+	rulePrefix := []byte(rw.rulesPathPrefix)
+	ruleKeyBuffer := make([]byte, 0, 128)
+	compareRuleKey := func(rule *placement.Rule, key []byte) int {
+		ruleKeyBuffer = hex.AppendEncode(ruleKeyBuffer[:0], []byte(rule.GroupID))
+		ruleKeyBuffer = append(ruleKeyBuffer, '-')
+		ruleKeyBuffer = hex.AppendEncode(ruleKeyBuffer, []byte(rule.ID))
+		return bytes.Compare(ruleKeyBuffer, key)
+	}
+	_, err = rw.scanRuleSnapshotKeys(ctx, rw.rulesPathPrefix, snapshotRevision,
+		func(page []*mvccpb.KeyValue, revision int64) error {
+			type ruleChange struct {
+				meta *mvccpb.KeyValue
+				old  *placement.Rule
+			}
+			changes := make([]ruleChange, 0)
+			metadata := make([]*mvccpb.KeyValue, 0)
+			for _, item := range page {
+				if !bytes.HasPrefix(item.Key, rulePrefix) {
+					return fmt.Errorf("unexpected placement rule key %q", item.Key)
+				}
+				key := item.Key[len(rulePrefix):]
+				for ruleIndex < len(rules) && compareRuleKey(rules[ruleIndex], key) < 0 {
+					deleteRule(rules[ruleIndex])
+					ruleIndex++
+				}
+				var old *placement.Rule
+				if ruleIndex < len(rules) && compareRuleKey(rules[ruleIndex], key) == 0 {
+					old = rules[ruleIndex]
+					ruleIndex++
+					if _, ok := changedGroups[old.GroupID]; ok {
+						suspectKeyRanges.Append(old.StartKey, old.EndKey)
+					}
+				}
+				if old != nil && item.ModRevision <= rw.ruleRevision {
+					continue
+				}
+				changes = append(changes, ruleChange{meta: item, old: old})
+				metadata = append(metadata, item)
+			}
+
+			values, err := rw.loadRuleSnapshotValues(ctx, metadata, revision)
+			if err != nil {
+				return err
+			}
+			for i, item := range values {
+				rule, err := placement.NewRuleFromJSON(item.Value)
+				if err != nil {
+					snapshotApplyFailed = true
+					log.Error("failed to load placement rule snapshot",
+						zap.ByteString("key", item.Key), zap.Error(err))
+					continue
+				}
+				if err := rw.ruleManager.AdjustRule(rule, ""); err != nil {
+					snapshotApplyFailed = true
+					log.Error("failed to adjust placement rule snapshot",
+						zap.ByteString("key", item.Key), zap.Error(err))
+					continue
+				}
+				patch.SetRule(rule)
+				suspectKeyRanges.Append(rule.StartKey, rule.EndKey)
+				if old := changes[i].old; old != nil {
+					suspectKeyRanges.Append(old.StartKey, old.EndKey)
+				}
+				changed = true
+			}
+			return nil
+		})
+	if err != nil {
+		return 0, err
+	}
+	for ruleIndex < len(rules) {
+		deleteRule(rules[ruleIndex])
+		ruleIndex++
+	}
+
+	if changed {
+		rw.ruleManager.Lock()
+		err = rw.ruleManager.TryCommitPatchLocked(patch)
+		rw.ruleManager.Unlock()
+		if err != nil {
+			return 0, err
+		}
+		for _, keyRange := range suspectKeyRanges.Ranges() {
+			rw.checkerController.AddSuspectKeyRange(keyRange.StartKey, keyRange.EndKey)
+		}
+	}
+	if snapshotApplyFailed {
+		rw.ruleRevisionContinuous = false
+	} else {
+		rw.ruleRevision = snapshotRevision
+		rw.ruleRevisionContinuous = true
+	}
+	return snapshotRevision + 1, nil
+}
+
 func (rw *Watcher) initializeRuleWatcher() error {
 	var suspectKeyRanges *keyutil.KeyRanges
+	var maxLoadedRevision int64
+	var applyFailed bool
 
 	preEventsFn := func([]*clientv3.Event) error {
 		// It will be locked until the postEventsFn is finished.
 		rw.ruleManager.Lock()
 		rw.patch = rw.ruleManager.BeginPatch()
 		suspectKeyRanges = &keyutil.KeyRanges{}
+		maxLoadedRevision = 0
+		applyFailed = false
 		return nil
 	}
 
@@ -123,10 +395,12 @@ func (rw *Watcher) initializeRuleWatcher() error {
 			log.Debug("update placement rule", zap.String("key", key), zap.String("value", string(kv.Value)))
 			rule, err := placement.NewRuleFromJSON(kv.Value)
 			if err != nil {
+				applyFailed = true
 				return err
 			}
 			// Try to add the rule change to the patch.
 			if err := rw.ruleManager.AdjustRule(rule, ""); err != nil {
+				applyFailed = true
 				return err
 			}
 			rw.patch.SetRule(rule)
@@ -135,11 +409,13 @@ func (rw *Watcher) initializeRuleWatcher() error {
 			if oldRule := rw.ruleManager.GetRuleLocked(rule.GroupID, rule.ID); oldRule != nil {
 				suspectKeyRanges.Append(oldRule.StartKey, oldRule.EndKey)
 			}
+			maxLoadedRevision = max(maxLoadedRevision, kv.ModRevision)
 			return nil
 		} else if strings.HasPrefix(key, rw.ruleGroupPathPrefix) {
 			log.Debug("update placement rule group", zap.String("key", key), zap.String("value", string(kv.Value)))
 			ruleGroup, err := placement.NewRuleGroupFromJSON(kv.Value)
 			if err != nil {
+				applyFailed = true
 				return err
 			}
 			// Try to add the rule group change to the patch.
@@ -148,6 +424,7 @@ func (rw *Watcher) initializeRuleWatcher() error {
 			for _, rule := range rw.ruleManager.GetRulesByGroupLocked(ruleGroup.ID) {
 				suspectKeyRanges.Append(rule.StartKey, rule.EndKey)
 			}
+			maxLoadedRevision = max(maxLoadedRevision, kv.ModRevision)
 			return nil
 		}
 		log.Warn("unknown key when updating placement rule", zap.String("key", key))
@@ -159,17 +436,20 @@ func (rw *Watcher) initializeRuleWatcher() error {
 			log.Debug("delete placement rule", zap.String("key", key))
 			ruleJSON, err := rw.ruleStorage.LoadRule(strings.TrimPrefix(key, rw.rulesPathPrefix))
 			if err != nil {
+				applyFailed = true
 				return err
 			}
 			rule, err := placement.NewRuleFromJSON([]byte(ruleJSON))
 			if err != nil {
+				applyFailed = true
 				return err
 			}
 			// Try to add the rule change to the patch.
 			rw.patch.DeleteRule(rule.GroupID, rule.ID)
 			// Update the suspect key ranges
 			suspectKeyRanges.Append(rule.StartKey, rule.EndKey)
-			return err
+			maxLoadedRevision = max(maxLoadedRevision, kv.ModRevision)
+			return nil
 		} else if strings.HasPrefix(key, rw.ruleGroupPathPrefix) {
 			log.Debug("delete placement rule group", zap.String("key", key))
 			trimmedKey := strings.TrimPrefix(key, rw.ruleGroupPathPrefix)
@@ -179,19 +459,31 @@ func (rw *Watcher) initializeRuleWatcher() error {
 			for _, rule := range rw.ruleManager.GetRulesByGroupLocked(trimmedKey) {
 				suspectKeyRanges.Append(rule.StartKey, rule.EndKey)
 			}
+			maxLoadedRevision = max(maxLoadedRevision, kv.ModRevision)
 			return nil
 		}
 		log.Warn("unknown key when deleting placement rule", zap.String("key", key))
 		return nil
 	}
-	postEventsFn := func([]*clientv3.Event) error {
+	postEventsFn := func(events []*clientv3.Event) error {
 		defer rw.ruleManager.Unlock()
 		if err := rw.ruleManager.TryCommitPatchLocked(rw.patch); err != nil {
+			applyFailed = true
+			if len(events) > 0 {
+				rw.ruleRevisionContinuous = false
+			}
 			log.Error("failed to commit patch", zap.Error(err))
 			return err
 		}
 		for _, kr := range suspectKeyRanges.Ranges() {
 			rw.checkerController.AddSuspectKeyRange(kr.StartKey, kr.EndKey)
+		}
+		if len(events) > 0 {
+			if applyFailed {
+				rw.ruleRevisionContinuous = false
+			} else if rw.ruleRevisionContinuous {
+				rw.ruleRevision = max(rw.ruleRevision, maxLoadedRevision)
+			}
 		}
 		return nil
 	}
@@ -206,6 +498,14 @@ func (rw *Watcher) initializeRuleWatcher() error {
 		postEventsFn,
 		true, /* withPrefix */
 	)
+	rw.ruleWatcher.SetConsistentLoad()
+	rw.ruleWatcher.SetInitialLoadSuccessFn(func() {
+		if !applyFailed {
+			rw.ruleRevision = maxLoadedRevision
+			rw.ruleRevisionContinuous = true
+		}
+	})
+	rw.ruleWatcher.SetCompactionReloadFn(rw.reconcileRuleSnapshot)
 	rw.ruleWatcher.StartWatchLoop()
 	return rw.ruleWatcher.WaitLoad()
 }

--- a/pkg/mcs/scheduling/server/rule/watcher.go
+++ b/pkg/mcs/scheduling/server/rule/watcher.go
@@ -212,7 +212,6 @@ func (rw *Watcher) reconcileRuleSnapshot(ctx context.Context) (int64, error) {
 	suspectKeyRanges := &keyutil.KeyRanges{}
 	changedGroups := make(map[string]struct{})
 	changed := false
-	snapshotApplyFailed := false
 	groupIndex, ruleIndex := 0, 0
 
 	deleteGroup := func(group *placement.RuleGroup) {
@@ -264,10 +263,7 @@ func (rw *Watcher) reconcileRuleSnapshot(ctx context.Context) (int64, error) {
 			for i, item := range values {
 				group, err := placement.NewRuleGroupFromJSON(item.Value)
 				if err != nil {
-					snapshotApplyFailed = true
-					log.Error("failed to load placement rule group snapshot",
-						zap.ByteString("key", item.Key), zap.Error(err))
-					continue
+					return fmt.Errorf("failed to load placement rule group snapshot at key %q: %w", item.Key, err)
 				}
 				old := changes[i].old
 				if old != nil && old.ID == group.ID && old.Index == group.Index && old.Override == group.Override {
@@ -344,16 +340,10 @@ func (rw *Watcher) reconcileRuleSnapshot(ctx context.Context) (int64, error) {
 			for i, item := range values {
 				rule, err := placement.NewRuleFromJSON(item.Value)
 				if err != nil {
-					snapshotApplyFailed = true
-					log.Error("failed to load placement rule snapshot",
-						zap.ByteString("key", item.Key), zap.Error(err))
-					continue
+					return fmt.Errorf("failed to load placement rule snapshot at key %q: %w", item.Key, err)
 				}
 				if err := rw.ruleManager.AdjustRule(rule, ""); err != nil {
-					snapshotApplyFailed = true
-					log.Error("failed to adjust placement rule snapshot",
-						zap.ByteString("key", item.Key), zap.Error(err))
-					continue
+					return fmt.Errorf("failed to adjust placement rule snapshot at key %q: %w", item.Key, err)
 				}
 				patch.SetRule(rule)
 				suspectKeyRanges.Append(rule.StartKey, rule.EndKey)
@@ -385,12 +375,8 @@ func (rw *Watcher) reconcileRuleSnapshot(ctx context.Context) (int64, error) {
 			rw.checkerController.AddSuspectKeyRange(keyRange.StartKey, keyRange.EndKey)
 		}
 	}
-	if snapshotApplyFailed {
-		rw.ruleRevisionContinuous = false
-	} else {
-		rw.ruleRevision = snapshotRevision
-		rw.ruleRevisionContinuous = true
-	}
+	rw.ruleRevision = snapshotRevision
+	rw.ruleRevisionContinuous = true
 	return snapshotRevision + 1, nil
 }
 

--- a/pkg/mcs/scheduling/server/rule/watcher.go
+++ b/pkg/mcs/scheduling/server/rule/watcher.go
@@ -127,7 +127,8 @@ func (rw *Watcher) scanRuleSnapshotKeys(
 	for {
 		opts := []clientv3.OpOption{
 			clientv3.WithRange(endKey),
-			clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend),
+			// etcd ranges are already ordered by key. WithSort would make etcd
+			// fetch and sort the whole range before applying the page limit.
 			clientv3.WithLimit(ruleSnapshotLoadBatchSize + 1),
 			clientv3.WithKeysOnly(),
 		}
@@ -354,6 +355,8 @@ func (rw *Watcher) reconcileRuleSnapshot(ctx context.Context) (int64, error) {
 		ruleIndex++
 	}
 
+	// TryCommitPatchLocked rebuilds the rule index, so skip it when the snapshot
+	// contains no detected changes.
 	if changed {
 		rw.ruleManager.Lock()
 		err = rw.ruleManager.TryCommitPatchLocked(patch)

--- a/pkg/mcs/scheduling/server/rule/watcher.go
+++ b/pkg/mcs/scheduling/server/rule/watcher.go
@@ -84,10 +84,8 @@ type Watcher struct {
 	ruleWatcher  *etcdutil.LoopWatcher
 	labelWatcher *etcdutil.LoopWatcher
 
-	// ruleRevision remains a safe applied lower bound after a callback failure.
-	// A gap stops live events from advancing it until snapshot reconciliation.
-	ruleRevision           int64
-	ruleRevisionContinuous bool
+	// ruleRevision is the latest etcd revision successfully applied to ruleManager.
+	ruleRevision int64
 
 	// patch is used to cache the placement rule changes.
 	patch *placement.RuleConfigPatch
@@ -425,7 +423,6 @@ func (rw *Watcher) reconcileRuleSnapshot(ctx context.Context) (int64, error) {
 		}
 	}
 	rw.ruleRevision = snapshotRevision
-	rw.ruleRevisionContinuous = true
 	return snapshotRevision + 1, nil
 }
 
@@ -523,7 +520,6 @@ func (rw *Watcher) initializeRuleWatcher() error {
 	postEventsFn := func(events []*clientv3.Event) error {
 		defer rw.ruleManager.Unlock()
 		if applyFailed {
-			rw.ruleRevisionContinuous = false
 			return errors.New("failed to apply placement rule events")
 		}
 		// A scheduling server can start before PD has persisted placement rules.
@@ -532,14 +528,13 @@ func (rw *Watcher) initializeRuleWatcher() error {
 			return nil
 		}
 		if err := rw.ruleManager.TryCommitPatchLocked(rw.patch); err != nil {
-			rw.ruleRevisionContinuous = false
 			log.Error("failed to commit patch", zap.Error(err))
 			return err
 		}
 		for _, kr := range suspectKeyRanges.Ranges() {
 			rw.checkerController.AddSuspectKeyRange(kr.StartKey, kr.EndKey)
 		}
-		if len(events) > 0 && rw.ruleRevisionContinuous {
+		if len(events) > 0 {
 			rw.ruleRevision = max(rw.ruleRevision, maxLoadedRevision)
 		}
 		return nil
@@ -557,12 +552,10 @@ func (rw *Watcher) initializeRuleWatcher() error {
 	)
 	rw.ruleWatcher.SetConsistentLoad()
 	rw.ruleWatcher.SetInitialLoadSuccessFn(func() {
-		if !applyFailed {
-			rw.ruleRevision = maxLoadedRevision
-			rw.ruleRevisionContinuous = true
-		}
+		rw.ruleRevision = maxLoadedRevision
 	})
 	rw.ruleWatcher.SetCompactionReloadFn(rw.reconcileRuleSnapshot)
+	rw.ruleWatcher.SetRetryOnPostEventError()
 	rw.ruleWatcher.StartWatchLoop()
 	return rw.ruleWatcher.WaitLoad()
 }

--- a/pkg/mcs/scheduling/server/rule/watcher.go
+++ b/pkg/mcs/scheduling/server/rule/watcher.go
@@ -548,8 +548,9 @@ func (rw *Watcher) initializeRuleWatcher() error {
 	)
 	rw.ruleWatcher.SetConsistentLoad()
 	rw.ruleWatcher.SetInitialLoadSuccessFn(func() {
-		rw.ruleRevision = maxLoadedRevision
+		rw.ruleRevision = max(rw.ruleRevision, maxLoadedRevision)
 	})
+	rw.ruleWatcher.SetInitialLoadRetryFn(rw.reconcileRuleSnapshot)
 	rw.ruleWatcher.SetCompactionReloadFn(rw.reconcileRuleSnapshot)
 	rw.ruleWatcher.SetRetryOnPostEventError()
 	rw.ruleWatcher.StartWatchLoop()

--- a/pkg/mcs/scheduling/server/rule/watcher.go
+++ b/pkg/mcs/scheduling/server/rule/watcher.go
@@ -40,9 +40,9 @@ import (
 )
 
 const (
-	// Keep value loading and patch construction bounded independently from the
-	// larger keys-only etcd range responses.
-	ruleSnapshotLoadBatchSize = int64(10000)
+	// Bound the entries processed and values loaded per callback independently
+	// from the larger keys-only etcd range responses.
+	ruleSnapshotProcessBatchSize = int64(10000)
 
 	// Aim for 2-4 MiB keys-only responses. The initial batch matches the lower
 	// bound for the typical placement-rule key size and may grow up to 100k.
@@ -144,7 +144,7 @@ func (rw *Watcher) scanRuleSnapshotKeys(
 	revision int64,
 	fetchBatchSize int64,
 	processBatchSize int,
-	handlePage func([]*mvccpb.KeyValue, int64) error,
+	handleBatch func([]*mvccpb.KeyValue, int64) error,
 ) (int64, error) {
 	startKey := prefix
 	prefixEnd := clientv3.GetPrefixRangeEnd(prefix)
@@ -182,13 +182,13 @@ func (rw *Watcher) scanRuleSnapshotKeys(
 				startKey = string(append(page[len(page)-1].Key, 0))
 			}
 			if len(page) == 0 {
-				if err := handlePage(page, revision); err != nil {
+				if err := handleBatch(page, revision); err != nil {
 					return 0, err
 				}
 			} else {
 				for start := 0; start < len(page); start += processBatchSize {
 					end := min(start+processBatchSize, len(page))
-					if err := handlePage(page[start:end], revision); err != nil {
+					if err := handleBatch(page[start:end], revision); err != nil {
 						return 0, err
 					}
 				}
@@ -269,11 +269,11 @@ func (rw *Watcher) reconcileRuleSnapshot(ctx context.Context) (int64, error) {
 
 	groupPrefix := []byte(rw.ruleGroupPathPrefix)
 	snapshotRevision, err := rw.scanRuleSnapshotKeys(
-		ctx, rw.ruleGroupPathPrefix, nil, 0, ruleSnapshotScanBatchSize, int(ruleSnapshotLoadBatchSize),
-		func(page []*mvccpb.KeyValue, revision int64) error {
+		ctx, rw.ruleGroupPathPrefix, nil, 0, ruleSnapshotScanBatchSize, int(ruleSnapshotProcessBatchSize),
+		func(batch []*mvccpb.KeyValue, revision int64) error {
 			oldGroups := make([]*placement.RuleGroup, 0)
 			metadata := make([]*mvccpb.KeyValue, 0)
-			for _, item := range page {
+			for _, item := range batch {
 				if !bytes.HasPrefix(item.Key, groupPrefix) {
 					return fmt.Errorf("unexpected placement rule group key %q", item.Key)
 				}
@@ -340,11 +340,11 @@ func (rw *Watcher) reconcileRuleSnapshot(ctx context.Context) (int64, error) {
 	}
 	_, err = rw.scanRuleSnapshotKeys(
 		ctx, rw.rulesPathPrefix, ruleRangeEnds, snapshotRevision,
-		ruleSnapshotScanBatchSize, int(ruleSnapshotLoadBatchSize),
-		func(page []*mvccpb.KeyValue, revision int64) error {
+		ruleSnapshotScanBatchSize, int(ruleSnapshotProcessBatchSize),
+		func(batch []*mvccpb.KeyValue, revision int64) error {
 			oldRules := make([]*placement.Rule, 0)
 			metadata := make([]*mvccpb.KeyValue, 0)
-			for _, item := range page {
+			for _, item := range batch {
 				if !bytes.HasPrefix(item.Key, rulePrefix) {
 					return fmt.Errorf("unexpected placement rule key %q", item.Key)
 				}

--- a/pkg/mcs/scheduling/server/rule/watcher_test.go
+++ b/pkg/mcs/scheduling/server/rule/watcher_test.go
@@ -184,15 +184,21 @@ func TestReconcileRuleSnapshot(t *testing.T) {
 
 	storage := endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil)
 	conf := mockconfig.NewTestOptions()
-	ruleManager := placement.NewRuleManager(ctx, storage, nil, conf)
+	cluster := mockcluster.NewCluster(ctx, conf)
+	cluster.AddLabelsStore(1, 0, map[string]string{"zone": "z1"})
+	ruleManager := placement.NewRuleManager(ctx, storage, cluster, conf)
 	re.NoError(ruleManager.Initialize(3, nil, "", false))
 	re.NoError(ruleManager.SetRuleGroup(&placement.RuleGroup{ID: "g", Index: 1}))
 	re.NoError(ruleManager.SetRules([]*placement.Rule{
 		{GroupID: "g", ID: "deleted", Role: placement.Learner, Count: 1},
-		{GroupID: "g", ID: "unchanged", Role: placement.Learner, Count: 1},
+		{
+			GroupID: "g", ID: "unchanged", Role: placement.Learner, Count: 1,
+			LabelConstraints: []placement.LabelConstraint{
+				{Key: "zone", Op: placement.In, Values: []string{"z1"}},
+			},
+		},
 	}))
 
-	cluster := mockcluster.NewCluster(ctx, conf)
 	cluster.RuleManager = ruleManager
 	opController := operator.NewController(ctx, cluster.GetBasicCluster(), cluster.GetSharedConfig(), nil)
 	checkerController := checker.NewController(ctx, cluster, cluster.GetCheckerConfig(), opController)
@@ -239,4 +245,24 @@ func TestReconcileRuleSnapshot(t *testing.T) {
 	re.Zero(ruleManager.GetRuleGroup("g").Index)
 	re.Equal(updated.Header.Revision, rw.ruleRevision)
 	re.True(rw.ruleRevisionContinuous)
+
+	updatedRule := ruleManager.GetRule("g", "unchanged")
+	updatedRule.LabelConstraints[0].Values = []string{"z2"}
+	updatedRuleValue, err := json.Marshal(updatedRule)
+	re.NoError(err)
+	updatedRuleResp, err := client.Put(ctx, keypath.RuleKeyPath(updatedRule.StoreKey()), string(updatedRuleValue))
+	re.NoError(err)
+
+	_, err = rw.reconcileRuleSnapshot(ctx)
+	re.ErrorContains(err, "can not match any store")
+	re.Equal(updated.Header.Revision, rw.ruleRevision)
+	re.Equal([]string{"z1"}, ruleManager.GetRule("g", "unchanged").LabelConstraints[0].Values)
+
+	cluster.SetStoreLabel(1, map[string]string{"zone": "z2"})
+	nextRevision, err = rw.reconcileRuleSnapshot(ctx)
+	re.NoError(err)
+	re.Equal(updatedRuleResp.Header.Revision+1, nextRevision)
+	re.Equal(updatedRuleResp.Header.Revision, rw.ruleRevision)
+	re.True(rw.ruleRevisionContinuous)
+	re.Equal([]string{"z2"}, ruleManager.GetRule("g", "unchanged").LabelConstraints[0].Values)
 }

--- a/pkg/mcs/scheduling/server/rule/watcher_test.go
+++ b/pkg/mcs/scheduling/server/rule/watcher_test.go
@@ -353,13 +353,12 @@ func TestReconcileRuleSnapshot(t *testing.T) {
 	re.NoError(err)
 
 	rw := &Watcher{
-		rulesPathPrefix:        keypath.RulesPathPrefix(),
-		ruleGroupPathPrefix:    keypath.RuleGroupPathPrefix(),
-		etcdClient:             client,
-		ruleManager:            ruleManager,
-		checkerController:      checkerController,
-		ruleRevision:           initial.Header.Revision,
-		ruleRevisionContinuous: true,
+		rulesPathPrefix:     keypath.RulesPathPrefix(),
+		ruleGroupPathPrefix: keypath.RuleGroupPathPrefix(),
+		etcdClient:          client,
+		ruleManager:         ruleManager,
+		checkerController:   checkerController,
+		ruleRevision:        initial.Header.Revision,
 	}
 	nextRevision, err := rw.reconcileRuleSnapshot(ctx)
 	re.NoError(err)
@@ -369,7 +368,6 @@ func TestReconcileRuleSnapshot(t *testing.T) {
 	re.Equal(unchangedVersion, ruleManager.GetRule("g", "unchanged").Version)
 	re.Zero(ruleManager.GetRuleGroup("g").Index)
 	re.Equal(updated.Header.Revision, rw.ruleRevision)
-	re.True(rw.ruleRevisionContinuous)
 
 	updatedRule := ruleManager.GetRule("g", "unchanged")
 	updatedRule.LabelConstraints[0].Values = []string{"z2"}
@@ -388,7 +386,6 @@ func TestReconcileRuleSnapshot(t *testing.T) {
 	re.NoError(err)
 	re.Equal(updatedRuleResp.Header.Revision+1, nextRevision)
 	re.Equal(updatedRuleResp.Header.Revision, rw.ruleRevision)
-	re.True(rw.ruleRevisionContinuous)
 	re.Equal([]string{"z2"}, ruleManager.GetRule("g", "unchanged").LabelConstraints[0].Values)
 
 	mismatchedGroupValue, err := json.Marshal(&placement.RuleGroup{ID: "payload"})

--- a/pkg/mcs/scheduling/server/rule/watcher_test.go
+++ b/pkg/mcs/scheduling/server/rule/watcher_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -342,13 +343,20 @@ func TestReconcileRuleSnapshot(t *testing.T) {
 	re.NoError(err)
 
 	unchangedVersion := ruleManager.GetRule("g", "unchanged").Version
+	updatedGroup := &placement.RuleGroup{ID: "g", Index: 2}
+	updatedGroupValue, err := json.Marshal(updatedGroup)
+	re.NoError(err)
+	addedGroup := &placement.RuleGroup{ID: "added", Index: 3}
+	addedGroupValue, err := json.Marshal(addedGroup)
+	re.NoError(err)
 	updatedDefault := ruleManager.GetRule(placement.DefaultGroupID, placement.DefaultRuleID)
 	updatedDefault.Count = 5
 	updatedValue, err := json.Marshal(updatedDefault)
 	re.NoError(err)
 	updated, err := client.Txn(ctx).Then(
 		clientv3.OpDelete(keypath.RuleKeyPath((&placement.Rule{GroupID: "g", ID: "deleted"}).StoreKey())),
-		clientv3.OpDelete(keypath.RuleGroupIDPath("g")),
+		clientv3.OpPut(keypath.RuleGroupIDPath(updatedGroup.ID), string(updatedGroupValue)),
+		clientv3.OpPut(keypath.RuleGroupIDPath(addedGroup.ID), string(addedGroupValue)),
 		clientv3.OpPut(keypath.RuleKeyPath(updatedDefault.StoreKey()), string(updatedValue)),
 	).Commit()
 	re.NoError(err)
@@ -367,8 +375,21 @@ func TestReconcileRuleSnapshot(t *testing.T) {
 	re.Nil(ruleManager.GetRule("g", "deleted"))
 	re.Equal(5, ruleManager.GetRule(placement.DefaultGroupID, placement.DefaultRuleID).Count)
 	re.Equal(unchangedVersion, ruleManager.GetRule("g", "unchanged").Version)
-	re.Zero(ruleManager.GetRuleGroup("g").Index)
+	re.Equal(updatedGroup, ruleManager.GetRuleGroup("g"))
+	re.Equal(addedGroup, ruleManager.GetRuleGroup("added"))
 	re.Equal(updated.Header.Revision, rw.ruleRevision)
+
+	groupsDeleted, err := client.Txn(ctx).Then(
+		clientv3.OpDelete(keypath.RuleGroupIDPath(updatedGroup.ID)),
+		clientv3.OpDelete(keypath.RuleGroupIDPath(addedGroup.ID)),
+	).Commit()
+	re.NoError(err)
+	nextRevision, err = rw.reconcileRuleSnapshot(ctx)
+	re.NoError(err)
+	re.Equal(groupsDeleted.Header.Revision+1, nextRevision)
+	re.Zero(ruleManager.GetRuleGroup("g").Index)
+	re.Nil(ruleManager.GetRuleGroup("added"))
+	re.Equal(groupsDeleted.Header.Revision, rw.ruleRevision)
 
 	updatedRule := ruleManager.GetRule("g", "unchanged")
 	updatedRule.LabelConstraints[0].Values = []string{"z2"}
@@ -379,7 +400,7 @@ func TestReconcileRuleSnapshot(t *testing.T) {
 
 	_, err = rw.reconcileRuleSnapshot(ctx)
 	re.ErrorContains(err, "can not match any store")
-	re.Equal(updated.Header.Revision, rw.ruleRevision)
+	re.Equal(groupsDeleted.Header.Revision, rw.ruleRevision)
 	re.Equal([]string{"z1"}, ruleManager.GetRule("g", "unchanged").LabelConstraints[0].Values)
 
 	cluster.SetStoreLabel(1, map[string]string{"zone": "z2"})
@@ -411,4 +432,75 @@ func TestReconcileRuleSnapshot(t *testing.T) {
 	re.ErrorContains(err, "placement rule snapshot key does not match payload identity")
 	re.Equal(updatedRuleResp.Header.Revision, rw.ruleRevision)
 	re.Nil(ruleManager.GetRule("payload", "rule"))
+}
+
+func TestRuleWatcherReplaysFailedLiveRuleUpdate(t *testing.T) {
+	re := require.New(t)
+	ctx, client, clean := prepare(t, false)
+	defer clean()
+
+	storage := endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil)
+	conf := mockconfig.NewTestOptions()
+	cluster := mockcluster.NewCluster(ctx, conf)
+	cluster.AddLabelsStore(1, 0, map[string]string{"zone": "z1"})
+	ruleManager := placement.NewRuleManager(ctx, storage, cluster, conf)
+	re.NoError(ruleManager.Initialize(3, nil, "", false))
+	re.NoError(ruleManager.SetRule(&placement.Rule{
+		GroupID: "g",
+		ID:      "r",
+		Role:    placement.Learner,
+		Count:   1,
+		LabelConstraints: []placement.LabelConstraint{
+			{Key: "zone", Op: placement.In, Values: []string{"z1"}},
+		},
+	}))
+	cluster.RuleManager = ruleManager
+
+	opController := operator.NewController(ctx, cluster.GetBasicCluster(), cluster.GetSharedConfig(), nil)
+	checkerController := checker.NewController(ctx, cluster, cluster.GetCheckerConfig(), opController)
+	for _, rule := range ruleManager.GetAllRules() {
+		value, err := json.Marshal(rule)
+		re.NoError(err)
+		_, err = client.Put(ctx, keypath.RuleKeyPath(rule.StoreKey()), string(value))
+		re.NoError(err)
+	}
+
+	watchCtx, cancel := context.WithCancel(ctx)
+	rw := &Watcher{
+		ctx:                 watchCtx,
+		cancel:              cancel,
+		rulesPathPrefix:     keypath.RulesPathPrefix(),
+		ruleGroupPathPrefix: keypath.RuleGroupPathPrefix(),
+		etcdClient:          client,
+		ruleStorage:         storage,
+		ruleManager:         ruleManager,
+		checkerController:   checkerController,
+	}
+	defer rw.Close()
+	re.NoError(rw.initializeRuleWatcher())
+
+	logFile := testutil.InitTempFileLogger("info")
+	defer os.RemoveAll(logFile)
+	updatedRule := ruleManager.GetRule("g", "r")
+	updatedRule.LabelConstraints[0].Values = []string{"z2"}
+	updatedValue, err := json.Marshal(updatedRule)
+	re.NoError(err)
+	updated, err := client.Put(ctx, keypath.RuleKeyPath(updatedRule.StoreKey()), string(updatedValue))
+	re.NoError(err)
+
+	testutil.Eventually(re, func() bool {
+		contents, err := os.ReadFile(logFile)
+		return err == nil &&
+			strings.Contains(string(contents), "run post event failed in watch loop") &&
+			strings.Contains(string(contents), "scheduling-rule-watcher")
+	})
+	re.Equal([]string{"z1"}, ruleManager.GetRule("g", "r").LabelConstraints[0].Values)
+
+	cluster.SetStoreLabel(1, map[string]string{"zone": "z2"})
+	testutil.Eventually(re, func() bool {
+		rule := ruleManager.GetRule("g", "r")
+		return rule != nil && len(rule.LabelConstraints) == 1 &&
+			len(rule.LabelConstraints[0].Values) == 1 && rule.LabelConstraints[0].Values[0] == "z2"
+	})
+	re.Equal(updated.Header.Revision, rw.ruleRevision)
 }

--- a/pkg/mcs/scheduling/server/rule/watcher_test.go
+++ b/pkg/mcs/scheduling/server/rule/watcher_test.go
@@ -151,11 +151,12 @@ func prepareWithEtcdConfig(
 func BenchmarkRuleSnapshotKeyScan(b *testing.B) {
 	ctx, client, clean := prepareWithEtcdConfig(b, false, func(cfg *embed.Config) {
 		cfg.MaxTxnOps = ruleSnapshotBenchmarkTxnOps
+		cfg.LogLevel = "error"
 	})
 	defer clean()
 
 	prefix := keypath.RulesPathPrefix()
-	rangeEnds := make([]string, 0, ruleSnapshotBenchmarkRules/int(ruleSnapshotLoadBatchSize))
+	rangeEnds := make([]string, 0, ruleSnapshotBenchmarkRules/int(ruleSnapshotScanBatchSize))
 	ops := make([]clientv3.Op, 0, ruleSnapshotBenchmarkTxnOps)
 	var snapshotRevision int64
 	commit := func() {
@@ -166,7 +167,7 @@ func BenchmarkRuleSnapshotKeyScan(b *testing.B) {
 	}
 	for i := range ruleSnapshotBenchmarkRules {
 		key := fmt.Sprintf("%s67-%016x", prefix, i)
-		if i > 0 && i%int(ruleSnapshotLoadBatchSize) == 0 {
+		if i > 0 && i%int(ruleSnapshotScanBatchSize) == 0 {
 			rangeEnds = append(rangeEnds, key)
 		}
 		ops = append(ops, clientv3.OpPut(key, "{}"))
@@ -181,22 +182,19 @@ func BenchmarkRuleSnapshotKeyScan(b *testing.B) {
 	rw := &Watcher{etcdClient: client}
 	runPaged := func(b *testing.B, rangeEnds []string) {
 		b.ReportAllocs()
-		var totalRPCs int
 		for range b.N {
-			scanned, rpcs := 0, 0
+			scanned := 0
 			revision, err := rw.scanRuleSnapshotKeys(
-				ctx, prefix, rangeEnds, snapshotRevision, ruleSnapshotLoadBatchSize,
+				ctx, prefix, rangeEnds, snapshotRevision,
+				ruleSnapshotScanBatchSize, int(ruleSnapshotLoadBatchSize),
 				func(page []*mvccpb.KeyValue, _ int64) error {
 					scanned += len(page)
-					rpcs++
 					return nil
 				})
 			require.NoError(b, err)
 			require.Equal(b, snapshotRevision, revision)
 			require.Equal(b, ruleSnapshotBenchmarkRules, scanned)
-			totalRPCs += rpcs
 		}
-		b.ReportMetric(float64(totalRPCs)/float64(b.N), "rpcs/op")
 	}
 
 	b.Run("paged/empty-local", func(b *testing.B) {
@@ -219,8 +217,18 @@ func BenchmarkRuleSnapshotKeyScan(b *testing.B) {
 			require.NoError(b, err)
 			require.Len(b, resp.Kvs, ruleSnapshotBenchmarkRules)
 		}
-		b.ReportMetric(1, "rpcs/op")
 	})
+}
+
+func TestAdjustRuleSnapshotScanBatchSize(t *testing.T) {
+	re := require.New(t)
+	minimum := ruleSnapshotLoadBatchSize
+	re.Equal(int64(100000), adjustRuleSnapshotScanBatchSize(50000, minimum, 1024*1024))
+	re.Equal(int64(100000), adjustRuleSnapshotScanBatchSize(100000, minimum, 1024*1024))
+	re.Equal(int64(50000), adjustRuleSnapshotScanBatchSize(100000, minimum, 5*1024*1024))
+	re.Equal(int64(25000), adjustRuleSnapshotScanBatchSize(50000, minimum, 5*1024*1024))
+	re.Equal(minimum, adjustRuleSnapshotScanBatchSize(minimum, minimum, 5*1024*1024))
+	re.Equal(int64(50000), adjustRuleSnapshotScanBatchSize(50000, minimum, 3*1024*1024))
 }
 
 func TestScanRuleSnapshotKeyRanges(t *testing.T) {
@@ -246,8 +254,9 @@ func TestScanRuleSnapshotKeyRanges(t *testing.T) {
 	rw := &Watcher{etcdClient: client}
 	var loaded []string
 	callbackCount := 0
-	revision, err := rw.scanRuleSnapshotKeys(ctx, prefix, []string{prefix + "b"}, 0, 2,
+	revision, err := rw.scanRuleSnapshotKeys(ctx, prefix, []string{prefix + "b"}, 0, 4, 2,
 		func(page []*mvccpb.KeyValue, _ int64) error {
+			re.LessOrEqual(len(page), 2)
 			for _, item := range page {
 				loaded = append(loaded, string(item.Key))
 			}

--- a/pkg/mcs/scheduling/server/rule/watcher_test.go
+++ b/pkg/mcs/scheduling/server/rule/watcher_test.go
@@ -265,4 +265,27 @@ func TestReconcileRuleSnapshot(t *testing.T) {
 	re.Equal(updatedRuleResp.Header.Revision, rw.ruleRevision)
 	re.True(rw.ruleRevisionContinuous)
 	re.Equal([]string{"z2"}, ruleManager.GetRule("g", "unchanged").LabelConstraints[0].Values)
+
+	mismatchedGroupValue, err := json.Marshal(&placement.RuleGroup{ID: "payload"})
+	re.NoError(err)
+	_, err = client.Put(ctx, keypath.RuleGroupIDPath("storage"), string(mismatchedGroupValue))
+	re.NoError(err)
+	_, err = rw.reconcileRuleSnapshot(ctx)
+	re.ErrorContains(err, "placement rule group snapshot key does not match payload identity")
+	re.Equal(updatedRuleResp.Header.Revision, rw.ruleRevision)
+	re.Nil(ruleManager.GetRuleGroup("payload"))
+
+	mismatchedRule := &placement.Rule{GroupID: "payload", ID: "rule", Role: placement.Learner, Count: 1}
+	mismatchedRuleValue, err := json.Marshal(mismatchedRule)
+	re.NoError(err)
+	storageRule := &placement.Rule{GroupID: "storage", ID: "rule"}
+	_, err = client.Txn(ctx).Then(
+		clientv3.OpDelete(keypath.RuleGroupIDPath("storage")),
+		clientv3.OpPut(keypath.RuleKeyPath(storageRule.StoreKey()), string(mismatchedRuleValue)),
+	).Commit()
+	re.NoError(err)
+	_, err = rw.reconcileRuleSnapshot(ctx)
+	re.ErrorContains(err, "placement rule snapshot key does not match payload identity")
+	re.Equal(updatedRuleResp.Header.Revision, rw.ruleRevision)
+	re.Nil(ruleManager.GetRule("payload", "rule"))
 }

--- a/pkg/mcs/scheduling/server/rule/watcher_test.go
+++ b/pkg/mcs/scheduling/server/rule/watcher_test.go
@@ -242,6 +242,7 @@ func TestScanRuleSnapshotKeyRanges(t *testing.T) {
 		prefix + "aa",
 		prefix + "aaa",
 		prefix + "aaaa",
+		prefix + "aaaaa",
 		prefix + "c",
 	}
 	ops := make([]clientv3.Op, 0, len(keys))

--- a/pkg/mcs/scheduling/server/rule/watcher_test.go
+++ b/pkg/mcs/scheduling/server/rule/watcher_test.go
@@ -27,7 +27,12 @@ import (
 	"go.uber.org/goleak"
 
 	"github.com/tikv/pd/pkg/keyspace"
+	"github.com/tikv/pd/pkg/mock/mockcluster"
+	"github.com/tikv/pd/pkg/mock/mockconfig"
+	"github.com/tikv/pd/pkg/schedule/checker"
 	"github.com/tikv/pd/pkg/schedule/labeler"
+	"github.com/tikv/pd/pkg/schedule/operator"
+	"github.com/tikv/pd/pkg/schedule/placement"
 	"github.com/tikv/pd/pkg/storage/endpoint"
 	"github.com/tikv/pd/pkg/storage/kv"
 	"github.com/tikv/pd/pkg/utils/etcdutil"
@@ -45,14 +50,14 @@ const (
 
 func TestLoadLargeRules(t *testing.T) {
 	re := require.New(t)
-	ctx, client, clean := prepare(t)
+	ctx, client, clean := prepare(t, true)
 	defer clean()
 	runWatcherLoadLabelRule(ctx, re, client)
 }
 
 func BenchmarkLoadLargeRules(b *testing.B) {
 	re := require.New(b)
-	ctx, client, clean := prepare(b)
+	ctx, client, clean := prepare(b, true)
 	defer clean()
 
 	b.ResetTimer() // Resets the timer to ignore initialization time in the benchmark
@@ -83,7 +88,7 @@ func runWatcherLoadLabelRule(ctx context.Context, re *require.Assertions, client
 	cancel()
 }
 
-func prepare(t require.TestingT) (context.Context, *clientv3.Client, func()) {
+func prepare(t require.TestingT, loadLabelRules bool) (context.Context, *clientv3.Client, func()) {
 	re := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	cfg := etcdutil.NewTestEtcdConfig()
@@ -97,22 +102,24 @@ func prepare(t require.TestingT) (context.Context, *clientv3.Client, func()) {
 	re.NoError(err)
 	<-etcd.Server.ReadyNotify()
 
-	ops := make([]clientv3.Op, 0, etcdutil.MaxEtcdTxnOps)
-	for i := 1; i < rulesNum+1; i++ {
-		rule := keyspace.MakeTxnLabelRule(uint32(i))
-		value, err := json.Marshal(rule)
-		re.NoError(err)
-		key := keypath.RegionLabelKeyPath(rule.ID)
-		ops = append(ops, clientv3.OpPut(key, string(value)))
-		if len(ops) == etcdutil.MaxEtcdTxnOps {
+	if loadLabelRules {
+		ops := make([]clientv3.Op, 0, etcdutil.MaxEtcdTxnOps)
+		for i := 1; i < rulesNum+1; i++ {
+			rule := keyspace.MakeTxnLabelRule(uint32(i))
+			value, err := json.Marshal(rule)
+			re.NoError(err)
+			key := keypath.RegionLabelKeyPath(rule.ID)
+			ops = append(ops, clientv3.OpPut(key, string(value)))
+			if len(ops) == etcdutil.MaxEtcdTxnOps {
+				_, err = client.Txn(ctx).Then(ops...).Commit()
+				re.NoError(err)
+				ops = ops[:0]
+			}
+		}
+		if len(ops) > 0 {
 			_, err = client.Txn(ctx).Then(ops...).Commit()
 			re.NoError(err)
-			ops = ops[:0]
 		}
-	}
-	if len(ops) > 0 {
-		_, err = client.Txn(ctx).Then(ops...).Commit()
-		re.NoError(err)
 	}
 
 	return ctx, client, func() {
@@ -121,4 +128,68 @@ func prepare(t require.TestingT) (context.Context, *clientv3.Client, func()) {
 		etcd.Close()
 		os.RemoveAll(cfg.Dir)
 	}
+}
+
+func TestReconcileRuleSnapshot(t *testing.T) {
+	re := require.New(t)
+	ctx, client, clean := prepare(t, false)
+	defer clean()
+
+	storage := endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil)
+	conf := mockconfig.NewTestOptions()
+	ruleManager := placement.NewRuleManager(ctx, storage, nil, conf)
+	re.NoError(ruleManager.Initialize(3, nil, "", false))
+	re.NoError(ruleManager.SetRuleGroup(&placement.RuleGroup{ID: "g", Index: 1}))
+	re.NoError(ruleManager.SetRules([]*placement.Rule{
+		{GroupID: "g", ID: "deleted", Role: placement.Learner, Count: 1},
+		{GroupID: "g", ID: "unchanged", Role: placement.Learner, Count: 1},
+	}))
+
+	cluster := mockcluster.NewCluster(ctx, conf)
+	cluster.RuleManager = ruleManager
+	opController := operator.NewController(ctx, cluster.GetBasicCluster(), cluster.GetSharedConfig(), nil)
+	checkerController := checker.NewController(ctx, cluster, cluster.GetCheckerConfig(), opController)
+
+	ops := make([]clientv3.Op, 0, ruleManager.GetRulesCount()+1)
+	for _, rule := range ruleManager.GetAllRules() {
+		value, err := json.Marshal(rule)
+		re.NoError(err)
+		ops = append(ops, clientv3.OpPut(keypath.RuleKeyPath(rule.StoreKey()), string(value)))
+	}
+	groupValue, err := json.Marshal(ruleManager.GetRuleGroup("g"))
+	re.NoError(err)
+	ops = append(ops, clientv3.OpPut(keypath.RuleGroupIDPath("g"), string(groupValue)))
+	initial, err := client.Txn(ctx).Then(ops...).Commit()
+	re.NoError(err)
+
+	unchangedVersion := ruleManager.GetRule("g", "unchanged").Version
+	updatedDefault := ruleManager.GetRule(placement.DefaultGroupID, placement.DefaultRuleID)
+	updatedDefault.Count = 5
+	updatedValue, err := json.Marshal(updatedDefault)
+	re.NoError(err)
+	updated, err := client.Txn(ctx).Then(
+		clientv3.OpDelete(keypath.RuleKeyPath((&placement.Rule{GroupID: "g", ID: "deleted"}).StoreKey())),
+		clientv3.OpDelete(keypath.RuleGroupIDPath("g")),
+		clientv3.OpPut(keypath.RuleKeyPath(updatedDefault.StoreKey()), string(updatedValue)),
+	).Commit()
+	re.NoError(err)
+
+	rw := &Watcher{
+		rulesPathPrefix:        keypath.RulesPathPrefix(),
+		ruleGroupPathPrefix:    keypath.RuleGroupPathPrefix(),
+		etcdClient:             client,
+		ruleManager:            ruleManager,
+		checkerController:      checkerController,
+		ruleRevision:           initial.Header.Revision,
+		ruleRevisionContinuous: true,
+	}
+	nextRevision, err := rw.reconcileRuleSnapshot(ctx)
+	re.NoError(err)
+	re.Equal(updated.Header.Revision+1, nextRevision)
+	re.Nil(ruleManager.GetRule("g", "deleted"))
+	re.Equal(5, ruleManager.GetRule(placement.DefaultGroupID, placement.DefaultRuleID).Count)
+	re.Equal(unchangedVersion, ruleManager.GetRule("g", "unchanged").Version)
+	re.Zero(ruleManager.GetRuleGroup("g").Index)
+	re.Equal(updated.Header.Revision, rw.ruleRevision)
+	re.True(rw.ruleRevisionContinuous)
 }

--- a/pkg/mcs/scheduling/server/rule/watcher_test.go
+++ b/pkg/mcs/scheduling/server/rule/watcher_test.go
@@ -177,6 +177,30 @@ func TestScanRuleSnapshotKeyRanges(t *testing.T) {
 	re.Greater(callbackCount, 2)
 }
 
+func TestRuleWatcherAllowsEmptyInitialSnapshot(t *testing.T) {
+	re := require.New(t)
+	ctx, client, clean := prepare(t, false)
+	defer clean()
+
+	storage := endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil)
+	ruleManager := placement.NewRuleManager(ctx, storage, nil, nil)
+	re.NoError(ruleManager.Initialize(3, nil, "", true))
+	watchCtx, cancel := context.WithCancel(ctx)
+	rw := &Watcher{
+		ctx:                 watchCtx,
+		cancel:              cancel,
+		rulesPathPrefix:     keypath.RulesPathPrefix(),
+		ruleGroupPathPrefix: keypath.RuleGroupPathPrefix(),
+		etcdClient:          client,
+		ruleStorage:         storage,
+		ruleManager:         ruleManager,
+	}
+	defer rw.Close()
+
+	re.NoError(rw.initializeRuleWatcher())
+	re.Zero(ruleManager.GetRulesCount())
+}
+
 func TestReconcileRuleSnapshot(t *testing.T) {
 	re := require.New(t)
 	ctx, client, clean := prepare(t, false)

--- a/pkg/mcs/scheduling/server/rule/watcher_test.go
+++ b/pkg/mcs/scheduling/server/rule/watcher_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -476,7 +477,8 @@ func TestRuleWatcherReconcilesNewerSnapshotAfterFailedLiveRuleUpdate(t *testing.
 		ruleManager:         ruleManager,
 		checkerController:   checkerController,
 	}
-	defer rw.Close()
+	closeWatcher := sync.OnceFunc(rw.Close)
+	defer closeWatcher()
 	re.NoError(rw.initializeRuleWatcher())
 
 	logFile := testutil.InitTempFileLogger("info")
@@ -508,5 +510,6 @@ func TestRuleWatcherReconcilesNewerSnapshotAfterFailedLiveRuleUpdate(t *testing.
 		return rule != nil && rule.Count == 2 && len(rule.LabelConstraints) == 1 &&
 			len(rule.LabelConstraints[0].Values) == 1 && rule.LabelConstraints[0].Values[0] == "z1"
 	})
+	closeWatcher()
 	re.Equal(corrected.Header.Revision, rw.ruleRevision)
 }

--- a/pkg/mcs/scheduling/server/rule/watcher_test.go
+++ b/pkg/mcs/scheduling/server/rule/watcher_test.go
@@ -17,6 +17,7 @@ package rule
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -46,7 +47,9 @@ func TestMain(m *testing.M) {
 }
 
 const (
-	rulesNum = 16384
+	rulesNum                    = 16384
+	ruleSnapshotBenchmarkRules  = 1_000_000
+	ruleSnapshotBenchmarkTxnOps = 10_000
 )
 
 func TestLoadLargeRules(t *testing.T) {
@@ -90,9 +93,20 @@ func runWatcherLoadLabelRule(ctx context.Context, re *require.Assertions, client
 }
 
 func prepare(t require.TestingT, loadLabelRules bool) (context.Context, *clientv3.Client, func()) {
+	return prepareWithEtcdConfig(t, loadLabelRules, nil)
+}
+
+func prepareWithEtcdConfig(
+	t require.TestingT,
+	loadLabelRules bool,
+	configure func(*embed.Config),
+) (context.Context, *clientv3.Client, func()) {
 	re := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	cfg := etcdutil.NewTestEtcdConfig()
+	if configure != nil {
+		configure(cfg)
+	}
 	var err error
 	cfg.Dir, err = os.MkdirTemp("", "pd_tests")
 	re.NoError(err)
@@ -129,6 +143,84 @@ func prepare(t require.TestingT, loadLabelRules bool) (context.Context, *clientv
 		etcd.Close()
 		os.RemoveAll(cfg.Dir)
 	}
+}
+
+// BenchmarkRuleSnapshotKeyScan compares the current paginated scan with and
+// without local-rule-derived range bounds against a one-shot keys-only scan.
+// Use -benchtime=1x because preparing the one-million-rule snapshot is costly.
+func BenchmarkRuleSnapshotKeyScan(b *testing.B) {
+	ctx, client, clean := prepareWithEtcdConfig(b, false, func(cfg *embed.Config) {
+		cfg.MaxTxnOps = ruleSnapshotBenchmarkTxnOps
+	})
+	defer clean()
+
+	prefix := keypath.RulesPathPrefix()
+	rangeEnds := make([]string, 0, ruleSnapshotBenchmarkRules/int(ruleSnapshotLoadBatchSize))
+	ops := make([]clientv3.Op, 0, ruleSnapshotBenchmarkTxnOps)
+	var snapshotRevision int64
+	commit := func() {
+		resp, err := client.Txn(ctx).Then(ops...).Commit()
+		require.NoError(b, err)
+		snapshotRevision = resp.Header.Revision
+		ops = ops[:0]
+	}
+	for i := range ruleSnapshotBenchmarkRules {
+		key := fmt.Sprintf("%s67-%016x", prefix, i)
+		if i > 0 && i%int(ruleSnapshotLoadBatchSize) == 0 {
+			rangeEnds = append(rangeEnds, key)
+		}
+		ops = append(ops, clientv3.OpPut(key, "{}"))
+		if len(ops) == ruleSnapshotBenchmarkTxnOps {
+			commit()
+		}
+	}
+	if len(ops) > 0 {
+		commit()
+	}
+
+	rw := &Watcher{etcdClient: client}
+	runPaged := func(b *testing.B, rangeEnds []string) {
+		b.ReportAllocs()
+		var totalRPCs int
+		for range b.N {
+			scanned, rpcs := 0, 0
+			revision, err := rw.scanRuleSnapshotKeys(
+				ctx, prefix, rangeEnds, snapshotRevision, ruleSnapshotLoadBatchSize,
+				func(page []*mvccpb.KeyValue, _ int64) error {
+					scanned += len(page)
+					rpcs++
+					return nil
+				})
+			require.NoError(b, err)
+			require.Equal(b, snapshotRevision, revision)
+			require.Equal(b, ruleSnapshotBenchmarkRules, scanned)
+			totalRPCs += rpcs
+		}
+		b.ReportMetric(float64(totalRPCs)/float64(b.N), "rpcs/op")
+	}
+
+	b.Run("paged/empty-local", func(b *testing.B) {
+		runPaged(b, nil)
+	})
+	b.Run("paged/matching-local", func(b *testing.B) {
+		runPaged(b, rangeEnds)
+	})
+	b.Run("one-shot", func(b *testing.B) {
+		b.ReportAllocs()
+		for range b.N {
+			resp, err := etcdutil.EtcdKVGetWithContext(
+				ctx,
+				client,
+				prefix,
+				clientv3.WithRange(clientv3.GetPrefixRangeEnd(prefix)),
+				clientv3.WithKeysOnly(),
+				clientv3.WithRev(snapshotRevision),
+			)
+			require.NoError(b, err)
+			require.Len(b, resp.Kvs, ruleSnapshotBenchmarkRules)
+		}
+		b.ReportMetric(1, "rpcs/op")
+	})
 }
 
 func TestScanRuleSnapshotKeyRanges(t *testing.T) {

--- a/pkg/mcs/scheduling/server/rule/watcher_test.go
+++ b/pkg/mcs/scheduling/server/rule/watcher_test.go
@@ -434,7 +434,7 @@ func TestReconcileRuleSnapshot(t *testing.T) {
 	re.Nil(ruleManager.GetRule("payload", "rule"))
 }
 
-func TestRuleWatcherReplaysFailedLiveRuleUpdate(t *testing.T) {
+func TestRuleWatcherReconcilesNewerSnapshotAfterFailedLiveRuleUpdate(t *testing.T) {
 	re := require.New(t)
 	ctx, client, clean := prepare(t, false)
 	defer clean()
@@ -481,11 +481,11 @@ func TestRuleWatcherReplaysFailedLiveRuleUpdate(t *testing.T) {
 
 	logFile := testutil.InitTempFileLogger("info")
 	defer os.RemoveAll(logFile)
-	updatedRule := ruleManager.GetRule("g", "r")
-	updatedRule.LabelConstraints[0].Values = []string{"z2"}
-	updatedValue, err := json.Marshal(updatedRule)
+	failedRule := ruleManager.GetRule("g", "r")
+	failedRule.LabelConstraints[0].Values = []string{"z2"}
+	failedValue, err := json.Marshal(failedRule)
 	re.NoError(err)
-	updated, err := client.Put(ctx, keypath.RuleKeyPath(updatedRule.StoreKey()), string(updatedValue))
+	_, err = client.Put(ctx, keypath.RuleKeyPath(failedRule.StoreKey()), string(failedValue))
 	re.NoError(err)
 
 	testutil.Eventually(re, func() bool {
@@ -496,11 +496,17 @@ func TestRuleWatcherReplaysFailedLiveRuleUpdate(t *testing.T) {
 	})
 	re.Equal([]string{"z1"}, ruleManager.GetRule("g", "r").LabelConstraints[0].Values)
 
-	cluster.SetStoreLabel(1, map[string]string{"zone": "z2"})
+	correctedRule := ruleManager.GetRule("g", "r")
+	correctedRule.Count = 2
+	correctedValue, err := json.Marshal(correctedRule)
+	re.NoError(err)
+	corrected, err := client.Put(ctx, keypath.RuleKeyPath(correctedRule.StoreKey()), string(correctedValue))
+	re.NoError(err)
+
 	testutil.Eventually(re, func() bool {
 		rule := ruleManager.GetRule("g", "r")
-		return rule != nil && len(rule.LabelConstraints) == 1 &&
-			len(rule.LabelConstraints[0].Values) == 1 && rule.LabelConstraints[0].Values[0] == "z2"
+		return rule != nil && rule.Count == 2 && len(rule.LabelConstraints) == 1 &&
+			len(rule.LabelConstraints[0].Values) == 1 && rule.LabelConstraints[0].Values[0] == "z1"
 	})
-	re.Equal(updated.Header.Revision, rw.ruleRevision)
+	re.Equal(corrected.Header.Revision, rw.ruleRevision)
 }

--- a/pkg/mcs/scheduling/server/rule/watcher_test.go
+++ b/pkg/mcs/scheduling/server/rule/watcher_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/api/v3/mvccpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/server/v3/embed"
 	"go.uber.org/goleak"
@@ -128,6 +129,52 @@ func prepare(t require.TestingT, loadLabelRules bool) (context.Context, *clientv
 		etcd.Close()
 		os.RemoveAll(cfg.Dir)
 	}
+}
+
+func TestScanRuleSnapshotKeyRanges(t *testing.T) {
+	re := require.New(t)
+	ctx, client, clean := prepare(t, false)
+	defer clean()
+
+	prefix := keypath.RulesPathPrefix()
+	keys := []string{
+		prefix + "a",
+		prefix + "aa",
+		prefix + "aaa",
+		prefix + "aaaa",
+		prefix + "c",
+	}
+	ops := make([]clientv3.Op, 0, len(keys))
+	for _, key := range keys {
+		ops = append(ops, clientv3.OpPut(key, "value"))
+	}
+	resp, err := client.Txn(ctx).Then(ops...).Commit()
+	re.NoError(err)
+
+	rw := &Watcher{etcdClient: client}
+	var loaded []string
+	callbackCount := 0
+	revision, err := rw.scanRuleSnapshotKeys(ctx, prefix, []string{prefix + "b"}, 0, 2,
+		func(page []*mvccpb.KeyValue, _ int64) error {
+			for _, item := range page {
+				loaded = append(loaded, string(item.Key))
+			}
+			if callbackCount == 0 {
+				_, err := client.Txn(ctx).Then(
+					clientv3.OpDelete(prefix+"c"),
+					clientv3.OpPut(prefix+"d", "new"),
+				).Commit()
+				if err != nil {
+					return err
+				}
+			}
+			callbackCount++
+			return nil
+		})
+	re.NoError(err)
+	re.Equal(resp.Header.Revision, revision)
+	re.Equal(keys, loaded)
+	re.Greater(callbackCount, 2)
 }
 
 func TestReconcileRuleSnapshot(t *testing.T) {

--- a/pkg/mcs/scheduling/server/rule/watcher_test.go
+++ b/pkg/mcs/scheduling/server/rule/watcher_test.go
@@ -30,6 +30,8 @@ import (
 	"go.etcd.io/etcd/server/v3/embed"
 	"go.uber.org/goleak"
 
+	"github.com/pingcap/failpoint"
+
 	"github.com/tikv/pd/pkg/keyspace"
 	"github.com/tikv/pd/pkg/mock/mockcluster"
 	"github.com/tikv/pd/pkg/mock/mockconfig"
@@ -303,6 +305,47 @@ func TestRuleWatcherAllowsEmptyInitialSnapshot(t *testing.T) {
 
 	re.NoError(rw.initializeRuleWatcher())
 	re.Zero(ruleManager.GetRulesCount())
+}
+
+func TestRuleWatcherReconcilesInitialLoadRetry(t *testing.T) {
+	re := require.New(t)
+	ctx, client, clean := prepare(t, false)
+	defer clean()
+
+	fixture := newRuleWatcherTestFixture(t, ctx)
+	staleRule := &placement.Rule{GroupID: "g", ID: "stale", Role: placement.Learner, Count: 1}
+	re.NoError(fixture.ruleManager.SetRule(staleRule))
+	defaultRule := fixture.ruleManager.GetRule(placement.DefaultGroupID, placement.DefaultRuleID)
+	defaultValue, err := json.Marshal(defaultRule)
+	re.NoError(err)
+	_, err = client.Put(ctx, keypath.RuleKeyPath(defaultRule.StoreKey()), string(defaultValue))
+	re.NoError(err)
+	snapshot, err := client.Get(ctx, keypath.RuleCommonPathPrefix(), clientv3.WithPrefix())
+	re.NoError(err)
+
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/utils/etcdutil/loadTemporaryFail", "return(1)"))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/utils/etcdutil/loadTemporaryFail"))
+	}()
+
+	watchCtx, cancel := context.WithCancel(ctx)
+	rw := &Watcher{
+		ctx:                 watchCtx,
+		cancel:              cancel,
+		rulesPathPrefix:     keypath.RulesPathPrefix(),
+		ruleGroupPathPrefix: keypath.RuleGroupPathPrefix(),
+		etcdClient:          client,
+		ruleStorage:         fixture.storage,
+		ruleManager:         fixture.ruleManager,
+		checkerController:   fixture.checkerController,
+	}
+	closeWatcher := sync.OnceFunc(rw.Close)
+	defer closeWatcher()
+	re.NoError(rw.initializeRuleWatcher())
+	closeWatcher()
+
+	re.Nil(fixture.ruleManager.GetRule(staleRule.GroupID, staleRule.ID))
+	re.Equal(snapshot.Header.Revision, rw.ruleRevision)
 }
 
 type ruleWatcherTestFixture struct {

--- a/pkg/mcs/scheduling/server/rule/watcher_test.go
+++ b/pkg/mcs/scheduling/server/rule/watcher_test.go
@@ -188,9 +188,9 @@ func BenchmarkRuleSnapshotKeyScan(b *testing.B) {
 			scanned := 0
 			revision, err := rw.scanRuleSnapshotKeys(
 				ctx, prefix, rangeEnds, snapshotRevision,
-				ruleSnapshotScanBatchSize, int(ruleSnapshotLoadBatchSize),
-				func(page []*mvccpb.KeyValue, _ int64) error {
-					scanned += len(page)
+				ruleSnapshotScanBatchSize, int(ruleSnapshotProcessBatchSize),
+				func(batch []*mvccpb.KeyValue, _ int64) error {
+					scanned += len(batch)
 					return nil
 				})
 			require.NoError(b, err)
@@ -224,7 +224,7 @@ func BenchmarkRuleSnapshotKeyScan(b *testing.B) {
 
 func TestAdjustRuleSnapshotScanBatchSize(t *testing.T) {
 	re := require.New(t)
-	minimum := ruleSnapshotLoadBatchSize
+	minimum := ruleSnapshotProcessBatchSize
 	re.Equal(int64(100000), adjustRuleSnapshotScanBatchSize(50000, minimum, 1024*1024))
 	re.Equal(int64(100000), adjustRuleSnapshotScanBatchSize(100000, minimum, 1024*1024))
 	re.Equal(int64(50000), adjustRuleSnapshotScanBatchSize(100000, minimum, 5*1024*1024))
@@ -258,9 +258,9 @@ func TestScanRuleSnapshotKeyRanges(t *testing.T) {
 	var loaded []string
 	callbackCount := 0
 	revision, err := rw.scanRuleSnapshotKeys(ctx, prefix, []string{prefix + "b"}, 0, 4, 2,
-		func(page []*mvccpb.KeyValue, _ int64) error {
-			re.LessOrEqual(len(page), 2)
-			for _, item := range page {
+		func(batch []*mvccpb.KeyValue, _ int64) error {
+			re.LessOrEqual(len(batch), 2)
+			for _, item := range batch {
 				loaded = append(loaded, string(item.Key))
 			}
 			if callbackCount == 0 {
@@ -305,17 +305,38 @@ func TestRuleWatcherAllowsEmptyInitialSnapshot(t *testing.T) {
 	re.Zero(ruleManager.GetRulesCount())
 }
 
-func TestReconcileRuleSnapshot(t *testing.T) {
-	re := require.New(t)
-	ctx, client, clean := prepare(t, false)
-	defer clean()
+type ruleWatcherTestFixture struct {
+	storage           *endpoint.StorageEndpoint
+	cluster           *mockcluster.Cluster
+	ruleManager       *placement.RuleManager
+	checkerController *checker.Controller
+}
 
+func newRuleWatcherTestFixture(t *testing.T, ctx context.Context) *ruleWatcherTestFixture {
+	re := require.New(t)
 	storage := endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil)
 	conf := mockconfig.NewTestOptions()
 	cluster := mockcluster.NewCluster(ctx, conf)
 	cluster.AddLabelsStore(1, 0, map[string]string{"zone": "z1"})
 	ruleManager := placement.NewRuleManager(ctx, storage, cluster, conf)
 	re.NoError(ruleManager.Initialize(3, nil, "", false))
+	cluster.RuleManager = ruleManager
+	opController := operator.NewController(ctx, cluster.GetBasicCluster(), cluster.GetSharedConfig(), nil)
+	return &ruleWatcherTestFixture{
+		storage:           storage,
+		cluster:           cluster,
+		ruleManager:       ruleManager,
+		checkerController: checker.NewController(ctx, cluster, cluster.GetCheckerConfig(), opController),
+	}
+}
+
+func TestReconcileRuleSnapshot(t *testing.T) {
+	re := require.New(t)
+	ctx, client, clean := prepare(t, false)
+	defer clean()
+
+	fixture := newRuleWatcherTestFixture(t, ctx)
+	ruleManager := fixture.ruleManager
 	re.NoError(ruleManager.SetRuleGroup(&placement.RuleGroup{ID: "g", Index: 1}))
 	re.NoError(ruleManager.SetRules([]*placement.Rule{
 		{GroupID: "g", ID: "deleted", Role: placement.Learner, Count: 1},
@@ -326,10 +347,6 @@ func TestReconcileRuleSnapshot(t *testing.T) {
 			},
 		},
 	}))
-
-	cluster.RuleManager = ruleManager
-	opController := operator.NewController(ctx, cluster.GetBasicCluster(), cluster.GetSharedConfig(), nil)
-	checkerController := checker.NewController(ctx, cluster, cluster.GetCheckerConfig(), opController)
 
 	ops := make([]clientv3.Op, 0, ruleManager.GetRulesCount()+1)
 	for _, rule := range ruleManager.GetAllRules() {
@@ -367,7 +384,7 @@ func TestReconcileRuleSnapshot(t *testing.T) {
 		ruleGroupPathPrefix: keypath.RuleGroupPathPrefix(),
 		etcdClient:          client,
 		ruleManager:         ruleManager,
-		checkerController:   checkerController,
+		checkerController:   fixture.checkerController,
 		ruleRevision:        initial.Header.Revision,
 	}
 	nextRevision, err := rw.reconcileRuleSnapshot(ctx)
@@ -404,7 +421,7 @@ func TestReconcileRuleSnapshot(t *testing.T) {
 	re.Equal(groupsDeleted.Header.Revision, rw.ruleRevision)
 	re.Equal([]string{"z1"}, ruleManager.GetRule("g", "unchanged").LabelConstraints[0].Values)
 
-	cluster.SetStoreLabel(1, map[string]string{"zone": "z2"})
+	fixture.cluster.SetStoreLabel(1, map[string]string{"zone": "z2"})
 	nextRevision, err = rw.reconcileRuleSnapshot(ctx)
 	re.NoError(err)
 	re.Equal(updatedRuleResp.Header.Revision+1, nextRevision)
@@ -440,12 +457,8 @@ func TestRuleWatcherReconcilesNewerSnapshotAfterFailedLiveRuleUpdate(t *testing.
 	ctx, client, clean := prepare(t, false)
 	defer clean()
 
-	storage := endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil)
-	conf := mockconfig.NewTestOptions()
-	cluster := mockcluster.NewCluster(ctx, conf)
-	cluster.AddLabelsStore(1, 0, map[string]string{"zone": "z1"})
-	ruleManager := placement.NewRuleManager(ctx, storage, cluster, conf)
-	re.NoError(ruleManager.Initialize(3, nil, "", false))
+	fixture := newRuleWatcherTestFixture(t, ctx)
+	ruleManager := fixture.ruleManager
 	re.NoError(ruleManager.SetRule(&placement.Rule{
 		GroupID: "g",
 		ID:      "r",
@@ -455,10 +468,6 @@ func TestRuleWatcherReconcilesNewerSnapshotAfterFailedLiveRuleUpdate(t *testing.
 			{Key: "zone", Op: placement.In, Values: []string{"z1"}},
 		},
 	}))
-	cluster.RuleManager = ruleManager
-
-	opController := operator.NewController(ctx, cluster.GetBasicCluster(), cluster.GetSharedConfig(), nil)
-	checkerController := checker.NewController(ctx, cluster, cluster.GetCheckerConfig(), opController)
 	for _, rule := range ruleManager.GetAllRules() {
 		value, err := json.Marshal(rule)
 		re.NoError(err)
@@ -473,9 +482,9 @@ func TestRuleWatcherReconcilesNewerSnapshotAfterFailedLiveRuleUpdate(t *testing.
 		rulesPathPrefix:     keypath.RulesPathPrefix(),
 		ruleGroupPathPrefix: keypath.RuleGroupPathPrefix(),
 		etcdClient:          client,
-		ruleStorage:         storage,
+		ruleStorage:         fixture.storage,
 		ruleManager:         ruleManager,
-		checkerController:   checkerController,
+		checkerController:   fixture.checkerController,
 	}
 	closeWatcher := sync.OnceFunc(rw.Close)
 	defer closeWatcher()

--- a/pkg/schedule/placement/rule_manager.go
+++ b/pkg/schedule/placement/rule_manager.go
@@ -375,6 +375,30 @@ func (m *RuleManager) GetGroupsCount() int {
 	return len(m.ruleConfig.groups)
 }
 
+// GetRuleConfigForReconcile returns storage-key-ordered references to the
+// current rules and explicitly configured groups. Callers must not mutate them.
+func (m *RuleManager) GetRuleConfigForReconcile() ([]*Rule, []*RuleGroup) {
+	m.RLock()
+	rules := make([]*Rule, 0, len(m.ruleConfig.rules))
+	for _, rule := range m.ruleConfig.rules {
+		rules = append(rules, rule)
+	}
+	groups := make([]*RuleGroup, 0, len(m.ruleConfig.groups))
+	for _, group := range m.ruleConfig.groups {
+		if !group.isDefault() {
+			groups = append(groups, group)
+		}
+	}
+	m.RUnlock()
+
+	sort.Slice(rules, func(i, j int) bool {
+		return rules[i].GroupID < rules[j].GroupID ||
+			(rules[i].GroupID == rules[j].GroupID && rules[i].ID < rules[j].ID)
+	})
+	sort.Slice(groups, func(i, j int) bool { return groups[i].ID < groups[j].ID })
+	return rules, groups
+}
+
 // GetRulesByGroup returns sorted rules of a group.
 func (m *RuleManager) GetRulesByGroup(group string) []*Rule {
 	m.RLock()

--- a/pkg/utils/etcdutil/etcdutil.go
+++ b/pkg/utils/etcdutil/etcdutil.go
@@ -923,9 +923,10 @@ func (lw *LoopWatcher) reconcileLoadedKeys(snapshotKeys map[string]struct{}) ([]
 }
 
 func (lw *LoopWatcher) buildLoadingOpts(limit, revision int64) []clientv3.OpOption {
-	// MVCC ranges are ordered by key. An explicit sort would make etcd fetch and
-	// sort the whole range before applying the page limit.
-	var opts []clientv3.OpOption
+	// Sort by key to get the next key and we don't need to worry about the performance,
+	// Because the default sort is just SortByKey and SortAscend
+	opts := []clientv3.OpOption{
+		clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend)}
 	// In most cases, 'Get(foo, WithPrefix())' is equivalent to 'Get(foo, WithRange(GetPrefixRangeEnd(foo))'.
 	// However, when the startKey changes, the two are no longer equivalent.
 	// For example, the end key for 'WithRange(GetPrefixRangeEnd(foo))' is consistently 'fop'.

--- a/pkg/utils/etcdutil/etcdutil.go
+++ b/pkg/utils/etcdutil/etcdutil.go
@@ -422,6 +422,9 @@ type LoopWatcher struct {
 	// compactionReloadFn replaces the default full-value reload for consumers
 	// that need a specialized reconciliation strategy.
 	compactionReloadFn func(context.Context) (int64, error)
+	// retryOnPostEventError keeps the watch revision unchanged when postEventsFn
+	// fails, so the same event batch is replayed after the watch is recreated.
+	retryOnPostEventError bool
 	// updateClientCh is used to update the etcd client.
 	// It's only used for testing.
 	updateClientCh chan *clientv3.Client
@@ -694,9 +697,9 @@ func (lw *LoopWatcher) watch(ctx context.Context, revision int64) (nextRevision 
 			if err := lw.postEventsFn(wresp.Events); err != nil {
 				log.Error("run post event failed in watch loop", zap.Error(err),
 					zap.Int64("revision", revision), zap.String("name", lw.name), zap.String("key", lw.key))
-				if lw.compactionReloadFn != nil {
-					// Recreate the watch from the unadvanced revision. If it was
-					// compacted, the custom reload will reconcile the snapshot.
+				if lw.retryOnPostEventError {
+					// Recreate the watch from the unadvanced revision so the
+					// consumer can apply the same event batch again.
 					return revision, err
 				}
 			} else {
@@ -1020,6 +1023,14 @@ func (lw *LoopWatcher) SetReloadOnCompaction() {
 // It must be called before StartWatchLoop.
 func (lw *LoopWatcher) SetCompactionReloadFn(fn func(context.Context) (int64, error)) {
 	lw.compactionReloadFn = fn
+}
+
+// SetRetryOnPostEventError makes a failed postEventsFn call recreate the watch
+// from the unadvanced revision. It must be called before StartWatchLoop.
+// Callbacks must keep changes private until postEventsFn publishes them and
+// must tolerate replaying the same event batch.
+func (lw *LoopWatcher) SetRetryOnPostEventError() {
+	lw.retryOnPostEventError = true
 }
 
 // SetReconcileDeletedKeys enables deletion reconciliation and full snapshot

--- a/pkg/utils/etcdutil/etcdutil.go
+++ b/pkg/utils/etcdutil/etcdutil.go
@@ -694,6 +694,11 @@ func (lw *LoopWatcher) watch(ctx context.Context, revision int64) (nextRevision 
 			if err := lw.postEventsFn(wresp.Events); err != nil {
 				log.Error("run post event failed in watch loop", zap.Error(err),
 					zap.Int64("revision", revision), zap.String("name", lw.name), zap.String("key", lw.key))
+				if lw.compactionReloadFn != nil {
+					// Recreate the watch from the unadvanced revision. If it was
+					// compacted, the custom reload will reconcile the snapshot.
+					return revision, err
+				}
 			} else {
 				for _, event := range appliedEvents {
 					if event.Type == clientv3.EventTypeDelete {

--- a/pkg/utils/etcdutil/etcdutil.go
+++ b/pkg/utils/etcdutil/etcdutil.go
@@ -923,10 +923,9 @@ func (lw *LoopWatcher) reconcileLoadedKeys(snapshotKeys map[string]struct{}) ([]
 }
 
 func (lw *LoopWatcher) buildLoadingOpts(limit, revision int64) []clientv3.OpOption {
-	// Sort by key to get the next key and we don't need to worry about the performance,
-	// Because the default sort is just SortByKey and SortAscend
-	opts := []clientv3.OpOption{
-		clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend)}
+	// MVCC ranges are ordered by key. An explicit sort would make etcd fetch and
+	// sort the whole range before applying the page limit.
+	var opts []clientv3.OpOption
 	// In most cases, 'Get(foo, WithPrefix())' is equivalent to 'Get(foo, WithRange(GetPrefixRangeEnd(foo))'.
 	// However, when the startKey changes, the two are no longer equivalent.
 	// For example, the end key for 'WithRange(GetPrefixRangeEnd(foo))' is consistently 'fop'.

--- a/pkg/utils/etcdutil/etcdutil.go
+++ b/pkg/utils/etcdutil/etcdutil.go
@@ -423,10 +423,12 @@ type LoopWatcher struct {
 	// snapshot without changing their externally visible event contract.
 	reloadOnCompaction bool
 	// compactionReloadFn replaces the default full-value reload for consumers
-	// that need a specialized reconciliation strategy.
+	// that need a specialized reconciliation strategy. When live event retries
+	// are enabled, it also reconciles an event batch that failed to apply.
 	compactionReloadFn func(context.Context) (int64, error)
-	// retryOnPostEventError keeps the watch revision unchanged when postEventsFn
-	// fails, so the same event batch is replayed after the watch is recreated.
+	// retryOnPostEventError recovers from a failed postEventsFn without advancing
+	// past unapplied data. It uses compactionReloadFn when available; otherwise,
+	// it recreates the watch from the unchanged revision to replay the batch.
 	retryOnPostEventError bool
 	// updateClientCh is used to update the etcd client.
 	// It's only used for testing.
@@ -701,9 +703,19 @@ func (lw *LoopWatcher) watch(ctx context.Context, revision int64) (nextRevision 
 				log.Error("run post event failed in watch loop", zap.Error(err),
 					zap.Int64("revision", revision), zap.String("name", lw.name), zap.String("key", lw.key))
 				if lw.retryOnPostEventError {
-					// Recreate the watch from the unadvanced revision so the
-					// consumer can apply the same event batch again.
-					return revision, err
+					if lw.compactionReloadFn == nil {
+						// Recreate the watch from the unadvanced revision so the
+						// consumer can apply the same event batch again.
+						return revision, err
+					}
+					// An event that remains invalid can otherwise block all newer
+					// revisions. Reconcile the latest authoritative snapshot instead.
+					loadedRevision, shouldContinue := lw.reloadWithRetry(ctx, lw.compactionReloadFn)
+					if !shouldContinue {
+						return max(revision, loadedRevision), nil
+					}
+					revision = loadedRevision
+					continue
 				}
 				if lw.atomicLoadCallbacks {
 					log.Warn("watch callback batch failed, reload from etcd in watch loop",
@@ -1059,16 +1071,20 @@ func (lw *LoopWatcher) SetReloadOnCompaction() {
 
 // SetCompactionReloadFn sets a consumer-specific compaction reload and enables
 // it. The callback must return the next revision to watch after reconciliation.
-// It must be called before StartWatchLoop.
+// When SetRetryOnPostEventError is also enabled, the callback reconciles a
+// failed live event batch from the latest authoritative snapshot. It must be
+// called before StartWatchLoop.
 func (lw *LoopWatcher) SetCompactionReloadFn(fn func(context.Context) (int64, error)) {
 	lw.compactionReloadFn = fn
 }
 
-// SetRetryOnPostEventError makes a failed postEventsFn call recreate the watch
-// from the unadvanced revision. It must be called before StartWatchLoop.
+// SetRetryOnPostEventError prevents a failed postEventsFn call from advancing
+// past unapplied data. When a custom compaction reload is configured, it
+// reconciles the latest authoritative snapshot; otherwise, it recreates the
+// watch from the unadvanced revision. It must be called before StartWatchLoop.
 // Callbacks must keep changes private until postEventsFn publishes them and
-// must tolerate replaying the same event batch. This behavior takes precedence
-// over the full reload enabled by SetAtomicLoadCallbacks.
+// tolerate replay. This behavior takes precedence over the full reload enabled
+// by SetAtomicLoadCallbacks.
 func (lw *LoopWatcher) SetRetryOnPostEventError() {
 	lw.retryOnPostEventError = true
 }

--- a/pkg/utils/etcdutil/etcdutil.go
+++ b/pkg/utils/etcdutil/etcdutil.go
@@ -419,6 +419,9 @@ type LoopWatcher struct {
 	// reloadOnCompaction is enabled by consumers that can reconcile a full
 	// snapshot without changing their externally visible event contract.
 	reloadOnCompaction bool
+	// compactionReloadFn replaces the default full-value reload for consumers
+	// that need a specialized reconciliation strategy.
+	compactionReloadFn func(context.Context) (int64, error)
 	// updateClientCh is used to update the etcd client.
 	// It's only used for testing.
 	updateClientCh chan *clientv3.Client
@@ -628,7 +631,7 @@ func (lw *LoopWatcher) watch(ctx context.Context, revision int64) (nextRevision 
 			})
 			lastReceivedResponseTime = time.Now()
 			if wresp.CompactRevision != 0 {
-				if !lw.reloadOnCompaction {
+				if !lw.reloadOnCompaction && lw.compactionReloadFn == nil {
 					log.Warn("required revision has been compacted, use the compact revision in watch loop",
 						zap.Int64("required-revision", revision), zap.Int64("compact-revision", wresp.CompactRevision),
 						zap.String("name", lw.name), zap.String("key", lw.key))
@@ -715,7 +718,11 @@ func (lw *LoopWatcher) watch(ctx context.Context, revision int64) (nextRevision 
 func (lw *LoopWatcher) reloadAfterCompaction(ctx context.Context) (int64, bool) {
 	retryInterval := lw.watchChangeRetryInterval
 	for {
-		loadedRevision, err := lw.load(ctx)
+		loadFn := lw.load
+		if lw.compactionReloadFn != nil {
+			loadFn = lw.compactionReloadFn
+		}
+		loadedRevision, err := loadFn(ctx)
 		if err == nil {
 			return loadedRevision, ctx.Err() == nil
 		}
@@ -1001,6 +1008,13 @@ func (lw *LoopWatcher) SetInitialLoadSuccessFn(fn func()) {
 // keep failed loads private.
 func (lw *LoopWatcher) SetReloadOnCompaction() {
 	lw.reloadOnCompaction = true
+}
+
+// SetCompactionReloadFn sets a consumer-specific compaction reload and enables
+// it. The callback must return the next revision to watch after reconciliation.
+// It must be called before StartWatchLoop.
+func (lw *LoopWatcher) SetCompactionReloadFn(fn func(context.Context) (int64, error)) {
+	lw.compactionReloadFn = fn
 }
 
 // SetReconcileDeletedKeys enables deletion reconciliation and full snapshot

--- a/pkg/utils/etcdutil/etcdutil.go
+++ b/pkg/utils/etcdutil/etcdutil.go
@@ -702,6 +702,7 @@ func (lw *LoopWatcher) watch(ctx context.Context, revision int64) (nextRevision 
 			if err := lw.postEventsFn(wresp.Events); err != nil {
 				log.Error("run post event failed in watch loop", zap.Error(err),
 					zap.Int64("revision", revision), zap.String("name", lw.name), zap.String("key", lw.key))
+				var reloadFn func(context.Context) (int64, error)
 				if lw.retryOnPostEventError {
 					if lw.compactionReloadFn == nil {
 						// Recreate the watch from the unadvanced revision so the
@@ -710,18 +711,15 @@ func (lw *LoopWatcher) watch(ctx context.Context, revision int64) (nextRevision 
 					}
 					// An event that remains invalid can otherwise block all newer
 					// revisions. Reconcile the latest authoritative snapshot instead.
-					loadedRevision, shouldContinue := lw.reloadWithRetry(ctx, lw.compactionReloadFn)
-					if !shouldContinue {
-						return max(revision, loadedRevision), nil
-					}
-					revision = loadedRevision
-					continue
-				}
-				if lw.atomicLoadCallbacks {
+					reloadFn = lw.compactionReloadFn
+				} else if lw.atomicLoadCallbacks {
 					log.Warn("watch callback batch failed, reload from etcd in watch loop",
 						zap.Int64("revision", revision), zap.String("name", lw.name),
 						zap.String("key", lw.key), zap.Error(err))
-					loadedRevision, shouldContinue := lw.reloadWithRetry(ctx, lw.load)
+					reloadFn = lw.load
+				}
+				if reloadFn != nil {
+					loadedRevision, shouldContinue := lw.reloadWithRetry(ctx, reloadFn)
 					if !shouldContinue {
 						return max(revision, loadedRevision), nil
 					}
@@ -744,7 +742,7 @@ func (lw *LoopWatcher) watch(ctx context.Context, revision int64) (nextRevision 
 }
 
 // reloadAfterCompaction uses the consumer-specific compaction reconciliation
-// when configured. Other reloads always use the watcher's regular full load.
+// when configured and the watcher's regular full load otherwise.
 func (lw *LoopWatcher) reloadAfterCompaction(ctx context.Context) (int64, bool) {
 	loadFn := lw.load
 	if lw.compactionReloadFn != nil {

--- a/pkg/utils/etcdutil/etcdutil.go
+++ b/pkg/utils/etcdutil/etcdutil.go
@@ -403,6 +403,10 @@ type LoopWatcher struct {
 	preEventsFn func([]*clientv3.Event) error
 	// initialLoadSuccessFn is called after the initial load succeeds and before watching starts.
 	initialLoadSuccessFn func()
+	// initialLoadRetryFn replaces the regular full load after the first initial
+	// load attempt fails. It lets consumers reconcile partially published state
+	// without changing the first-load fast path.
+	initialLoadRetryFn func(context.Context) (int64, error)
 	// forceLoadMu is used to ensure two force loads have minimal interval.
 	forceLoadMu syncutil.RWMutex
 	// lastTimeForceLoad is used to record the last time force loading data from etcd.
@@ -526,7 +530,11 @@ func (lw *LoopWatcher) initFromEtcd(ctx context.Context) int64 {
 				failpoint.Continue()
 			}
 		})
-		watchStartRevision, err = lw.load(ctx)
+		loadFn := lw.load
+		if i > 0 && lw.initialLoadRetryFn != nil {
+			loadFn = lw.initialLoadRetryFn
+		}
+		watchStartRevision, err = loadFn(ctx)
 		if err == nil && ctx.Err() == nil {
 			if lw.initialLoadSuccessFn != nil {
 				lw.initialLoadSuccessFn()
@@ -1055,6 +1063,14 @@ func (lw *LoopWatcher) SetAtomicLoadCallbacks() {
 // It must be called before StartWatchLoop.
 func (lw *LoopWatcher) SetInitialLoadSuccessFn(fn func()) {
 	lw.initialLoadSuccessFn = fn
+}
+
+// SetInitialLoadRetryFn sets a consumer-specific reconciliation callback for
+// retries after the first initial load attempt fails. The callback must return
+// the next revision to watch after reconciliation. It must be called before
+// StartWatchLoop.
+func (lw *LoopWatcher) SetInitialLoadRetryFn(fn func(context.Context) (int64, error)) {
+	lw.initialLoadRetryFn = fn
 }
 
 // SetReloadOnCompaction enables a full, revision-consistent snapshot reload

--- a/pkg/utils/etcdutil/etcdutil_test.go
+++ b/pkg/utils/etcdutil/etcdutil_test.go
@@ -1276,6 +1276,29 @@ func (suite *loopWatcherTestSuite) TestWatcherReloadsAfterCompactionWhenEnabled(
 	re.GreaterOrEqual(result.revision, updatedResp.Header.Revision+1)
 }
 
+func (suite *loopWatcherTestSuite) TestWatcherUsesCustomCompactionReload() {
+	re := suite.Require()
+	watcher := NewLoopWatcher(
+		suite.ctx,
+		&suite.wg,
+		suite.client,
+		"test",
+		"TestWatcherUsesCustomCompactionReload",
+		func([]*clientv3.Event) error { return nil },
+		func(*mvccpb.KeyValue) error { return nil },
+		func(*mvccpb.KeyValue) error { return nil },
+		func([]*clientv3.Event) error { return nil },
+		false, /* withPrefix */
+	)
+	watcher.SetCompactionReloadFn(func(context.Context) (int64, error) {
+		return 42, nil
+	})
+
+	revision, shouldContinue := watcher.reloadAfterCompaction(suite.ctx)
+	re.True(shouldContinue)
+	re.Equal(int64(42), revision)
+}
+
 func (suite *loopWatcherTestSuite) TestWatcherStopsCompactionReloadWhenContextCanceled() {
 	re := suite.Require()
 	const key = "TestWatcherStopsCompactionReloadWhenContextCanceled"

--- a/pkg/utils/etcdutil/etcdutil_test.go
+++ b/pkg/utils/etcdutil/etcdutil_test.go
@@ -1276,6 +1276,72 @@ func (suite *loopWatcherTestSuite) TestWatcherReloadsAfterCompactionWhenEnabled(
 	re.GreaterOrEqual(result.revision, updatedResp.Header.Revision+1)
 }
 
+func (suite *loopWatcherTestSuite) TestWatcherUsesCustomCompactionReload() {
+	re := suite.Require()
+	ctx, cancel := context.WithCancel(suite.ctx)
+	defer cancel()
+
+	const key = "TestWatcherUsesCustomCompactionReload"
+	initialResp, err := suite.client.Put(ctx, key, "before-compaction")
+	re.NoError(err)
+	updatedResp, err := suite.client.Put(ctx, key, "after-compaction")
+	re.NoError(err)
+	_, err = suite.etcd.Server.Compact(ctx, &etcdserverpb.CompactionRequest{Revision: updatedResp.Header.Revision})
+	re.NoError(err)
+
+	reloadValues := make(chan string, 1)
+	liveValues := make(chan string, 1)
+	watcher := NewLoopWatcher(
+		ctx,
+		&sync.WaitGroup{},
+		suite.client,
+		"test",
+		key,
+		func([]*clientv3.Event) error { return nil },
+		func(kv *mvccpb.KeyValue) error {
+			liveValues <- string(kv.Value)
+			cancel()
+			return nil
+		},
+		func(*mvccpb.KeyValue) error { return nil },
+		func([]*clientv3.Event) error { return nil },
+		false, /* withPrefix */
+	)
+	watcher.SetCompactionReloadFn(func(ctx context.Context) (int64, error) {
+		resp, err := EtcdKVGetWithContext(ctx, suite.client, key)
+		if err != nil {
+			return 0, err
+		}
+		if len(resp.Kvs) != 1 {
+			return 0, fmt.Errorf("expected one key, got %d", len(resp.Kvs))
+		}
+		reloadValues <- string(resp.Kvs[0].Value)
+		return resp.Header.Revision + 1, nil
+	})
+
+	watchDone := make(chan error, 1)
+	go func() {
+		_, watchErr := watcher.watch(ctx, initialResp.Header.Revision)
+		watchDone <- watchErr
+	}()
+
+	select {
+	case value := <-reloadValues:
+		re.Equal("after-compaction", value)
+	case <-time.After(3 * time.Second):
+		suite.T().Fatal("custom compaction reload was not called")
+	}
+	_, err = suite.client.Put(suite.ctx, key, "after-reload-live")
+	re.NoError(err)
+	select {
+	case value := <-liveValues:
+		re.Equal("after-reload-live", value)
+	case <-time.After(3 * time.Second):
+		suite.T().Fatal("watcher did not resume after custom compaction reload")
+	}
+	re.NoError(<-watchDone)
+}
+
 func (suite *loopWatcherTestSuite) TestWatcherDoesNotAdvanceAfterLivePostCallbackFailure() {
 	re := suite.Require()
 	ctx, cancel := context.WithTimeout(suite.ctx, 3*time.Second)
@@ -1298,12 +1364,7 @@ func (suite *loopWatcherTestSuite) TestWatcherDoesNotAdvanceAfterLivePostCallbac
 		func([]*clientv3.Event) error { return postErr },
 		false, /* withPrefix */
 	)
-	watcher.SetCompactionReloadFn(func(context.Context) (int64, error) {
-		return 42, nil
-	})
-	revision, shouldContinue := watcher.reloadAfterCompaction(ctx)
-	re.True(shouldContinue)
-	re.Equal(int64(42), revision)
+	watcher.SetRetryOnPostEventError()
 
 	type watchResult struct {
 		revision int64
@@ -1324,6 +1385,139 @@ func (suite *loopWatcherTestSuite) TestWatcherDoesNotAdvanceAfterLivePostCallbac
 	case <-time.After(3 * time.Second):
 		suite.T().Fatal("watcher advanced after the failed live event batch")
 	}
+}
+
+func (suite *loopWatcherTestSuite) TestCustomCompactionReloadDoesNotEnableLivePostRetry() {
+	re := suite.Require()
+	ctx, cancel := context.WithCancel(suite.ctx)
+	defer cancel()
+
+	const key = "TestCustomCompactionReloadDoesNotEnableLivePostRetry"
+	initialResp, err := suite.client.Put(ctx, key, "initial")
+	re.NoError(err)
+
+	postErr := errors.New("post callback failed")
+	watcher := NewLoopWatcher(
+		ctx,
+		&sync.WaitGroup{},
+		suite.client,
+		"test",
+		key,
+		func([]*clientv3.Event) error { return nil },
+		func(*mvccpb.KeyValue) error { return nil },
+		func(*mvccpb.KeyValue) error { return nil },
+		func([]*clientv3.Event) error {
+			cancel()
+			return postErr
+		},
+		false, /* withPrefix */
+	)
+	watcher.SetCompactionReloadFn(func(context.Context) (int64, error) {
+		return 0, errors.New("unexpected compaction reload")
+	})
+
+	type watchResult struct {
+		revision int64
+		err      error
+	}
+	watchDone := make(chan watchResult, 1)
+	go func() {
+		revision, watchErr := watcher.watch(ctx, initialResp.Header.Revision+1)
+		watchDone <- watchResult{revision: revision, err: watchErr}
+	}()
+	updatedResp, err := suite.client.Put(suite.ctx, key, "updated")
+	re.NoError(err)
+
+	select {
+	case result := <-watchDone:
+		re.NoError(result.err)
+		re.Equal(updatedResp.Header.Revision+1, result.revision)
+	case <-time.After(3 * time.Second):
+		suite.T().Fatal("watcher did not preserve legacy post callback behavior")
+	}
+}
+
+func (suite *loopWatcherTestSuite) TestWatcherRetriesLivePostCallbackFailure() {
+	re := suite.Require()
+	ctx, cancel := context.WithCancel(suite.ctx)
+	var watcherWG sync.WaitGroup
+	defer func() {
+		cancel()
+		watcherWG.Wait()
+	}()
+
+	const key = "TestWatcherRetriesLivePostCallbackFailure"
+	_, err := suite.client.Put(ctx, key, "initial")
+	re.NoError(err)
+
+	state := struct {
+		sync.Mutex
+		committed    string
+		pending      string
+		failNext     bool
+		failureCount int
+	}{}
+	replayed := make(chan struct{}, 1)
+	postErr := errors.New("post callback failed")
+	watcher := NewLoopWatcher(
+		ctx,
+		&watcherWG,
+		suite.client,
+		"test",
+		key,
+		func([]*clientv3.Event) error {
+			state.Lock()
+			defer state.Unlock()
+			state.pending = state.committed
+			return nil
+		},
+		func(kv *mvccpb.KeyValue) error {
+			state.Lock()
+			defer state.Unlock()
+			state.pending = string(kv.Value)
+			return nil
+		},
+		func(*mvccpb.KeyValue) error { return nil },
+		func(events []*clientv3.Event) error {
+			state.Lock()
+			defer state.Unlock()
+			if len(events) > 0 && state.failNext {
+				state.failNext = false
+				state.failureCount++
+				return postErr
+			}
+			state.committed = state.pending
+			if len(events) > 0 && state.committed == "updated" {
+				select {
+				case replayed <- struct{}{}:
+				default:
+				}
+			}
+			return nil
+		},
+		false, /* withPrefix */
+	)
+	watcher.SetRetryOnPostEventError()
+	watcher.watchChangeRetryInterval = 10 * time.Millisecond
+	watcher.StartWatchLoop()
+	re.NoError(watcher.WaitLoad())
+
+	state.Lock()
+	re.Equal("initial", state.committed)
+	state.failNext = true
+	state.Unlock()
+	_, err = suite.client.Put(ctx, key, "updated")
+	re.NoError(err)
+
+	select {
+	case <-replayed:
+	case <-time.After(3 * time.Second):
+		suite.T().Fatal("watcher did not replay the failed live event batch")
+	}
+	state.Lock()
+	defer state.Unlock()
+	re.Equal("updated", state.committed)
+	re.Equal(1, state.failureCount)
 }
 
 func (suite *loopWatcherTestSuite) TestWatcherStopsCompactionReloadWhenContextCanceled() {

--- a/pkg/utils/etcdutil/etcdutil_test.go
+++ b/pkg/utils/etcdutil/etcdutil_test.go
@@ -1276,27 +1276,54 @@ func (suite *loopWatcherTestSuite) TestWatcherReloadsAfterCompactionWhenEnabled(
 	re.GreaterOrEqual(result.revision, updatedResp.Header.Revision+1)
 }
 
-func (suite *loopWatcherTestSuite) TestWatcherUsesCustomCompactionReload() {
+func (suite *loopWatcherTestSuite) TestWatcherDoesNotAdvanceAfterLivePostCallbackFailure() {
 	re := suite.Require()
+	ctx, cancel := context.WithTimeout(suite.ctx, 3*time.Second)
+	defer cancel()
+
+	const key = "TestWatcherDoesNotAdvanceAfterLivePostCallbackFailure"
+	initialResp, err := suite.client.Put(ctx, key, "initial")
+	re.NoError(err)
+
+	postErr := errors.New("post callback failed")
 	watcher := NewLoopWatcher(
-		suite.ctx,
-		&suite.wg,
+		ctx,
+		&sync.WaitGroup{},
 		suite.client,
 		"test",
-		"TestWatcherUsesCustomCompactionReload",
+		key,
 		func([]*clientv3.Event) error { return nil },
 		func(*mvccpb.KeyValue) error { return nil },
 		func(*mvccpb.KeyValue) error { return nil },
-		func([]*clientv3.Event) error { return nil },
+		func([]*clientv3.Event) error { return postErr },
 		false, /* withPrefix */
 	)
 	watcher.SetCompactionReloadFn(func(context.Context) (int64, error) {
 		return 42, nil
 	})
-
-	revision, shouldContinue := watcher.reloadAfterCompaction(suite.ctx)
+	revision, shouldContinue := watcher.reloadAfterCompaction(ctx)
 	re.True(shouldContinue)
 	re.Equal(int64(42), revision)
+
+	type watchResult struct {
+		revision int64
+		err      error
+	}
+	watchDone := make(chan watchResult, 1)
+	go func() {
+		nextRevision, watchErr := watcher.watch(ctx, initialResp.Header.Revision+1)
+		watchDone <- watchResult{revision: nextRevision, err: watchErr}
+	}()
+	_, err = suite.client.Put(suite.ctx, key, "updated")
+	re.NoError(err)
+
+	select {
+	case result := <-watchDone:
+		re.ErrorIs(result.err, postErr)
+		re.Equal(initialResp.Header.Revision+1, result.revision)
+	case <-time.After(3 * time.Second):
+		suite.T().Fatal("watcher advanced after the failed live event batch")
+	}
 }
 
 func (suite *loopWatcherTestSuite) TestWatcherStopsCompactionReloadWhenContextCanceled() {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #11032

The scheduling service can retain stale placement rules or rule groups when its etcd watch revision is compacted and delete events are missed.

### What is changed and how does it work?

- Reload a revision-consistent placement-rule snapshot after watch compaction.
- Reconcile added, updated, and deleted rules and groups in one atomic patch.
- Scan keys-only metadata in bounded, adaptive etcd ranges and fetch values only for changed entries.
- Retry an incomplete snapshot without advancing the watch revision.
- Replay a failed live event batch from its unadvanced revision.
- Keep compaction reload and live-event replay as independent explicit options.

Normal successful watch processing does not scan etcd. This PR does not change the placement-rule storage format, write path, wire protocol, or configuration.

### Check List

Tests

- [x] Unit tests for pagination, reconciliation, retry, compaction recovery, and live-event replay.
- [x] Affected package tests and race tests.
- [x] `go vet` and golangci-lint.

### Release note

```release-note
Fix stale placement rules in the scheduling service after etcd watch compaction.
```
