### PR TITLE
client/resource_group: expose RU v1 calculation details

### DIFF
--- a/client/resource_group/controller/global_controller.go
+++ b/client/resource_group/controller/global_controller.go
@@ -85,27 +85,6 @@ type ResourceGroupKVInterceptor interface {
 	GetRUVersion() RUVersion
 }
 
-// ResourceGroupKVInterceptorWithRUDetails optionally exposes the inputs and
-// factors used by the RU v1 calculation.
-type ResourceGroupKVInterceptorWithRUDetails interface {
-	ResourceGroupKVInterceptor
-	// OnRequestWaitWithRUDetails is OnRequestWait with its RU v1 formula inputs.
-	OnRequestWaitWithRUDetails(ctx context.Context, resourceGroupName string, info RequestInfo) (
-		delta, penalty *rmpb.Consumption, detail RUCalculation,
-		waitDuration time.Duration, priority uint32, err error,
-	)
-	// OnResponseWithRUDetails is OnResponse with its RU v1 formula inputs.
-	OnResponseWithRUDetails(resourceGroupName string, req RequestInfo, resp ResponseInfo) (
-		delta *rmpb.Consumption, detail RUCalculation, err error,
-	)
-	// OnResponseWaitWithRUDetails is OnResponseWait with its RU v1 formula inputs.
-	OnResponseWaitWithRUDetails(ctx context.Context, resourceGroupName string, req RequestInfo, resp ResponseInfo) (
-		delta *rmpb.Consumption, detail RUCalculation, waitDuration time.Duration, err error,
-	)
-}
-
-var _ ResourceGroupKVInterceptorWithRUDetails = (*ResourceGroupsController)(nil)
-
 // ResourceGroupProvider provides some api to interact with resource manager server.
 type ResourceGroupProvider interface {
 	GetResourceGroup(ctx context.Context, resourceGroupName string, opts ...pd.GetResourceGroupOption) (*rmpb.ResourceGroup, error)
@@ -859,22 +838,6 @@ func (c *ResourceGroupsController) OnRequestWait(
 	return gc.onRequestWaitImpl(ctx, info)
 }
 
-// OnRequestWaitWithRUDetails is OnRequestWait with the calculation delta
-// produced from the group controller's effective factor snapshot.
-func (c *ResourceGroupsController) OnRequestWaitWithRUDetails(
-	ctx context.Context, resourceGroupName string, info RequestInfo,
-) (delta, penalty *rmpb.Consumption, detail RUCalculation, waitDuration time.Duration, priority uint32, err error) {
-	gc, err := c.tryGetResourceGroupController(ctx, resourceGroupName, true)
-	if err != nil {
-		return nil, nil, RUCalculation{}, 0, 0, err
-	}
-	delta, penalty, waitDuration, priority, err = gc.onRequestWaitWithDetailImpl(ctx, info, &detail)
-	if err != nil {
-		return nil, nil, RUCalculation{}, waitDuration, 0, err
-	}
-	return delta, penalty, detail, waitDuration, priority, nil
-}
-
 // OnResponse is used to consume tokens after receiving response
 func (c *ResourceGroupsController) OnResponse(
 	resourceGroupName string, req RequestInfo, resp ResponseInfo,
@@ -887,24 +850,6 @@ func (c *ResourceGroupsController) OnResponse(
 	return gc.onResponseImpl(req, resp)
 }
 
-// OnResponseWithRUDetails is OnResponse with the calculation delta produced
-// from the group controller's effective factor snapshot.
-func (c *ResourceGroupsController) OnResponseWithRUDetails(
-	resourceGroupName string, req RequestInfo, resp ResponseInfo,
-) (*rmpb.Consumption, RUCalculation, error) {
-	gc, ok := c.loadGroupController(resourceGroupName)
-	if !ok {
-		log.Warn("[resource group controller] resource group name does not exist", zap.String("name", resourceGroupName))
-		return &rmpb.Consumption{}, RUCalculation{}, nil
-	}
-	var detail RUCalculation
-	delta, err := gc.onResponseWithDetailImpl(req, resp, &detail)
-	if err != nil {
-		return nil, RUCalculation{}, err
-	}
-	return delta, detail, nil
-}
-
 // OnResponseWait is used to consume tokens after receiving response
 func (c *ResourceGroupsController) OnResponseWait(
 	ctx context.Context, resourceGroupName string, req RequestInfo, resp ResponseInfo,
@@ -915,24 +860,6 @@ func (c *ResourceGroupsController) OnResponseWait(
 		return &rmpb.Consumption{}, time.Duration(0), nil
 	}
 	return gc.onResponseWaitImpl(ctx, req, resp)
-}
-
-// OnResponseWaitWithRUDetails is OnResponseWait with the calculation delta
-// produced from the group controller's effective factor snapshot.
-func (c *ResourceGroupsController) OnResponseWaitWithRUDetails(
-	ctx context.Context, resourceGroupName string, req RequestInfo, resp ResponseInfo,
-) (*rmpb.Consumption, RUCalculation, time.Duration, error) {
-	gc, ok := c.loadGroupController(resourceGroupName)
-	if !ok {
-		log.Warn("[resource group controller] resource group name does not exist", zap.String("name", resourceGroupName))
-		return &rmpb.Consumption{}, RUCalculation{}, 0, nil
-	}
-	var detail RUCalculation
-	delta, waitDuration, err := gc.onResponseWaitWithDetailImpl(ctx, req, resp, &detail)
-	if err != nil {
-		return nil, RUCalculation{}, waitDuration, err
-	}
-	return delta, detail, waitDuration, nil
 }
 
 // IsBackgroundRequest If the resource group has background jobs, we should not record consumption and wait for it.

--- a/client/resource_group/controller/global_controller.go
+++ b/client/resource_group/controller/global_controller.go
@@ -85,6 +85,27 @@ type ResourceGroupKVInterceptor interface {
 	GetRUVersion() RUVersion
 }
 
+// ResourceGroupKVInterceptorWithRUDetails optionally exposes the inputs and
+// factors used by the RU v1 calculation.
+type ResourceGroupKVInterceptorWithRUDetails interface {
+	ResourceGroupKVInterceptor
+	// OnRequestWaitWithRUDetails is OnRequestWait with its RU v1 formula inputs.
+	OnRequestWaitWithRUDetails(ctx context.Context, resourceGroupName string, info RequestInfo) (
+		delta, penalty *rmpb.Consumption, detail RUCalculation,
+		waitDuration time.Duration, priority uint32, err error,
+	)
+	// OnResponseWithRUDetails is OnResponse with its RU v1 formula inputs.
+	OnResponseWithRUDetails(resourceGroupName string, req RequestInfo, resp ResponseInfo) (
+		delta *rmpb.Consumption, detail RUCalculation, err error,
+	)
+	// OnResponseWaitWithRUDetails is OnResponseWait with its RU v1 formula inputs.
+	OnResponseWaitWithRUDetails(ctx context.Context, resourceGroupName string, req RequestInfo, resp ResponseInfo) (
+		delta *rmpb.Consumption, detail RUCalculation, waitDuration time.Duration, err error,
+	)
+}
+
+var _ ResourceGroupKVInterceptorWithRUDetails = (*ResourceGroupsController)(nil)
+
 // ResourceGroupProvider provides some api to interact with resource manager server.
 type ResourceGroupProvider interface {
 	GetResourceGroup(ctx context.Context, resourceGroupName string, opts ...pd.GetResourceGroupOption) (*rmpb.ResourceGroup, error)
@@ -838,6 +859,22 @@ func (c *ResourceGroupsController) OnRequestWait(
 	return gc.onRequestWaitImpl(ctx, info)
 }
 
+// OnRequestWaitWithRUDetails is OnRequestWait with the calculation delta
+// produced from the group controller's effective factor snapshot.
+func (c *ResourceGroupsController) OnRequestWaitWithRUDetails(
+	ctx context.Context, resourceGroupName string, info RequestInfo,
+) (delta, penalty *rmpb.Consumption, detail RUCalculation, waitDuration time.Duration, priority uint32, err error) {
+	gc, err := c.tryGetResourceGroupController(ctx, resourceGroupName, true)
+	if err != nil {
+		return nil, nil, RUCalculation{}, 0, 0, err
+	}
+	delta, penalty, waitDuration, priority, err = gc.onRequestWaitWithDetailImpl(ctx, info, &detail)
+	if err != nil {
+		return nil, nil, RUCalculation{}, waitDuration, 0, err
+	}
+	return delta, penalty, detail, waitDuration, priority, nil
+}
+
 // OnResponse is used to consume tokens after receiving response
 func (c *ResourceGroupsController) OnResponse(
 	resourceGroupName string, req RequestInfo, resp ResponseInfo,
@@ -850,6 +887,24 @@ func (c *ResourceGroupsController) OnResponse(
 	return gc.onResponseImpl(req, resp)
 }
 
+// OnResponseWithRUDetails is OnResponse with the calculation delta produced
+// from the group controller's effective factor snapshot.
+func (c *ResourceGroupsController) OnResponseWithRUDetails(
+	resourceGroupName string, req RequestInfo, resp ResponseInfo,
+) (*rmpb.Consumption, RUCalculation, error) {
+	gc, ok := c.loadGroupController(resourceGroupName)
+	if !ok {
+		log.Warn("[resource group controller] resource group name does not exist", zap.String("name", resourceGroupName))
+		return &rmpb.Consumption{}, RUCalculation{}, nil
+	}
+	var detail RUCalculation
+	delta, err := gc.onResponseWithDetailImpl(req, resp, &detail)
+	if err != nil {
+		return nil, RUCalculation{}, err
+	}
+	return delta, detail, nil
+}
+
 // OnResponseWait is used to consume tokens after receiving response
 func (c *ResourceGroupsController) OnResponseWait(
 	ctx context.Context, resourceGroupName string, req RequestInfo, resp ResponseInfo,
@@ -860,6 +915,24 @@ func (c *ResourceGroupsController) OnResponseWait(
 		return &rmpb.Consumption{}, time.Duration(0), nil
 	}
 	return gc.onResponseWaitImpl(ctx, req, resp)
+}
+
+// OnResponseWaitWithRUDetails is OnResponseWait with the calculation delta
+// produced from the group controller's effective factor snapshot.
+func (c *ResourceGroupsController) OnResponseWaitWithRUDetails(
+	ctx context.Context, resourceGroupName string, req RequestInfo, resp ResponseInfo,
+) (*rmpb.Consumption, RUCalculation, time.Duration, error) {
+	gc, ok := c.loadGroupController(resourceGroupName)
+	if !ok {
+		log.Warn("[resource group controller] resource group name does not exist", zap.String("name", resourceGroupName))
+		return &rmpb.Consumption{}, RUCalculation{}, 0, nil
+	}
+	var detail RUCalculation
+	delta, waitDuration, err := gc.onResponseWaitWithDetailImpl(ctx, req, resp, &detail)
+	if err != nil {
+		return nil, RUCalculation{}, waitDuration, err
+	}
+	return delta, detail, waitDuration, nil
 }
 
 // IsBackgroundRequest If the resource group has background jobs, we should not record consumption and wait for it.

--- a/client/resource_group/controller/group_controller.go
+++ b/client/resource_group/controller/group_controller.go
@@ -788,9 +788,7 @@ func (gc *groupCostController) onRequestWaitImpl(
 	*gc.mu.storeCounter[info.StoreID()] = *gc.mu.globalCounter
 	gc.mu.Unlock()
 	gc.metrics.addRequestSourceRUDelta(requestSource(info), reportedDelta)
-	if collector != nil {
-		collector.CollectRUCalculation(*detail)
-	}
+	collectRUCalculation(collector, detail, delta)
 
 	return delta, penalty, waitDuration, gc.getMeta().GetPriority(), nil
 }
@@ -827,9 +825,7 @@ func (gc *groupCostController) onResponseImpl(
 	gc.mu.Unlock()
 
 	gc.metrics.addRequestSourceRUDelta(requestSource(req), reportedDelta)
-	if collector != nil {
-		collector.CollectRUCalculation(*detail)
-	}
+	collectRUCalculation(collector, detail, delta)
 
 	return delta, nil
 }
@@ -889,9 +885,7 @@ func (gc *groupCostController) onResponseWaitImpl(
 	gc.mu.Unlock()
 
 	gc.metrics.addRequestSourceRUDelta(requestSource(req), reportedDelta)
-	if collector != nil {
-		collector.CollectRUCalculation(*detail)
-	}
+	collectRUCalculation(collector, detail, delta)
 
 	return delta, waitDuration, nil
 }
@@ -902,6 +896,15 @@ func newRUCalculationDetail(req RequestInfo) (RUCalculationCollector, *RUCalcula
 		return nil, nil
 	}
 	return collector, &RUCalculation{}
+}
+
+func collectRUCalculation(collector RUCalculationCollector, detail *RUCalculation, consumption *rmpb.Consumption) {
+	if collector == nil {
+		return
+	}
+	detail.RRU = consumption.RRU
+	detail.WRU = consumption.WRU
+	collector.CollectRUCalculation(*detail)
 }
 
 func (gc *groupCostController) addRUConsumption(consumption *rmpb.Consumption) {

--- a/client/resource_group/controller/group_controller.go
+++ b/client/resource_group/controller/group_controller.go
@@ -741,12 +741,7 @@ retryLoop:
 func (gc *groupCostController) onRequestWaitImpl(
 	ctx context.Context, info RequestInfo,
 ) (delta, penalty *rmpb.Consumption, waitDuration time.Duration, priority uint32, err error) {
-	return gc.onRequestWaitWithDetailImpl(ctx, info, nil)
-}
-
-func (gc *groupCostController) onRequestWaitWithDetailImpl(
-	ctx context.Context, info RequestInfo, detail *RUCalculation,
-) (delta, penalty *rmpb.Consumption, waitDuration time.Duration, priority uint32, err error) {
+	collector, detail := newRUCalculationDetail(info)
 	delta = &rmpb.Consumption{}
 	calculateBeforeKVRequest(gc.calculators, delta, detail, info)
 	reportedDelta := reportedRequestConsumption(gc.calculators, info, delta)
@@ -793,6 +788,9 @@ func (gc *groupCostController) onRequestWaitWithDetailImpl(
 	*gc.mu.storeCounter[info.StoreID()] = *gc.mu.globalCounter
 	gc.mu.Unlock()
 	gc.metrics.addRequestSourceRUDelta(requestSource(info), reportedDelta)
+	if collector != nil {
+		collector.CollectRUCalculation(*detail)
+	}
 
 	return delta, penalty, waitDuration, gc.getMeta().GetPriority(), nil
 }
@@ -800,12 +798,7 @@ func (gc *groupCostController) onRequestWaitWithDetailImpl(
 func (gc *groupCostController) onResponseImpl(
 	req RequestInfo, resp ResponseInfo,
 ) (*rmpb.Consumption, error) {
-	return gc.onResponseWithDetailImpl(req, resp, nil)
-}
-
-func (gc *groupCostController) onResponseWithDetailImpl(
-	req RequestInfo, resp ResponseInfo, detail *RUCalculation,
-) (*rmpb.Consumption, error) {
+	collector, detail := newRUCalculationDetail(req)
 	delta := &rmpb.Consumption{}
 	calculateAfterKVRequest(gc.calculators, delta, detail, req, resp)
 	reportedDelta := reportedResponseConsumption(gc.calculators, req, delta)
@@ -834,6 +827,9 @@ func (gc *groupCostController) onResponseWithDetailImpl(
 	gc.mu.Unlock()
 
 	gc.metrics.addRequestSourceRUDelta(requestSource(req), reportedDelta)
+	if collector != nil {
+		collector.CollectRUCalculation(*detail)
+	}
 
 	return delta, nil
 }
@@ -841,12 +837,7 @@ func (gc *groupCostController) onResponseWithDetailImpl(
 func (gc *groupCostController) onResponseWaitImpl(
 	ctx context.Context, req RequestInfo, resp ResponseInfo,
 ) (*rmpb.Consumption, time.Duration, error) {
-	return gc.onResponseWaitWithDetailImpl(ctx, req, resp, nil)
-}
-
-func (gc *groupCostController) onResponseWaitWithDetailImpl(
-	ctx context.Context, req RequestInfo, resp ResponseInfo, detail *RUCalculation,
-) (*rmpb.Consumption, time.Duration, error) {
+	collector, detail := newRUCalculationDetail(req)
 	delta := &rmpb.Consumption{}
 	calculateAfterKVRequest(gc.calculators, delta, detail, req, resp)
 	reportedDelta := reportedResponseConsumption(gc.calculators, req, delta)
@@ -898,8 +889,19 @@ func (gc *groupCostController) onResponseWaitWithDetailImpl(
 	gc.mu.Unlock()
 
 	gc.metrics.addRequestSourceRUDelta(requestSource(req), reportedDelta)
+	if collector != nil {
+		collector.CollectRUCalculation(*detail)
+	}
 
 	return delta, waitDuration, nil
+}
+
+func newRUCalculationDetail(req RequestInfo) (RUCalculationCollector, *RUCalculation) {
+	collector, ok := req.(RUCalculationCollector)
+	if !ok {
+		return nil, nil
+	}
+	return collector, &RUCalculation{}
 }
 
 func (gc *groupCostController) addRUConsumption(consumption *rmpb.Consumption) {

--- a/client/resource_group/controller/group_controller.go
+++ b/client/resource_group/controller/group_controller.go
@@ -741,10 +741,14 @@ retryLoop:
 func (gc *groupCostController) onRequestWaitImpl(
 	ctx context.Context, info RequestInfo,
 ) (delta, penalty *rmpb.Consumption, waitDuration time.Duration, priority uint32, err error) {
+	return gc.onRequestWaitWithDetailImpl(ctx, info, nil)
+}
+
+func (gc *groupCostController) onRequestWaitWithDetailImpl(
+	ctx context.Context, info RequestInfo, detail *RUCalculation,
+) (delta, penalty *rmpb.Consumption, waitDuration time.Duration, priority uint32, err error) {
 	delta = &rmpb.Consumption{}
-	for _, calc := range gc.calculators {
-		calc.BeforeKVRequest(delta, info)
-	}
+	calculateBeforeKVRequest(gc.calculators, delta, detail, info)
 	reportedDelta := reportedRequestConsumption(gc.calculators, info, delta)
 
 	gc.mu.Lock()
@@ -796,17 +800,19 @@ func (gc *groupCostController) onRequestWaitImpl(
 func (gc *groupCostController) onResponseImpl(
 	req RequestInfo, resp ResponseInfo,
 ) (*rmpb.Consumption, error) {
+	return gc.onResponseWithDetailImpl(req, resp, nil)
+}
+
+func (gc *groupCostController) onResponseWithDetailImpl(
+	req RequestInfo, resp ResponseInfo, detail *RUCalculation,
+) (*rmpb.Consumption, error) {
 	delta := &rmpb.Consumption{}
-	for _, calc := range gc.calculators {
-		calc.AfterKVRequest(delta, req, resp)
-	}
+	calculateAfterKVRequest(gc.calculators, delta, detail, req, resp)
 	reportedDelta := reportedResponseConsumption(gc.calculators, req, delta)
 	// `count` is the full per-request consumption (BeforeKVRequest + AfterKVRequest).
 	count := &rmpb.Consumption{}
 	*count = *delta
-	for _, calc := range gc.calculators {
-		calc.BeforeKVRequest(count, req)
-	}
+	calculateBeforeKVRequest(gc.calculators, count, nil, req)
 	bytesForEst, isPagingRead := pagingReadEstimate(req)
 	if isPagingRead {
 		gc.metrics.observePagingResponse(bytesForEst, resp.ReadBytes())
@@ -835,17 +841,19 @@ func (gc *groupCostController) onResponseImpl(
 func (gc *groupCostController) onResponseWaitImpl(
 	ctx context.Context, req RequestInfo, resp ResponseInfo,
 ) (*rmpb.Consumption, time.Duration, error) {
+	return gc.onResponseWaitWithDetailImpl(ctx, req, resp, nil)
+}
+
+func (gc *groupCostController) onResponseWaitWithDetailImpl(
+	ctx context.Context, req RequestInfo, resp ResponseInfo, detail *RUCalculation,
+) (*rmpb.Consumption, time.Duration, error) {
 	delta := &rmpb.Consumption{}
-	for _, calc := range gc.calculators {
-		calc.AfterKVRequest(delta, req, resp)
-	}
+	calculateAfterKVRequest(gc.calculators, delta, detail, req, resp)
 	reportedDelta := reportedResponseConsumption(gc.calculators, req, delta)
 	// `count` is the full per-request consumption (BeforeKVRequest + AfterKVRequest).
 	count := &rmpb.Consumption{}
 	*count = *delta
-	for _, calc := range gc.calculators {
-		calc.BeforeKVRequest(count, req)
-	}
+	calculateBeforeKVRequest(gc.calculators, count, nil, req)
 	bytesForEst, isPagingRead := pagingReadEstimate(req)
 	var waitDuration time.Duration
 	if !gc.burstable.Load() {

--- a/client/resource_group/controller/group_controller_test.go
+++ b/client/resource_group/controller/group_controller_test.go
@@ -343,15 +343,21 @@ func TestRUCalculationDetail(t *testing.T) {
 	re.Len(writeReq.calculations, 2)
 	paybackDetail := writeReq.calculations[1]
 	re.InDelta(-5, paybackConsumption.WRU, 1e-12)
-	re.Equal(float64(1), paybackDetail.Inputs.FailedWriteRPCCount)
-	re.Equal(float64(10), paybackDetail.Inputs.FailedWriteBytes)
+	re.Equal(float64(1), paybackDetail.Inputs.FailedWriteBaseCostRefundCount)
+	re.Equal(float64(10), paybackDetail.Inputs.FailedWriteRefundBytes)
+	re.InDelta(
+		-paybackDetail.Inputs.FailedWriteBaseCostRefundCount*paybackDetail.Factors.WriteBaseCost-
+			paybackDetail.Inputs.FailedWriteRefundBytes*paybackDetail.Factors.WriteBytesCost,
+		paybackDetail.WRU,
+		1e-12,
+	)
 	re.InDelta(paybackConsumption.WRU, paybackDetail.WRU, 1e-12)
 
 	writeDetail.Add(paybackDetail)
 	re.Equal(float64(3), writeDetail.Inputs.ReplicaWeightedWriteRPCCount)
 	re.Equal(float64(30), writeDetail.Inputs.ReplicaWeightedWriteBytes)
-	re.Equal(float64(1), writeDetail.Inputs.FailedWriteRPCCount)
-	re.Equal(float64(10), writeDetail.Inputs.FailedWriteBytes)
+	re.Equal(float64(1), writeDetail.Inputs.FailedWriteBaseCostRefundCount)
+	re.Equal(float64(10), writeDetail.Inputs.FailedWriteRefundBytes)
 	re.InDelta(writeConsumption.WRU+paybackConsumption.WRU, writeDetail.WRU, 1e-12)
 
 	retryConsumption, _, _, _, err := gc.onRequestWaitImpl(context.Background(), writeReq)
@@ -369,7 +375,7 @@ func TestRUCalculationDetail(t *testing.T) {
 	writeDetail.Add(retryResponseDetail)
 	re.Equal(float64(6), writeDetail.Inputs.ReplicaWeightedWriteRPCCount)
 	re.Equal(float64(60), writeDetail.Inputs.ReplicaWeightedWriteBytes)
-	re.Equal(float64(1), writeDetail.Inputs.FailedWriteRPCCount)
+	re.Equal(float64(1), writeDetail.Inputs.FailedWriteBaseCostRefundCount)
 	re.InDelta(writeConsumption.WRU+paybackConsumption.WRU+retryConsumption.WRU, writeDetail.WRU, 1e-12)
 }
 

--- a/client/resource_group/controller/group_controller_test.go
+++ b/client/resource_group/controller/group_controller_test.go
@@ -253,6 +253,106 @@ func TestRequestAndResponseConsumption(t *testing.T) {
 	}
 }
 
+func TestRUCalculationDetail(t *testing.T) {
+	re := require.New(t)
+	gc := createTestGroupCostController(re)
+	cfg := *DefaultRUConfig()
+	cfg.ReadBaseCost = 1
+	cfg.ReadPerBatchBaseCost = 2
+	cfg.ReadBytesCost = 0.1
+	cfg.WriteBaseCost = 3
+	cfg.WritePerBatchBaseCost = 5
+	cfg.WriteBytesCost = 0.2
+	cfg.CPUMsCost = 0.5
+	gc.mainCfg = &cfg
+	gc.calculators = []ResourceCalculator{newKVCalculator(&cfg), newSQLCalculator(&cfg)}
+
+	readReq := &TestRequestInfo{
+		predictedReadBytes: 10,
+		isCop:              true,
+	}
+	var requestDetail RUCalculation
+	requestConsumption, _, _, _, err := gc.onRequestWaitWithDetailImpl(context.Background(), readReq, &requestDetail)
+	re.NoError(err)
+	re.InDelta(3.4, requestConsumption.RRU, 1e-12)
+	re.Equal(RUFactorSnapshot{
+		ReadBaseCost:          1,
+		ReadPerBatchBaseCost:  2,
+		ReadBytesCost:         0.1,
+		WriteBaseCost:         3,
+		WritePerBatchBaseCost: 5,
+		WriteBytesCost:        0.2,
+		CPUMsCost:             0.5,
+		BatchProportion:       0.7,
+	}, requestDetail.Factors)
+	re.Equal(float64(1), requestDetail.Inputs.ReadRPCCount)
+	re.Equal(float64(10), requestDetail.Inputs.ReadBytes)
+	re.InDelta(requestConsumption.RRU, requestDetail.RRU(), 1e-12)
+
+	readResp := &TestResponseInfo{
+		readBytes: 4,
+		kvCPU:     time.Millisecond,
+		succeed:   true,
+	}
+	var responseDetail RUCalculation
+	responseConsumption, _, err := gc.onResponseWaitWithDetailImpl(context.Background(), readReq, readResp, &responseDetail)
+	re.NoError(err)
+	re.InDelta(-0.1, responseConsumption.RRU, 1e-12)
+	re.Equal(requestDetail.Factors, responseDetail.Factors)
+	re.Equal(float64(-6), responseDetail.Inputs.ReadBytes)
+	re.Equal(float64(1), responseDetail.Inputs.KVCPUTimeMs)
+	re.InDelta(responseConsumption.RRU, responseDetail.RRU(), 1e-12)
+
+	requestDetail.Add(responseDetail)
+	re.Equal(float64(1), requestDetail.Inputs.ReadRPCCount)
+	re.Equal(float64(4), requestDetail.Inputs.ReadBytes)
+	re.Equal(float64(1), requestDetail.Inputs.KVCPUTimeMs)
+
+	writeReq := &TestRequestInfo{
+		isWrite:     true,
+		writeBytes:  10,
+		numReplicas: 3,
+	}
+	var writeDetail RUCalculation
+	writeConsumption, _, _, _, err := gc.onRequestWaitWithDetailImpl(context.Background(), writeReq, &writeDetail)
+	re.NoError(err)
+	re.InDelta(25.5, writeConsumption.WRU, 1e-12)
+	re.Equal(float64(3), writeDetail.Inputs.ReplicaWeightedWriteRPCCount)
+	re.Equal(float64(30), writeDetail.Inputs.ReplicaWeightedWriteBytes)
+	re.InDelta(writeConsumption.WRU, writeDetail.WRU(), 1e-12)
+
+	var paybackDetail RUCalculation
+	paybackConsumption, _, err := gc.onResponseWaitWithDetailImpl(
+		context.Background(), writeReq, &TestResponseInfo{succeed: false}, &paybackDetail,
+	)
+	re.NoError(err)
+	re.InDelta(-5, paybackConsumption.WRU, 1e-12)
+	re.Equal(float64(1), paybackDetail.Inputs.FailedWriteRPCCount)
+	re.Equal(float64(10), paybackDetail.Inputs.FailedWriteBytes)
+	re.InDelta(paybackConsumption.WRU, paybackDetail.WRU(), 1e-12)
+
+	writeDetail.Add(paybackDetail)
+	re.Equal(float64(3), writeDetail.Inputs.ReplicaWeightedWriteRPCCount)
+	re.Equal(float64(30), writeDetail.Inputs.ReplicaWeightedWriteBytes)
+	re.Equal(float64(1), writeDetail.Inputs.FailedWriteRPCCount)
+	re.Equal(float64(10), writeDetail.Inputs.FailedWriteBytes)
+
+	var retryDetail RUCalculation
+	retryConsumption, _, _, _, err := gc.onRequestWaitWithDetailImpl(context.Background(), writeReq, &retryDetail)
+	re.NoError(err)
+	re.InDelta(25.5, retryConsumption.WRU, 1e-12)
+	var retryResponseDetail RUCalculation
+	_, _, err = gc.onResponseWaitWithDetailImpl(
+		context.Background(), writeReq, &TestResponseInfo{succeed: true}, &retryResponseDetail,
+	)
+	re.NoError(err)
+	writeDetail.Add(retryDetail)
+	writeDetail.Add(retryResponseDetail)
+	re.Equal(float64(6), writeDetail.Inputs.ReplicaWeightedWriteRPCCount)
+	re.Equal(float64(60), writeDetail.Inputs.ReplicaWeightedWriteBytes)
+	re.Equal(float64(1), writeDetail.Inputs.FailedWriteRPCCount)
+}
+
 func TestOnResponseWaitConsumption(t *testing.T) {
 	re := require.New(t)
 	gc := createTestGroupCostController(re)

--- a/client/resource_group/controller/group_controller_test.go
+++ b/client/resource_group/controller/group_controller_test.go
@@ -229,7 +229,7 @@ func TestRequestAndResponseConsumption(t *testing.T) {
 		re.Equal(priority, gc.meta.Priority)
 		expectedConsumption := &rmpb.Consumption{}
 		if testCase.req.IsWrite() {
-			kvCalculator.calculateWriteCost(expectedConsumption, testCase.req)
+			kvCalculator.calculateWriteCostWithDetail(expectedConsumption, nil, testCase.req)
 			re.Equal(expectedConsumption.WRU, consumption.WRU)
 			if testCase.req.AccessLocationType() != AccessUnknown {
 				re.Positive(expectedConsumption.WriteCrossAzTrafficBytes, caseNum)
@@ -237,8 +237,8 @@ func TestRequestAndResponseConsumption(t *testing.T) {
 		}
 		consumption, err = gc.onResponseImpl(testCase.req, testCase.resp)
 		re.NoError(err, caseNum)
-		kvCalculator.calculateReadCost(expectedConsumption, testCase.resp)
-		kvCalculator.calculateCPUCost(expectedConsumption, testCase.resp)
+		kvCalculator.calculateReadCostWithDetail(expectedConsumption, nil, testCase.resp)
+		kvCalculator.calculateCPUCostWithDetail(expectedConsumption, nil, testCase.resp)
 		calculateCrossAZTraffic(expectedConsumption, testCase.req, testCase.resp)
 		re.Equal(expectedConsumption.RRU, consumption.RRU, caseNum)
 		re.Equal(expectedConsumption.TotalCpuTimeMs, consumption.TotalCpuTimeMs, caseNum)
@@ -400,7 +400,7 @@ func TestOnResponseWaitConsumption(t *testing.T) {
 	verify := func() {
 		expectedConsumption := &rmpb.Consumption{}
 		kvCalculator := gc.getKVCalculator()
-		kvCalculator.calculateReadCost(expectedConsumption, resp)
+		kvCalculator.calculateReadCostWithDetail(expectedConsumption, nil, resp)
 		re.Equal(expectedConsumption.RRU, consumption.RRU)
 	}
 	verify()

--- a/client/resource_group/controller/group_controller_test.go
+++ b/client/resource_group/controller/group_controller_test.go
@@ -267,13 +267,14 @@ func TestRUCalculationDetail(t *testing.T) {
 	gc.mainCfg = &cfg
 	gc.calculators = []ResourceCalculator{newKVCalculator(&cfg), newSQLCalculator(&cfg)}
 
-	readReq := &TestRequestInfo{
+	readReq := &ruCalculationCollectingRequest{TestRequestInfo: &TestRequestInfo{
 		predictedReadBytes: 10,
 		isCop:              true,
-	}
-	var requestDetail RUCalculation
-	requestConsumption, _, _, _, err := gc.onRequestWaitWithDetailImpl(context.Background(), readReq, &requestDetail)
+	}}
+	requestConsumption, _, _, _, err := gc.onRequestWaitImpl(context.Background(), readReq)
 	re.NoError(err)
+	re.Len(readReq.calculations, 1)
+	requestDetail := readReq.calculations[0]
 	re.InDelta(3.4, requestConsumption.RRU, 1e-12)
 	re.Equal(RUFactorSnapshot{
 		ReadBaseCost:          1,
@@ -294,9 +295,10 @@ func TestRUCalculationDetail(t *testing.T) {
 		kvCPU:     time.Millisecond,
 		succeed:   true,
 	}
-	var responseDetail RUCalculation
-	responseConsumption, _, err := gc.onResponseWaitWithDetailImpl(context.Background(), readReq, readResp, &responseDetail)
+	responseConsumption, _, err := gc.onResponseWaitImpl(context.Background(), readReq, readResp)
 	re.NoError(err)
+	re.Len(readReq.calculations, 2)
+	responseDetail := readReq.calculations[1]
 	re.InDelta(-0.1, responseConsumption.RRU, 1e-12)
 	re.Equal(requestDetail.Factors, responseDetail.Factors)
 	re.Equal(float64(-6), responseDetail.Inputs.ReadBytes)
@@ -308,24 +310,26 @@ func TestRUCalculationDetail(t *testing.T) {
 	re.Equal(float64(4), requestDetail.Inputs.ReadBytes)
 	re.Equal(float64(1), requestDetail.Inputs.KVCPUTimeMs)
 
-	writeReq := &TestRequestInfo{
+	writeReq := &ruCalculationCollectingRequest{TestRequestInfo: &TestRequestInfo{
 		isWrite:     true,
 		writeBytes:  10,
 		numReplicas: 3,
-	}
-	var writeDetail RUCalculation
-	writeConsumption, _, _, _, err := gc.onRequestWaitWithDetailImpl(context.Background(), writeReq, &writeDetail)
+	}}
+	writeConsumption, _, _, _, err := gc.onRequestWaitImpl(context.Background(), writeReq)
 	re.NoError(err)
+	re.Len(writeReq.calculations, 1)
+	writeDetail := writeReq.calculations[0]
 	re.InDelta(25.5, writeConsumption.WRU, 1e-12)
 	re.Equal(float64(3), writeDetail.Inputs.ReplicaWeightedWriteRPCCount)
 	re.Equal(float64(30), writeDetail.Inputs.ReplicaWeightedWriteBytes)
 	re.InDelta(writeConsumption.WRU, writeDetail.WRU(), 1e-12)
 
-	var paybackDetail RUCalculation
-	paybackConsumption, _, err := gc.onResponseWaitWithDetailImpl(
-		context.Background(), writeReq, &TestResponseInfo{succeed: false}, &paybackDetail,
+	paybackConsumption, _, err := gc.onResponseWaitImpl(
+		context.Background(), writeReq, &TestResponseInfo{succeed: false},
 	)
 	re.NoError(err)
+	re.Len(writeReq.calculations, 2)
+	paybackDetail := writeReq.calculations[1]
 	re.InDelta(-5, paybackConsumption.WRU, 1e-12)
 	re.Equal(float64(1), paybackDetail.Inputs.FailedWriteRPCCount)
 	re.Equal(float64(10), paybackDetail.Inputs.FailedWriteBytes)
@@ -337,20 +341,31 @@ func TestRUCalculationDetail(t *testing.T) {
 	re.Equal(float64(1), writeDetail.Inputs.FailedWriteRPCCount)
 	re.Equal(float64(10), writeDetail.Inputs.FailedWriteBytes)
 
-	var retryDetail RUCalculation
-	retryConsumption, _, _, _, err := gc.onRequestWaitWithDetailImpl(context.Background(), writeReq, &retryDetail)
+	retryConsumption, _, _, _, err := gc.onRequestWaitImpl(context.Background(), writeReq)
 	re.NoError(err)
+	re.Len(writeReq.calculations, 3)
+	retryDetail := writeReq.calculations[2]
 	re.InDelta(25.5, retryConsumption.WRU, 1e-12)
-	var retryResponseDetail RUCalculation
-	_, _, err = gc.onResponseWaitWithDetailImpl(
-		context.Background(), writeReq, &TestResponseInfo{succeed: true}, &retryResponseDetail,
+	_, _, err = gc.onResponseWaitImpl(
+		context.Background(), writeReq, &TestResponseInfo{succeed: true},
 	)
 	re.NoError(err)
+	re.Len(writeReq.calculations, 4)
+	retryResponseDetail := writeReq.calculations[3]
 	writeDetail.Add(retryDetail)
 	writeDetail.Add(retryResponseDetail)
 	re.Equal(float64(6), writeDetail.Inputs.ReplicaWeightedWriteRPCCount)
 	re.Equal(float64(60), writeDetail.Inputs.ReplicaWeightedWriteBytes)
 	re.Equal(float64(1), writeDetail.Inputs.FailedWriteRPCCount)
+}
+
+type ruCalculationCollectingRequest struct {
+	*TestRequestInfo
+	calculations []RUCalculation
+}
+
+func (r *ruCalculationCollectingRequest) CollectRUCalculation(calculation RUCalculation) {
+	r.calculations = append(r.calculations, calculation)
 }
 
 func TestOnResponseWaitConsumption(t *testing.T) {

--- a/client/resource_group/controller/group_controller_test.go
+++ b/client/resource_group/controller/group_controller_test.go
@@ -288,7 +288,7 @@ func TestRUCalculationDetail(t *testing.T) {
 	}, requestDetail.Factors)
 	re.Equal(float64(1), requestDetail.Inputs.ReadRPCCount)
 	re.Equal(float64(10), requestDetail.Inputs.ReadBytes)
-	re.InDelta(requestConsumption.RRU, requestDetail.RRU(), 1e-12)
+	re.InDelta(requestConsumption.RRU, requestDetail.RRU, 1e-12)
 
 	readResp := &TestResponseInfo{
 		readBytes: 4,
@@ -303,12 +303,24 @@ func TestRUCalculationDetail(t *testing.T) {
 	re.Equal(requestDetail.Factors, responseDetail.Factors)
 	re.Equal(float64(-6), responseDetail.Inputs.ReadBytes)
 	re.Equal(float64(1), responseDetail.Inputs.KVCPUTimeMs)
-	re.InDelta(responseConsumption.RRU, responseDetail.RRU(), 1e-12)
+	re.InDelta(responseConsumption.RRU, responseDetail.RRU, 1e-12)
 
 	requestDetail.Add(responseDetail)
 	re.Equal(float64(1), requestDetail.Inputs.ReadRPCCount)
 	re.Equal(float64(4), requestDetail.Inputs.ReadBytes)
 	re.Equal(float64(1), requestDetail.Inputs.KVCPUTimeMs)
+	re.InDelta(requestConsumption.RRU+responseConsumption.RRU, requestDetail.RRU, 1e-12)
+
+	nonWaitingReq := &ruCalculationCollectingRequest{TestRequestInfo: &TestRequestInfo{
+		predictedReadBytes: 10,
+		isCop:              true,
+	}}
+	_, _, _, _, err = gc.onRequestWaitImpl(context.Background(), nonWaitingReq)
+	re.NoError(err)
+	nonWaitingConsumption, err := gc.onResponseImpl(nonWaitingReq, readResp)
+	re.NoError(err)
+	re.Len(nonWaitingReq.calculations, 2)
+	re.InDelta(nonWaitingConsumption.RRU, nonWaitingReq.calculations[1].RRU, 1e-12)
 
 	writeReq := &ruCalculationCollectingRequest{TestRequestInfo: &TestRequestInfo{
 		isWrite:     true,
@@ -322,7 +334,7 @@ func TestRUCalculationDetail(t *testing.T) {
 	re.InDelta(25.5, writeConsumption.WRU, 1e-12)
 	re.Equal(float64(3), writeDetail.Inputs.ReplicaWeightedWriteRPCCount)
 	re.Equal(float64(30), writeDetail.Inputs.ReplicaWeightedWriteBytes)
-	re.InDelta(writeConsumption.WRU, writeDetail.WRU(), 1e-12)
+	re.InDelta(writeConsumption.WRU, writeDetail.WRU, 1e-12)
 
 	paybackConsumption, _, err := gc.onResponseWaitImpl(
 		context.Background(), writeReq, &TestResponseInfo{succeed: false},
@@ -333,13 +345,14 @@ func TestRUCalculationDetail(t *testing.T) {
 	re.InDelta(-5, paybackConsumption.WRU, 1e-12)
 	re.Equal(float64(1), paybackDetail.Inputs.FailedWriteRPCCount)
 	re.Equal(float64(10), paybackDetail.Inputs.FailedWriteBytes)
-	re.InDelta(paybackConsumption.WRU, paybackDetail.WRU(), 1e-12)
+	re.InDelta(paybackConsumption.WRU, paybackDetail.WRU, 1e-12)
 
 	writeDetail.Add(paybackDetail)
 	re.Equal(float64(3), writeDetail.Inputs.ReplicaWeightedWriteRPCCount)
 	re.Equal(float64(30), writeDetail.Inputs.ReplicaWeightedWriteBytes)
 	re.Equal(float64(1), writeDetail.Inputs.FailedWriteRPCCount)
 	re.Equal(float64(10), writeDetail.Inputs.FailedWriteBytes)
+	re.InDelta(writeConsumption.WRU+paybackConsumption.WRU, writeDetail.WRU, 1e-12)
 
 	retryConsumption, _, _, _, err := gc.onRequestWaitImpl(context.Background(), writeReq)
 	re.NoError(err)
@@ -357,6 +370,7 @@ func TestRUCalculationDetail(t *testing.T) {
 	re.Equal(float64(6), writeDetail.Inputs.ReplicaWeightedWriteRPCCount)
 	re.Equal(float64(60), writeDetail.Inputs.ReplicaWeightedWriteBytes)
 	re.Equal(float64(1), writeDetail.Inputs.FailedWriteRPCCount)
+	re.InDelta(writeConsumption.WRU+paybackConsumption.WRU+retryConsumption.WRU, writeDetail.WRU, 1e-12)
 }
 
 type ruCalculationCollectingRequest struct {

--- a/client/resource_group/controller/model.go
+++ b/client/resource_group/controller/model.go
@@ -285,10 +285,6 @@ func (kc *KVCalculator) beforeKVRequestWithDetail(consumption *rmpb.Consumption,
 	}
 }
 
-func (kc *KVCalculator) calculateWriteCost(consumption *rmpb.Consumption, req RequestInfo) {
-	kc.calculateWriteCostWithDetail(consumption, nil, req)
-}
-
 func (kc *KVCalculator) calculateWriteCostWithDetail(consumption *rmpb.Consumption, detail *RUCalculation, req RequestInfo) {
 	writeBytes := float64(req.WriteBytes())
 	consumption.WriteBytes += writeBytes
@@ -340,10 +336,6 @@ func (kc *KVCalculator) afterKVRequestWithDetail(consumption *rmpb.Consumption, 
 	calculateCrossAZTraffic(consumption, req, res)
 }
 
-func (kc *KVCalculator) calculateReadCost(consumption *rmpb.Consumption, res ResponseInfo) {
-	kc.calculateReadCostWithDetail(consumption, nil, res)
-}
-
 func (kc *KVCalculator) calculateReadCostWithDetail(consumption *rmpb.Consumption, detail *RUCalculation, res ResponseInfo) {
 	if consumption == nil {
 		return
@@ -354,10 +346,6 @@ func (kc *KVCalculator) calculateReadCostWithDetail(consumption *rmpb.Consumptio
 	if detail != nil {
 		detail.Inputs.ReadBytes += readBytes
 	}
-}
-
-func (kc *KVCalculator) calculateCPUCost(consumption *rmpb.Consumption, res ResponseInfo) {
-	kc.calculateCPUCostWithDetail(consumption, nil, res)
 }
 
 func (kc *KVCalculator) calculateCPUCostWithDetail(consumption *rmpb.Consumption, detail *RUCalculation, res ResponseInfo) {

--- a/client/resource_group/controller/model.go
+++ b/client/resource_group/controller/model.go
@@ -132,6 +132,66 @@ type ResponseInfo interface {
 	ResponseSize() uint64
 }
 
+// RUFactorSnapshot contains the effective RU v1 factors used by a calculation.
+type RUFactorSnapshot struct {
+	ReadBaseCost          float64
+	ReadPerBatchBaseCost  float64
+	ReadBytesCost         float64
+	WriteBaseCost         float64
+	WritePerBatchBaseCost float64
+	WriteBytesCost        float64
+	CPUMsCost             float64
+	BatchProportion       float64
+}
+
+// RUCalculationInputs contains the inputs used by an RU v1 calculation.
+type RUCalculationInputs struct {
+	ReadRPCCount                 float64
+	ReadBytes                    float64
+	KVCPUTimeMs                  float64
+	ReplicaWeightedWriteRPCCount float64
+	ReplicaWeightedWriteBytes    float64
+	FailedWriteRPCCount          float64
+	FailedWriteBytes             float64
+}
+
+// RUCalculation contains the factors and inputs needed to show an RU v1 formula.
+type RUCalculation struct {
+	Factors RUFactorSnapshot
+	Inputs  RUCalculationInputs
+}
+
+// Add adds another calculation delta with the same factors to c.
+func (c *RUCalculation) Add(other RUCalculation) {
+	if c.Factors == (RUFactorSnapshot{}) {
+		c.Factors = other.Factors
+	}
+	c.Inputs.ReadRPCCount += other.Inputs.ReadRPCCount
+	c.Inputs.ReadBytes += other.Inputs.ReadBytes
+	c.Inputs.KVCPUTimeMs += other.Inputs.KVCPUTimeMs
+	c.Inputs.ReplicaWeightedWriteRPCCount += other.Inputs.ReplicaWeightedWriteRPCCount
+	c.Inputs.ReplicaWeightedWriteBytes += other.Inputs.ReplicaWeightedWriteBytes
+	c.Inputs.FailedWriteRPCCount += other.Inputs.FailedWriteRPCCount
+	c.Inputs.FailedWriteBytes += other.Inputs.FailedWriteBytes
+}
+
+// RRU returns the read RU represented by this calculation.
+func (c *RUCalculation) RRU() float64 {
+	factors, inputs := c.Factors, c.Inputs
+	return inputs.ReadRPCCount*factors.ReadBaseCost +
+		inputs.ReadRPCCount*factors.ReadPerBatchBaseCost*factors.BatchProportion +
+		inputs.ReadBytes*factors.ReadBytesCost + inputs.KVCPUTimeMs*factors.CPUMsCost
+}
+
+// WRU returns the write RU represented by this calculation.
+func (c *RUCalculation) WRU() float64 {
+	factors, inputs := c.Factors, c.Inputs
+	return inputs.ReplicaWeightedWriteRPCCount*factors.WriteBaseCost +
+		inputs.ReplicaWeightedWriteRPCCount*factors.WritePerBatchBaseCost*factors.BatchProportion +
+		inputs.ReplicaWeightedWriteBytes*factors.WriteBytesCost -
+		inputs.FailedWriteRPCCount*factors.WriteBaseCost - inputs.FailedWriteBytes*factors.WriteBytesCost
+}
+
 // ResourceCalculator is used to calculate the resource consumption of a request.
 type ResourceCalculator interface {
 	// Trickle is used to calculate the resource consumption periodically rather than on the request path.
@@ -146,6 +206,26 @@ type ResourceCalculator interface {
 	AfterKVRequest(*rmpb.Consumption, RequestInfo, ResponseInfo)
 }
 
+func calculateBeforeKVRequest(calculators []ResourceCalculator, consumption *rmpb.Consumption, detail *RUCalculation, req RequestInfo) {
+	for _, calc := range calculators {
+		if kvCalc, ok := calc.(*KVCalculator); ok && detail != nil {
+			kvCalc.beforeKVRequestWithDetail(consumption, detail, req)
+			continue
+		}
+		calc.BeforeKVRequest(consumption, req)
+	}
+}
+
+func calculateAfterKVRequest(calculators []ResourceCalculator, consumption *rmpb.Consumption, detail *RUCalculation, req RequestInfo, resp ResponseInfo) {
+	for _, calc := range calculators {
+		if kvCalc, ok := calc.(*KVCalculator); ok && detail != nil {
+			kvCalc.afterKVRequestWithDetail(consumption, detail, req, resp)
+			continue
+		}
+		calc.AfterKVRequest(consumption, req, resp)
+	}
+}
+
 // KVCalculator is used to calculate the KV-side consumption.
 type KVCalculator struct {
 	*RUConfig
@@ -157,23 +237,49 @@ func newKVCalculator(cfg *RUConfig) *KVCalculator {
 	return &KVCalculator{RUConfig: cfg}
 }
 
+func (kc *KVCalculator) initCalculation(detail *RUCalculation) {
+	if detail != nil {
+		detail.Factors = RUFactorSnapshot{
+			ReadBaseCost:          float64(kc.ReadBaseCost),
+			ReadPerBatchBaseCost:  float64(kc.ReadPerBatchBaseCost),
+			ReadBytesCost:         float64(kc.ReadBytesCost),
+			WriteBaseCost:         float64(kc.WriteBaseCost),
+			WritePerBatchBaseCost: float64(kc.WritePerBatchBaseCost),
+			WriteBytesCost:        float64(kc.WriteBytesCost),
+			CPUMsCost:             float64(kc.CPUMsCost),
+			BatchProportion:       defaultAvgBatchProportion,
+		}
+	}
+}
+
 // Trickle ...
 func (*KVCalculator) Trickle(*rmpb.Consumption) {}
 
 // BeforeKVRequest ...
 func (kc *KVCalculator) BeforeKVRequest(consumption *rmpb.Consumption, req RequestInfo) {
+	kc.beforeKVRequestWithDetail(consumption, nil, req)
+}
+
+func (kc *KVCalculator) beforeKVRequestWithDetail(consumption *rmpb.Consumption, detail *RUCalculation, req RequestInfo) {
+	kc.initCalculation(detail)
 	if req.IsWrite() {
 		consumption.KvWriteRpcCount += 1
 		// Write bytes are knowable in advance, so we can calculate the WRU cost here.
-		kc.calculateWriteCost(consumption, req)
+		kc.calculateWriteCostWithDetail(consumption, detail, req)
 	} else {
 		consumption.KvReadRpcCount += 1
 		// Read bytes could not be known before the request is executed,
 		// so we only add the base cost here.
 		consumption.RRU += float64(kc.ReadBaseCost) + float64(kc.ReadPerBatchBaseCost)*defaultAvgBatchProportion
+		if detail != nil {
+			detail.Inputs.ReadRPCCount++
+		}
 		// Paging pre-charge
 		if bytesForEst := estimatedReadBytes(req); bytesForEst > 0 {
 			consumption.RRU += float64(kc.ReadBytesCost) * float64(bytesForEst)
+			if detail != nil {
+				detail.Inputs.ReadBytes += float64(bytesForEst)
+			}
 		}
 	}
 	if req.AccessLocationType() == AccessCrossZone {
@@ -186,6 +292,10 @@ func (kc *KVCalculator) BeforeKVRequest(consumption *rmpb.Consumption, req Reque
 }
 
 func (kc *KVCalculator) calculateWriteCost(consumption *rmpb.Consumption, req RequestInfo) {
+	kc.calculateWriteCostWithDetail(consumption, nil, req)
+}
+
+func (kc *KVCalculator) calculateWriteCostWithDetail(consumption *rmpb.Consumption, detail *RUCalculation, req RequestInfo) {
 	writeBytes := float64(req.WriteBytes())
 	consumption.WriteBytes += writeBytes
 	// write request cost need consider the replicas, due to write data will be replicate to all replicas.
@@ -193,7 +303,12 @@ func (kc *KVCalculator) calculateWriteCost(consumption *rmpb.Consumption, req Re
 	if replicaNums == 0 {
 		replicaNums = 1
 	}
-	consumption.WRU += (float64(kc.WriteBaseCost) + float64(kc.WritePerBatchBaseCost)*defaultAvgBatchProportion + float64(kc.WriteBytesCost)*writeBytes) * float64(replicaNums)
+	replicas := float64(replicaNums)
+	consumption.WRU += (float64(kc.WriteBaseCost) + float64(kc.WritePerBatchBaseCost)*defaultAvgBatchProportion + float64(kc.WriteBytesCost)*writeBytes) * replicas
+	if detail != nil {
+		detail.Inputs.ReplicaWeightedWriteRPCCount += replicas
+		detail.Inputs.ReplicaWeightedWriteBytes += writeBytes * replicas
+	}
 	// TODO: for a raft group with N replicas, we assume the cross AZ network traffic for raft replication
 	// is: writeBytes * (N - 1). This is not accurate, but the deviation should be small enough.
 	//
@@ -206,39 +321,61 @@ func (kc *KVCalculator) calculateWriteCost(consumption *rmpb.Consumption, req Re
 
 // AfterKVRequest ...
 func (kc *KVCalculator) AfterKVRequest(consumption *rmpb.Consumption, req RequestInfo, res ResponseInfo) {
+	kc.afterKVRequestWithDetail(consumption, nil, req, res)
+}
+
+func (kc *KVCalculator) afterKVRequestWithDetail(consumption *rmpb.Consumption, detail *RUCalculation, req RequestInfo, res ResponseInfo) {
+	kc.initCalculation(detail)
 	if !req.IsWrite() {
 		// For now, we can only collect the KV CPU cost for a read request.
-		kc.calculateCPUCost(consumption, res)
+		kc.calculateCPUCostWithDetail(consumption, detail, res)
 		// Paging settlement
 		if bytesForEst := estimatedReadBytes(req); bytesForEst > 0 {
 			consumption.RRU -= float64(kc.ReadBytesCost) * float64(bytesForEst)
+			if detail != nil {
+				detail.Inputs.ReadBytes -= float64(bytesForEst)
+			}
 		}
 	} else if !res.Succeed() {
 		// If the write request is not successfully returned, we need to pay back the WRU cost.
-		kc.payBackWriteCost(consumption, req)
+		kc.payBackWriteCostWithDetail(consumption, detail, req)
 	}
 	// A write request may also read data, which should be counted into the RRU cost.
 	// This part should be counted even if the request does not succeed.
-	kc.calculateReadCost(consumption, res)
+	kc.calculateReadCostWithDetail(consumption, detail, res)
 	calculateCrossAZTraffic(consumption, req, res)
 }
 
 func (kc *KVCalculator) calculateReadCost(consumption *rmpb.Consumption, res ResponseInfo) {
+	kc.calculateReadCostWithDetail(consumption, nil, res)
+}
+
+func (kc *KVCalculator) calculateReadCostWithDetail(consumption *rmpb.Consumption, detail *RUCalculation, res ResponseInfo) {
 	if consumption == nil {
 		return
 	}
 	readBytes := float64(res.ReadBytes())
 	consumption.ReadBytes += readBytes
 	consumption.RRU += float64(kc.ReadBytesCost) * readBytes
+	if detail != nil {
+		detail.Inputs.ReadBytes += readBytes
+	}
 }
 
 func (kc *KVCalculator) calculateCPUCost(consumption *rmpb.Consumption, res ResponseInfo) {
+	kc.calculateCPUCostWithDetail(consumption, nil, res)
+}
+
+func (kc *KVCalculator) calculateCPUCostWithDetail(consumption *rmpb.Consumption, detail *RUCalculation, res ResponseInfo) {
 	if consumption == nil {
 		return
 	}
 	kvCPUMs := float64(res.KVCPU().Nanoseconds()) / 1000000.0
 	consumption.TotalCpuTimeMs += kvCPUMs
 	consumption.RRU += float64(kc.CPUMsCost) * kvCPUMs
+	if detail != nil {
+		detail.Inputs.KVCPUTimeMs += kvCPUMs
+	}
 }
 
 func calculateCrossAZTraffic(consumption *rmpb.Consumption, req RequestInfo, res ResponseInfo) {
@@ -251,13 +388,17 @@ func calculateCrossAZTraffic(consumption *rmpb.Consumption, req RequestInfo, res
 	}
 }
 
-func (kc *KVCalculator) payBackWriteCost(consumption *rmpb.Consumption, req RequestInfo) {
+func (kc *KVCalculator) payBackWriteCostWithDetail(consumption *rmpb.Consumption, detail *RUCalculation, req RequestInfo) {
 	if consumption == nil {
 		return
 	}
 	writeBytes := float64(req.WriteBytes())
 	consumption.WriteBytes -= writeBytes
 	consumption.WRU -= float64(kc.WriteBaseCost) + float64(kc.WriteBytesCost)*writeBytes
+	if detail != nil {
+		detail.Inputs.FailedWriteRPCCount++
+		detail.Inputs.FailedWriteBytes += writeBytes
+	}
 }
 
 func cloneConsumption(consumption *rmpb.Consumption) *rmpb.Consumption {

--- a/client/resource_group/controller/model.go
+++ b/client/resource_group/controller/model.go
@@ -161,6 +161,12 @@ type RUCalculation struct {
 	Inputs  RUCalculationInputs
 }
 
+// RUCalculationCollector is optionally implemented by requests that need the
+// RU v1 calculation inputs used during request admission and settlement.
+type RUCalculationCollector interface {
+	CollectRUCalculation(RUCalculation)
+}
+
 // Add adds another calculation delta with the same factors to c.
 func (c *RUCalculation) Add(other RUCalculation) {
 	if c.Factors == (RUFactorSnapshot{}) {

--- a/client/resource_group/controller/model.go
+++ b/client/resource_group/controller/model.go
@@ -159,6 +159,9 @@ type RUCalculationInputs struct {
 type RUCalculation struct {
 	Factors RUFactorSnapshot
 	Inputs  RUCalculationInputs
+	// RRU and WRU are the actual consumption produced by KVCalculator for Inputs.
+	RRU float64
+	WRU float64
 }
 
 // RUCalculationCollector is optionally implemented by requests that need the
@@ -179,23 +182,8 @@ func (c *RUCalculation) Add(other RUCalculation) {
 	c.Inputs.ReplicaWeightedWriteBytes += other.Inputs.ReplicaWeightedWriteBytes
 	c.Inputs.FailedWriteRPCCount += other.Inputs.FailedWriteRPCCount
 	c.Inputs.FailedWriteBytes += other.Inputs.FailedWriteBytes
-}
-
-// RRU returns the read RU represented by this calculation.
-func (c *RUCalculation) RRU() float64 {
-	factors, inputs := c.Factors, c.Inputs
-	return inputs.ReadRPCCount*factors.ReadBaseCost +
-		inputs.ReadRPCCount*factors.ReadPerBatchBaseCost*factors.BatchProportion +
-		inputs.ReadBytes*factors.ReadBytesCost + inputs.KVCPUTimeMs*factors.CPUMsCost
-}
-
-// WRU returns the write RU represented by this calculation.
-func (c *RUCalculation) WRU() float64 {
-	factors, inputs := c.Factors, c.Inputs
-	return inputs.ReplicaWeightedWriteRPCCount*factors.WriteBaseCost +
-		inputs.ReplicaWeightedWriteRPCCount*factors.WritePerBatchBaseCost*factors.BatchProportion +
-		inputs.ReplicaWeightedWriteBytes*factors.WriteBytesCost -
-		inputs.FailedWriteRPCCount*factors.WriteBaseCost - inputs.FailedWriteBytes*factors.WriteBytesCost
+	c.RRU += other.RRU
+	c.WRU += other.WRU
 }
 
 // ResourceCalculator is used to calculate the resource consumption of a request.

--- a/client/resource_group/controller/model.go
+++ b/client/resource_group/controller/model.go
@@ -145,14 +145,26 @@ type RUFactorSnapshot struct {
 }
 
 // RUCalculationInputs contains the inputs used by an RU v1 calculation.
+//
+// The write RU calculation is:
+//
+//	ReplicaWeightedWriteRPCCount * (WriteBaseCost + WritePerBatchBaseCost * BatchProportion)
+//	+ ReplicaWeightedWriteBytes * WriteBytesCost
+//	- FailedWriteBaseCostRefundCount * WriteBaseCost
+//	- FailedWriteRefundBytes * WriteBytesCost
+//
+// A failed write refunds neither the per-batch cost nor the replica-weighted
+// portion of the original charge.
 type RUCalculationInputs struct {
 	ReadRPCCount                 float64
 	ReadBytes                    float64
 	KVCPUTimeMs                  float64
 	ReplicaWeightedWriteRPCCount float64
 	ReplicaWeightedWriteBytes    float64
-	FailedWriteRPCCount          float64
-	FailedWriteBytes             float64
+	// FailedWriteBaseCostRefundCount is the number of unweighted write base-cost refunds.
+	FailedWriteBaseCostRefundCount float64
+	// FailedWriteRefundBytes is the unweighted byte input refunded using WriteBytesCost.
+	FailedWriteRefundBytes float64
 }
 
 // RUCalculation contains the factors and inputs needed to show an RU v1 formula.
@@ -180,8 +192,8 @@ func (c *RUCalculation) Add(other RUCalculation) {
 	c.Inputs.KVCPUTimeMs += other.Inputs.KVCPUTimeMs
 	c.Inputs.ReplicaWeightedWriteRPCCount += other.Inputs.ReplicaWeightedWriteRPCCount
 	c.Inputs.ReplicaWeightedWriteBytes += other.Inputs.ReplicaWeightedWriteBytes
-	c.Inputs.FailedWriteRPCCount += other.Inputs.FailedWriteRPCCount
-	c.Inputs.FailedWriteBytes += other.Inputs.FailedWriteBytes
+	c.Inputs.FailedWriteBaseCostRefundCount += other.Inputs.FailedWriteBaseCostRefundCount
+	c.Inputs.FailedWriteRefundBytes += other.Inputs.FailedWriteRefundBytes
 	c.RRU += other.RRU
 	c.WRU += other.WRU
 }
@@ -378,8 +390,8 @@ func (kc *KVCalculator) payBackWriteCostWithDetail(consumption *rmpb.Consumption
 	consumption.WriteBytes -= writeBytes
 	consumption.WRU -= float64(kc.WriteBaseCost) + float64(kc.WriteBytesCost)*writeBytes
 	if detail != nil {
-		detail.Inputs.FailedWriteRPCCount++
-		detail.Inputs.FailedWriteBytes += writeBytes
+		detail.Inputs.FailedWriteBaseCostRefundCount++
+		detail.Inputs.FailedWriteRefundBytes += writeBytes
 	}
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #11178, ref pingcap/tidb#70251

TiDB reports the total RU consumed by a statement, but RU v1 users cannot see which request inputs and configured coefficients produced that total. The resource controller owns the authoritative calculation and effective coefficient configuration, so the detail must come from the same accounting path rather than be reconstructed later.

### What is changed and how does it work?

```commit-message
Expose RU v1 calculation inputs, the effective factor snapshot, and the actual RRU/WRU results from the existing KVCalculator path.

Add one optional request-scoped RUCalculationCollector. Existing OnRequestWait, OnResponse, and OnResponseWait methods populate it only when the request opts in.

Keep ResourceGroupKVInterceptor signatures, token accounting, limiting behavior, and RU v2 unchanged.
```

The effective PD controller configuration remains the source of truth. Each collected delta carries:

- the exact dynamic inputs used by the existing RU v1 calculator;
- the exact factor snapshot used for that calculation; and
- the actual RRU/WRU result returned by that calculation.

Downstream code can therefore format the inputs as a formula and independently compare its RRU and WRU components with the actual accounting results. PD does not maintain a second RU formula, and this PR introduces no protocol or kvproto change.

### Check List

Tests

- Unit test
- Integration test
- Manual test

Unit test:

```text
cd client
make gotest GOTEST_ARGS='./resource_group/controller -run TestRUCalculationDetail -count=1'
```

```text
ok github.com/tikv/pd/client/resource_group/controller
```

Changed-code lint:

```text
cd client
gofmt -s -l -d resource_group/controller
golangci-lint run -c ../.golangci.yml --new-from-rev=HEAD ./resource_group/controller --allow-parallel-runners
```

```text
0 issues.
```

Manual E2E used this PD PR (`d9b686cee60b`), client-go PR #2046 (`653c1824be20` for production code), TiDB PR pingcap/tidb#70543 (`72041e4b4b36`), and real PD/TiKV/TiDB processes. The schema contained 80 customers, 600 orders, 1,000 order items, JSON/ENUM columns, and unique/composite indexes.

Complex join/aggregate read:

```text
RU:5.72, RU_detail:RRU=read_rpc_count(5)*READ_BASE_COST(0.125)+read_rpc_count(5)*READ_PER_BATCH_BASE_COST(0.5)*BATCH_PROPORTION(0.7)+charged_read_bytes(219045)*READ_BYTES_COST(0.0000152587890625)=5.717361; RU=RRU(5.717361)=5.717361
```

`INSERT ... SELECT` inserted 120 rows:

```text
RU:49.86, RU_detail:RRU=read_rpc_count(4)*READ_BASE_COST(0.125)+read_rpc_count(4)*READ_PER_BATCH_BASE_COST(0.5)*BATCH_PROPORTION(0.7)+charged_read_bytes(309105)*READ_BYTES_COST(0.0000152587890625)=6.616568; WRU=replica_weighted_write_rpc_count(3)*WRITE_BASE_COST(1)+replica_weighted_write_rpc_count(3)*WRITE_PER_BATCH_BASE_COST(1)*BATCH_PROPORTION(0.7)+replica_weighted_write_bytes(39060)*WRITE_BYTES_COST(0.0009765625)=43.244531; RU=RRU(6.616568)+WRU(43.244531)=49.861099
```

`UPDATE` updated 65 rows:

```text
RU:18.99, RU_detail:RRU=read_rpc_count(1)*READ_BASE_COST(0.125)+read_rpc_count(1)*READ_PER_BATCH_BASE_COST(0.5)*BATCH_PROPORTION(0.7)+charged_read_bytes(79800)*READ_BYTES_COST(0.0000152587890625)=1.692651; WRU=replica_weighted_write_rpc_count(1)*WRITE_BASE_COST(1)+replica_weighted_write_rpc_count(1)*WRITE_PER_BATCH_BASE_COST(1)*BATCH_PROPORTION(0.7)+replica_weighted_write_bytes(15976)*WRITE_BYTES_COST(0.0009765625)=17.301563; RU=RRU(1.692651)+WRU(17.301563)=18.994214
```

Independent validation:

- Every displayed input/factor expression recomputed exactly to its displayed RRU or WRU at six-decimal display precision.
- The displayed RRU and WRU separately matched the existing authoritative slow-query `Request_unit_read` and `Request_unit_write` values at the same precision.
- Slow-log and `INFORMATION_SCHEMA.SLOW_QUERY` detail strings were byte-identical for all three statements.
- Changing the PD controller default to RU v2 removed `RU_detail` (`LENGTH(Request_unit_detail)=0`); changing it back to RU v1 restored the formula.
- No fatal, panic, or race record was found in the E2E process logs.

TiFlash Resource Control E2E:

- Added a second real-cluster pass with an official Linux/arm64 TiFlash nightly node (`v9.0.0-beta.2.pre-216-g8541997d4`), not a mock. The `customers`, `orders`, and `order_items` replicas all reached `AVAILABLE=1`.
- Resource Control was enabled (`@@tidb_enable_resource_control=1`). The plan used `mpp[tiflash]` table scans for all three tables, and the slow log reported `Storage_from_mpp: true` with TiFlash as the cop-task address.

```sql
EXPLAIN ANALYZE
SELECT /*ru_detail_e2e_tiflash_read*/
       c.region, c.tier, COUNT(DISTINCT o.order_id) AS order_count,
       ROUND(SUM(oi.qty * oi.unit_price), 2) AS gross
FROM customers c
JOIN orders o ON o.customer_id = c.customer_id
JOIN order_items oi ON oi.order_id = o.order_id
WHERE o.status IN ('PAID', 'SHIPPED')
  AND o.amount BETWEEN 100 AND 700
  AND JSON_EXTRACT(oi.attributes, '$.warehouse') IN ('east', 'west')
GROUP BY c.region, c.tier
HAVING gross > 500
ORDER BY gross DESC
LIMIT 8;
```

```text
Projection_24 ... task:root ... RU:3.83, RU_detail:RU=tiflash_ru(3.827052)=3.827052
└─ExchangeSender_76 ... task:mpp[tiflash]
  └─TableFullScan_75 ... task:mpp[tiflash] table:customers
...
# Request_unit_read: 3.827051798502604
# Storage_from_mpp: true
# Request_unit_detail: RU=tiflash_ru(3.827052)=3.827052
```

The raw TiFlash RU rounds to `3.827052`, exactly matching the EXPLAIN formula component. Slow-log and `INFORMATION_SCHEMA.SLOW_QUERY.REQUEST_UNIT_DETAIL` were byte-identical. TiFlash currently reports its final `Consumption` rather than the underlying coefficient inputs, so it is intentionally shown as the explicit opaque `tiflash_ru(...)` term. The earlier real-TiKV E2E continues to cover writes; a forced `INSERT ... SELECT` was not counted as TiFlash coverage because TiDB disallows MPP for non-read-only statements in strict SQL mode and executed that statement on TiKV.

Related changes:

- client-go: https://github.com/tikv/client-go/pull/2046
- TiDB: https://github.com/pingcap/tidb/pull/70543

### Release note

```release-note
Expose RU v1 calculation inputs, effective coefficients, and actual component results to downstream clients for query observability.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detailed Request Unit (RU) calculation reporting for supported requests.
  * RU details can include factor snapshots, read, processing, write, paging, replica, retry, and failed-write information.
  * Added aggregation of RU calculation details across operations.

* **Bug Fixes**
  * Preserved existing RU consumption behavior for requests that do not collect detailed calculation data.
  * Improved accuracy of full-accounting and failed-write refund calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->