### PR TITLE
pd-ctl: allow higher v1 store limits for NextGen

### DIFF
--- a/pkg/versioninfo/kerneltype/doc.go
+++ b/pkg/versioninfo/kerneltype/doc.go
@@ -34,3 +34,10 @@
 // for the data plane, typically using object storage solutions like Amazon S3 as
 // the single source of truth for data storage.
 package kerneltype
+
+const (
+	// Classic is the canonical name of the Classic kernel.
+	Classic = "Classic"
+	// NextGen is the canonical name of the Next Generation kernel.
+	NextGen = "Next Generation"
+)

--- a/pkg/versioninfo/kerneltype/doc_test.go
+++ b/pkg/versioninfo/kerneltype/doc_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 TiKV Project Authors.
+// Copyright 2026 TiKV Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,25 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !nextgen
-
 package kerneltype
 
 import (
-	"github.com/pingcap/failpoint"
+	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
-var (
-	// KernelType is the current kernel type, which is Classic in this case.
-	KernelType = Classic
-)
-
-// IsNextGen returns true if the current kernel type is NextGen.
-func IsNextGen() bool {
-	failpoint.Inject("mockNextGenBuildFlag", func(val failpoint.Value) {
-		if v, ok := val.(bool); ok {
-			failpoint.Return(v)
-		}
-	})
-	return false
+func TestKernelTypeWireNames(t *testing.T) {
+	require.Equal(t, "Classic", Classic)
+	require.Equal(t, "Next Generation", NextGen)
 }

--- a/pkg/versioninfo/kerneltype/doc_test.go
+++ b/pkg/versioninfo/kerneltype/doc_test.go
@@ -18,7 +18,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/tikv/pd/pkg/utils/testutil"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m, testutil.LeakOptions...)
+}
 
 func TestKernelTypeWireNames(t *testing.T) {
 	require.Equal(t, "Classic", Classic)

--- a/pkg/versioninfo/kerneltype/nextgen.go
+++ b/pkg/versioninfo/kerneltype/nextgen.go
@@ -22,7 +22,7 @@ import (
 
 var (
 	// KernelType is the current kernel type, which is Next Generation in this case.
-	KernelType = "Next Generation"
+	KernelType = NextGen
 )
 
 // IsNextGen returns true if the current kernel type is Next Generation.

--- a/tools/pd-ctl/pdctl/command/store_command.go
+++ b/tools/pd-ctl/pdctl/command/store_command.go
@@ -37,7 +37,13 @@ var (
 	storesLimitPrefix  = "pd/api/v1/stores/limit"
 	storePrefix        = "pd/api/v1/store/%v"
 	storeUpStatePrefix = "pd/api/v1/store/%v/state?state=Up"
-	maxStoreLimit      = float64(200)
+)
+
+const (
+	pdStatusPrefix       = "pd/api/v1/status"
+	classicMaxStoreLimit = float64(200)
+	nextGenMaxStoreLimit = float64(1000)
+	nextGenKernelType    = "Next Generation"
 )
 
 // NewStoreCommand return a stores subcommand of rootCmd
@@ -565,8 +571,7 @@ func storeLimitCommandFunc(cmd *cobra.Command, args []string) {
 		var prefix string
 		if args[0] == "all" {
 			prefix = storesLimitPrefix
-			if rate > maxStoreLimit {
-				cmd.Printf("rate should be less than %.1f for all\n", maxStoreLimit)
+			if !validateAllStoresLimitRate(cmd, rate) {
 				return
 			}
 		} else {
@@ -595,8 +600,7 @@ func storeLimitCommandFunc(cmd *cobra.Command, args []string) {
 				cmd.Println("rate should be a number that > 0.")
 				return
 			}
-			if rate > maxStoreLimit {
-				cmd.Printf("rate should be less than %.1f for all\n", maxStoreLimit)
+			if !validateAllStoresLimitRate(cmd, rate) {
 				return
 			}
 			postInput["rate"] = rate
@@ -608,6 +612,32 @@ func storeLimitCommandFunc(cmd *cobra.Command, args []string) {
 			postJSON(cmd, prefix, postInput)
 		}
 	}
+}
+
+func validateAllStoresLimitRate(cmd *cobra.Command, rate float64) bool {
+	maxStoreLimit := classicMaxStoreLimit
+	if rate > classicMaxStoreLimit {
+		resp, err := doRequest(cmd, pdStatusPrefix, http.MethodGet, http.Header{})
+		if err != nil {
+			cmd.Printf("Failed to get PD kernel type: %s\n", err)
+			return false
+		}
+		var status struct {
+			KernelType string `json:"kernel_type"`
+		}
+		if err := json.Unmarshal([]byte(resp), &status); err != nil {
+			cmd.Printf("Failed to parse PD kernel type: %s\n", err)
+			return false
+		}
+		if status.KernelType == nextGenKernelType {
+			maxStoreLimit = nextGenMaxStoreLimit
+		}
+	}
+	if rate > maxStoreLimit {
+		cmd.Printf("rate should be at most %.1f for all\n", maxStoreLimit)
+		return false
+	}
+	return true
 }
 
 func storeCheckCommandFunc(cmd *cobra.Command, args []string) {
@@ -681,6 +711,9 @@ func setAllLimitCommandFunc(cmd *cobra.Command, args []string) {
 	rate, err := strconv.ParseFloat(args[0], 64)
 	if err != nil || rate <= 0 {
 		cmd.Println("rate should be a number that > 0.")
+		return
+	}
+	if !validateAllStoresLimitRate(cmd, rate) {
 		return
 	}
 	prefix := storesLimitPrefix

--- a/tools/pd-ctl/pdctl/command/store_command.go
+++ b/tools/pd-ctl/pdctl/command/store_command.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/metapb"
 
 	"github.com/tikv/pd/pkg/response"
+	"github.com/tikv/pd/pkg/versioninfo/kerneltype"
 )
 
 var (
@@ -43,7 +44,6 @@ const (
 	pdStatusPrefix       = "pd/api/v1/status"
 	classicMaxStoreLimit = float64(200)
 	nextGenMaxStoreLimit = float64(1000)
-	nextGenKernelType    = "Next Generation"
 )
 
 // NewStoreCommand return a stores subcommand of rootCmd
@@ -629,7 +629,7 @@ func validateAllStoresLimitRate(cmd *cobra.Command, rate float64) bool {
 			cmd.Printf("Failed to parse PD kernel type: %s\n", err)
 			return false
 		}
-		if status.KernelType == nextGenKernelType {
+		if status.KernelType == kerneltype.NextGen {
 			maxStoreLimit = nextGenMaxStoreLimit
 		}
 	}

--- a/tools/pd-ctl/pdctl/command/store_command_test.go
+++ b/tools/pd-ctl/pdctl/command/store_command_test.go
@@ -24,18 +24,22 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
+
+	"github.com/tikv/pd/pkg/versioninfo/kerneltype"
 )
 
+type storeLimitTestCase struct {
+	name            string
+	kernelType      string
+	statusCode      int
+	args            []string
+	expectedOutput  string
+	expectedStatus  int
+	expectedUpdates int
+}
+
 func TestStoreLimitAllKernelAwareMaximum(t *testing.T) {
-	testCases := []struct {
-		name            string
-		kernelType      string
-		statusCode      int
-		args            []string
-		expectedOutput  string
-		expectedStatus  int
-		expectedUpdates int
-	}{
+	testCases := []storeLimitTestCase{
 		{
 			name:            "classic boundary does not query status",
 			args:            []string{"all", "200", "add-peer"},
@@ -43,28 +47,28 @@ func TestStoreLimitAllKernelAwareMaximum(t *testing.T) {
 		},
 		{
 			name:           "classic rejects above boundary",
-			kernelType:     "Classic",
+			kernelType:     kerneltype.Classic,
 			args:           []string{"all", "201", "add-peer"},
 			expectedOutput: "rate should be at most 200.0 for all",
 			expectedStatus: 1,
 		},
 		{
 			name:            "nextgen accepts boundary",
-			kernelType:      nextGenKernelType,
+			kernelType:      kerneltype.NextGen,
 			args:            []string{"all", "1000", "add-peer"},
 			expectedStatus:  1,
 			expectedUpdates: 1,
 		},
 		{
 			name:            "nextgen label filter accepts boundary",
-			kernelType:      nextGenKernelType,
+			kernelType:      kerneltype.NextGen,
 			args:            []string{"all", "engine", "tikv", "1000", "remove-peer"},
 			expectedStatus:  1,
 			expectedUpdates: 1,
 		},
 		{
 			name:           "nextgen rejects above boundary",
-			kernelType:     nextGenKernelType,
+			kernelType:     kerneltype.NextGen,
 			args:           []string{"all", "1001", "add-peer"},
 			expectedOutput: "rate should be at most 1000.0 for all",
 			expectedStatus: 1,
@@ -84,33 +88,11 @@ func TestStoreLimitAllKernelAwareMaximum(t *testing.T) {
 		},
 	}
 
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			server, statusRequests, updates := newStoreLimitTestServer(t, testCase.kernelType, testCase.statusCode)
-			defer server.Close()
-
-			cmd := NewStoreLimitCommand()
-			cmd.Flags().String("pd", server.URL, "")
-			cmd.SetArgs(testCase.args)
-			output := executeStoreLimitCommand(t, cmd)
-			require.Equal(t, testCase.expectedStatus, *statusRequests)
-			require.Equal(t, testCase.expectedUpdates, *updates)
-			if testCase.expectedOutput != "" {
-				require.Contains(t, output, testCase.expectedOutput)
-			}
-		})
-	}
+	runStoreLimitTestCases(t, NewStoreLimitCommand, testCases)
 }
 
 func TestDeprecatedStoreLimitAllKernelAwareMaximum(t *testing.T) {
-	testCases := []struct {
-		name            string
-		kernelType      string
-		args            []string
-		expectedOutput  string
-		expectedStatus  int
-		expectedUpdates int
-	}{
+	testCases := []storeLimitTestCase{
 		{
 			name:            "classic boundary",
 			args:            []string{"200", "add-peer"},
@@ -118,33 +100,38 @@ func TestDeprecatedStoreLimitAllKernelAwareMaximum(t *testing.T) {
 		},
 		{
 			name:           "classic rejects above boundary",
-			kernelType:     "Classic",
+			kernelType:     kerneltype.Classic,
 			args:           []string{"201", "add-peer"},
 			expectedOutput: "rate should be at most 200.0 for all",
 			expectedStatus: 1,
 		},
 		{
 			name:            "nextgen boundary",
-			kernelType:      nextGenKernelType,
+			kernelType:      kerneltype.NextGen,
 			args:            []string{"1000", "remove-peer"},
 			expectedStatus:  1,
 			expectedUpdates: 1,
 		},
 		{
 			name:           "nextgen rejects above boundary",
-			kernelType:     nextGenKernelType,
+			kernelType:     kerneltype.NextGen,
 			args:           []string{"1001", "remove-peer"},
 			expectedOutput: "rate should be at most 1000.0 for all",
 			expectedStatus: 1,
 		},
 	}
 
+	runStoreLimitTestCases(t, NewSetAllLimitCommand, testCases)
+}
+
+func runStoreLimitTestCases(t *testing.T, newCommand func() *cobra.Command, testCases []storeLimitTestCase) {
+	t.Helper()
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			server, statusRequests, updates := newStoreLimitTestServer(t, testCase.kernelType, 0)
+			server, statusRequests, updates := newStoreLimitTestServer(t, testCase.kernelType, testCase.statusCode)
 			defer server.Close()
 
-			cmd := NewSetAllLimitCommand()
+			cmd := newCommand()
 			cmd.Flags().String("pd", server.URL, "")
 			cmd.SetArgs(testCase.args)
 			output := executeStoreLimitCommand(t, cmd)

--- a/tools/pd-ctl/pdctl/command/store_command_test.go
+++ b/tools/pd-ctl/pdctl/command/store_command_test.go
@@ -1,0 +1,196 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStoreLimitAllKernelAwareMaximum(t *testing.T) {
+	testCases := []struct {
+		name            string
+		kernelType      string
+		statusCode      int
+		args            []string
+		expectedOutput  string
+		expectedStatus  int
+		expectedUpdates int
+	}{
+		{
+			name:            "classic boundary does not query status",
+			args:            []string{"all", "200", "add-peer"},
+			expectedUpdates: 1,
+		},
+		{
+			name:           "classic rejects above boundary",
+			kernelType:     "Classic",
+			args:           []string{"all", "201", "add-peer"},
+			expectedOutput: "rate should be at most 200.0 for all",
+			expectedStatus: 1,
+		},
+		{
+			name:            "nextgen accepts boundary",
+			kernelType:      nextGenKernelType,
+			args:            []string{"all", "1000", "add-peer"},
+			expectedStatus:  1,
+			expectedUpdates: 1,
+		},
+		{
+			name:            "nextgen label filter accepts boundary",
+			kernelType:      nextGenKernelType,
+			args:            []string{"all", "engine", "tikv", "1000", "remove-peer"},
+			expectedStatus:  1,
+			expectedUpdates: 1,
+		},
+		{
+			name:           "nextgen rejects above boundary",
+			kernelType:     nextGenKernelType,
+			args:           []string{"all", "1001", "add-peer"},
+			expectedOutput: "rate should be at most 1000.0 for all",
+			expectedStatus: 1,
+		},
+		{
+			name:           "missing kernel type falls back to classic",
+			args:           []string{"all", "201", "add-peer"},
+			expectedOutput: "rate should be at most 200.0 for all",
+			expectedStatus: 1,
+		},
+		{
+			name:           "status failure fails closed",
+			statusCode:     http.StatusInternalServerError,
+			args:           []string{"all", "201", "add-peer"},
+			expectedOutput: "Failed to get PD kernel type",
+			expectedStatus: 1,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			server, statusRequests, updates := newStoreLimitTestServer(t, testCase.kernelType, testCase.statusCode)
+			defer server.Close()
+
+			cmd := NewStoreLimitCommand()
+			cmd.Flags().String("pd", server.URL, "")
+			cmd.SetArgs(testCase.args)
+			output := executeStoreLimitCommand(t, cmd)
+			require.Equal(t, testCase.expectedStatus, *statusRequests)
+			require.Equal(t, testCase.expectedUpdates, *updates)
+			if testCase.expectedOutput != "" {
+				require.Contains(t, output, testCase.expectedOutput)
+			}
+		})
+	}
+}
+
+func TestDeprecatedStoreLimitAllKernelAwareMaximum(t *testing.T) {
+	testCases := []struct {
+		name            string
+		kernelType      string
+		args            []string
+		expectedOutput  string
+		expectedStatus  int
+		expectedUpdates int
+	}{
+		{
+			name:            "classic boundary",
+			args:            []string{"200", "add-peer"},
+			expectedUpdates: 1,
+		},
+		{
+			name:           "classic rejects above boundary",
+			kernelType:     "Classic",
+			args:           []string{"201", "add-peer"},
+			expectedOutput: "rate should be at most 200.0 for all",
+			expectedStatus: 1,
+		},
+		{
+			name:            "nextgen boundary",
+			kernelType:      nextGenKernelType,
+			args:            []string{"1000", "remove-peer"},
+			expectedStatus:  1,
+			expectedUpdates: 1,
+		},
+		{
+			name:           "nextgen rejects above boundary",
+			kernelType:     nextGenKernelType,
+			args:           []string{"1001", "remove-peer"},
+			expectedOutput: "rate should be at most 1000.0 for all",
+			expectedStatus: 1,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			server, statusRequests, updates := newStoreLimitTestServer(t, testCase.kernelType, 0)
+			defer server.Close()
+
+			cmd := NewSetAllLimitCommand()
+			cmd.Flags().String("pd", server.URL, "")
+			cmd.SetArgs(testCase.args)
+			output := executeStoreLimitCommand(t, cmd)
+			require.Equal(t, testCase.expectedStatus, *statusRequests)
+			require.Equal(t, testCase.expectedUpdates, *updates)
+			if testCase.expectedOutput != "" {
+				require.Contains(t, output, testCase.expectedOutput)
+			}
+		})
+	}
+}
+
+func newStoreLimitTestServer(t *testing.T, kernelType string, statusCode int) (*httptest.Server, *int, *int) {
+	t.Helper()
+	statusRequests := 0
+	updates := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/" + pdStatusPrefix:
+			statusRequests++
+			if statusCode != 0 {
+				http.Error(w, "status unavailable", statusCode)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			if _, err := fmt.Fprintf(w, `{"kernel_type":%q}`, kernelType); err != nil {
+				t.Errorf("write status response: %v", err)
+			}
+		case "/" + storesLimitPrefix:
+			updates++
+			w.Header().Set("Content-Type", "application/json")
+			if _, err := w.Write([]byte(`"Set store limit successfully."`)); err != nil {
+				t.Errorf("write store-limit response: %v", err)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	return server, &statusRequests, &updates
+}
+
+func executeStoreLimitCommand(t *testing.T, cmd *cobra.Command) string {
+	t.Helper()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	require.NoError(t, cmd.Execute())
+	return strings.TrimSpace(output.String())
+}

--- a/tools/pd-ctl/pdctl/command/store_command_test.go
+++ b/tools/pd-ctl/pdctl/command/store_command_test.go
@@ -144,7 +144,9 @@ func runStoreLimitTestCases(t *testing.T, newCommand func() *cobra.Command, test
 	}
 }
 
-func newStoreLimitTestServer(t *testing.T, kernelType string, statusCode int) (*httptest.Server, *int, *int) {
+func newStoreLimitTestServer(t *testing.T, kernelType string, statusCode int) (
+	testServer *httptest.Server, statusRequestCount *int, updateCount *int,
+) {
 	t.Helper()
 	statusRequests := 0
 	updates := 0

--- a/tools/pd-ctl/tests/store/store_test.go
+++ b/tools/pd-ctl/tests/store/store_test.go
@@ -491,17 +491,17 @@ func (s *storeTestSuite) checkStore(cluster *pdTests.TestCluster) {
 	re.NoError(err)
 	re.NotContains(string(output), "PANIC")
 
-	// store limit all 201 is invalid for all
+	// store limit all 201 is invalid for all on Classic PD.
 	args = []string{"-u", pdAddr, "store", "limit", "all", "201"}
 	output, err = tests.ExecuteCommand(cmd, args...)
 	re.NoError(err)
-	re.Contains(string(output), "rate should be less than")
+	re.Contains(string(output), "rate should be at most 200.0 for all")
 
-	// store limit all 201 is invalid for label
+	// store limit all 201 is invalid for label filtering on Classic PD.
 	args = []string{"-u", pdAddr, "store", "limit", "all", "engine", "key", "201", "add-peer"}
 	output, err = tests.ExecuteCommand(cmd, args...)
 	re.NoError(err)
-	re.Contains(string(output), "rate should be less than")
+	re.Contains(string(output), "rate should be at most 200.0 for all")
 
 	// store limit all engine tikv 21 remove peer for tikv stores
 	args = []string{"-u", pdAddr, "store", "limit", "all", "engine", "tikv", "21", "remove-peer"}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #11162

PD store-limit v1 is expressed in operators per minute. `pd-ctl store limit all` currently applies a fixed maximum of 200 to every kernel type. That boundary is sufficient for the current Classic TiKV scale-out profile and remains unchanged, but it is too restrictive for loaded NextGen scale-out.

NextGen's related CSE data-path tuning work is tracked in [cloud-storage-engine#5887](https://github.com/tidbcloud/cloud-storage-engine/issues/5887). Its 550 MiB/s DATA-volume baseline and PD's operator/min limit use different units. The end-to-end experiments also changed multiple controls, so this PR does not attribute their result to the PD limit alone.

### What is changed and how does it work?

```commit-message
pd-ctl: allow higher v1 store limits for NextGen
```

- Keep the `pd-ctl store limit all` maximum at 200 for Classic PD.
- For a requested rate above 200, query `/pd/api/v1/status` and allow up to 1000 only when `kernel_type` is `Next Generation`.
- Fail closed at the Classic boundary when status lookup or parsing fails.
- Apply the same check to the current command, label-filter form, and deprecated all-store command.

The 200/1000 check is a `pd-ctl` safety guard, not a server-side invariant. Direct API callers remain responsible for selecting an appropriate value.

This PR does not change server-side persistence, new-store inheritance, store-limit v2, or any scheduling defaults.

### Check List

Tests

- [x] Unit test
- [x] Integration test
- [ ] Manual test
- [ ] No code

Validated with:

- `go test ./pd-ctl/pdctl/command` from `tools`
- `go test -tags nextgen ./pd-ctl/pdctl/command -run 'Test(StoreLimitAllKernelAwareMaximum|DeprecatedStoreLimitAllKernelAwareMaximum)$' -count=1` from `tools`
- `go test -tags without_dashboard ./pd-ctl/tests/store` from `tools`

Code changes

- [ ] Has the configuration change
- [ ] Has HTTP APIs changed
- [ ] Has persistent data change

Side effects

- [ ] Possible performance regression
- [ ] Increased code complexity
- [ ] Breaking backward compatibility

Related changes

- Related NextGen data-path task: [cloud-storage-engine#5887](https://github.com/tidbcloud/cloud-storage-engine/issues/5887)
- PR to update `pingcap/docs`/`pingcap/docs-cn`: None
- PR to update `pingcap/tiup`: None
- Need to cherry-pick to the release branch: No

### Release note

```release-note
Allow pd-ctl to set a bounded higher all-store v1 scheduling limit for NextGen deployments while preserving the Classic limit.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Store rate limits now use the appropriate maximum for the detected kernel version.
  * Higher limits are accepted only when a next-generation kernel is confirmed.
  * Store-limit updates consistently validate limits across all command variants, including filtered stores.
  * Requests are rejected when system status cannot be retrieved or verified.
  * Error messages now identify the applicable maximum limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->