### PR TITLE
statistics, schedule: stop republishing metrics for a known-tombstoned store

### DIFF
--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -328,6 +328,7 @@ func (c *Cluster) SetRuntimeResources(
 	c.affinityWatcher = affinityWatcher
 	metaWatcher.SetOnStoreTombstoned(func(storeID uint64) {
 		c.hotStat.RemoveRollingStoreStats(storeID)
+		c.ruleManager.RemoveStoreCache(storeID)
 		DeleteStoreMetrics(strconv.FormatUint(storeID, 10))
 	})
 }

--- a/pkg/schedule/checker/rule_checker.go
+++ b/pkg/schedule/checker/rule_checker.go
@@ -132,7 +132,7 @@ func (c *RuleChecker) CheckWithFit(region *core.RegionInfo, fit *placement.Regio
 	if c.cluster.GetCheckerConfig().IsPlacementRulesCacheEnabled() {
 		if placement.ValidateFit(fit) && placement.ValidateRegion(region) && placement.ValidateStores(fit.GetRegionStores()) {
 			// If there is no need to fix, we will cache the fit
-			c.ruleManager.SetRegionFitCache(region, fit)
+			c.ruleManager.SetRegionFitCache(c.cluster, region, fit)
 			ruleCheckerSetCacheCounter.Inc()
 		}
 	}

--- a/pkg/schedule/checker/rule_checker.go
+++ b/pkg/schedule/checker/rule_checker.go
@@ -693,7 +693,7 @@ func (o *recorder) refresh(cluster sche.CheckerCluster) {
 	// re-count the offlineLeaderCounter if the store is already tombstone or store is gone.
 	if len(o.offlineLeaderCounter) > 0 && time.Since(o.lastUpdateTime) > offlineCounterTTL {
 		needClean := false
-		for _, storeID := range o.offlineLeaderCounter {
+		for storeID := range o.offlineLeaderCounter {
 			store := cluster.GetStore(storeID)
 			if store == nil || store.IsRemoved() {
 				needClean = true

--- a/pkg/schedule/checker/rule_checker_test.go
+++ b/pkg/schedule/checker/rule_checker_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/pingcap/failpoint"
@@ -2630,4 +2631,25 @@ func (suite *ruleCheckerTestSuite) TestFixBetterLocationEngineConstraint() {
 	region2 := suite.cluster.GetRegion(2)
 	op = suite.rc.Check(region2)
 	re.Empty(op)
+}
+
+func TestRecorderRefreshLooksUpStoreIDNotCount(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cluster := mockcluster.NewCluster(ctx, mockconfig.NewTestOptions())
+	// Store 5 exists and is live -- it's the counter *value* below, not a
+	// store ID. Store 999, the counter's real key, is never registered.
+	cluster.AddRegionStore(5, 0)
+
+	rec := newRecord()
+	rec.offlineLeaderCounter[999] = 5
+	rec.lastUpdateTime = time.Now().Add(-offlineCounterTTL - time.Minute)
+
+	// If refresh's loop bound its range variable to the map value instead of
+	// the key, it would look up store 5 (found, live) instead of store 999
+	// (not found) and wrongly conclude nothing needs cleaning.
+	rec.refresh(cluster)
+
+	re.Empty(rec.offlineLeaderCounter)
 }

--- a/pkg/schedule/coordinator.go
+++ b/pkg/schedule/coordinator.go
@@ -535,7 +535,15 @@ func collectHotMetrics(cluster sche.ClusterInformer, stores []*core.StoreInfo, t
 		storeAddress := s.GetAddress()
 		storeID := s.GetID()
 		storeLabel := strconv.FormatUint(storeID, 10)
+		// HotPeerCache.gc() only removes a tombstoned store from status.AsLeader/
+		// AsPeer's source data on its own TTL-throttled schedule, not every tick,
+		// so a known-tombstoned store here can still have stale hot-peer data.
+		// Treat it as not hot regardless, so the delete branches below run
+		// instead of republishing hotSpotStatusGauge every tick until
+		// HotPeerCache.gc() eventually catches up.
+		removed := s.IsRemoved()
 		stat, hasHotLeader := status.AsLeader[storeID]
+		hasHotLeader = hasHotLeader && !removed
 		if hasHotLeader {
 			hotSpotStatusGauge.WithLabelValues(storeAddress, storeLabel, "total_"+kind+"_bytes_as_leader").Set(stat.TotalBytesRate)
 			hotSpotStatusGauge.WithLabelValues(storeAddress, storeLabel, "total_"+kind+"_keys_as_leader").Set(stat.TotalKeysRate)
@@ -551,6 +559,7 @@ func collectHotMetrics(cluster sche.ClusterInformer, stores []*core.StoreInfo, t
 		}
 
 		stat, hasHotPeer := status.AsPeer[storeID]
+		hasHotPeer = hasHotPeer && !removed
 		if hasHotPeer {
 			hotSpotStatusGauge.WithLabelValues(storeAddress, storeLabel, "total_"+kind+"_bytes_as_peer").Set(stat.TotalBytesRate)
 			hotSpotStatusGauge.WithLabelValues(storeAddress, storeLabel, "total_"+kind+"_keys_as_peer").Set(stat.TotalKeysRate)
@@ -578,7 +587,7 @@ func collectHotMetrics(cluster sche.ClusterInformer, stores []*core.StoreInfo, t
 		// iteration's own s was still live: once a snapshot correctly shows
 		// IsRemoved(), a tombstoned store sitting in GetStores() for up to 30
 		// days doesn't cost a scan on every tick.
-		if !s.IsRemoved() {
+		if !removed {
 			if store := cluster.GetStore(storeID); store == nil || store.IsRemoved() {
 				DeleteStoreMetrics(storeLabel)
 			}

--- a/pkg/schedule/placement/region_rule_cache.go
+++ b/pkg/schedule/placement/region_rule_cache.go
@@ -86,7 +86,7 @@ func (manager *RegionRuleFitCacheManager) CheckAndGetCache(region *core.RegionIn
 }
 
 // SetCache stores RegionFit cache
-func (manager *RegionRuleFitCacheManager) SetCache(region *core.RegionInfo, fit *RegionFit) {
+func (manager *RegionRuleFitCacheManager) SetCache(storeSet StoreSet, region *core.RegionInfo, fit *RegionFit) {
 	if !ValidateRegion(region) || !ValidateFit(fit) || !ValidateStores(fit.regionStores) {
 		return
 	}
@@ -99,7 +99,7 @@ func (manager *RegionRuleFitCacheManager) SetCache(region *core.RegionInfo, fit 
 		}
 		return
 	}
-	manager.regionCaches[region.GetID()] = manager.toRegionRuleFitCache(region, fit)
+	manager.regionCaches[region.GetID()] = manager.toRegionRuleFitCache(storeSet, region, fit)
 }
 
 // regionRuleFitCache stores regions RegionFit result and involving variables
@@ -146,10 +146,10 @@ func storesEqual(a []*storeCache, b []*core.StoreInfo) bool {
 	})
 }
 
-func (manager *RegionRuleFitCacheManager) toRegionRuleFitCache(region *core.RegionInfo, fit *RegionFit) *regionRuleFitCache {
+func (manager *RegionRuleFitCacheManager) toRegionRuleFitCache(storeSet StoreSet, region *core.RegionInfo, fit *RegionFit) *regionRuleFitCache {
 	return &regionRuleFitCache{
 		region:       toRegionCache(region),
-		regionStores: manager.toStoreCacheList(fit.regionStores),
+		regionStores: manager.toStoreCacheList(storeSet, fit.regionStores),
 		rules:        toRuleCacheList(fit.rules),
 		bestFit:      nil,
 		hitCount:     0,
@@ -197,7 +197,7 @@ func (s storeCache) storeEqual(store *core.StoreInfo) bool {
 		labelEqual(s.labels, store.GetLabels())
 }
 
-func (manager *RegionRuleFitCacheManager) toStoreCacheList(stores []*core.StoreInfo) (c []*storeCache) {
+func (manager *RegionRuleFitCacheManager) toStoreCacheList(storeSet StoreSet, stores []*core.StoreInfo) (c []*storeCache) {
 	for _, s := range stores {
 		sCache, ok := manager.storeCaches[s.GetID()]
 		if !ok || !sCache.storeEqual(s) {
@@ -211,10 +211,13 @@ func (manager *RegionRuleFitCacheManager) toStoreCacheList(stores []*core.StoreI
 				state:   s.GetState(),
 			}
 			// A removed store's entry is only ever cleared once, when it's
-			// buried or finally removed; a stale RegionInfo snapshot that
-			// still lists it as a peer must not re-add it here, or it would
-			// linger in storeCaches for good since nothing sweeps it again.
-			if !s.IsRemoved() {
+			// buried or finally removed; nothing sweeps it again after that.
+			// The stores slice can be a stale RegionInfo snapshot taken before
+			// a store was buried, so re-check the store fresh through storeSet
+			// here rather than trusting s.IsRemoved() -- otherwise a store that
+			// was buried while this same FitRegion call was still computing
+			// could get re-added and linger in storeCaches for good.
+			if current := storeSet.GetStore(s.GetID()); current != nil && !current.IsRemoved() {
 				manager.storeCaches[s.GetID()] = sCache
 			}
 		}

--- a/pkg/schedule/placement/region_rule_cache.go
+++ b/pkg/schedule/placement/region_rule_cache.go
@@ -95,6 +95,20 @@ func (manager *RegionRuleFitCacheManager) SetCache(storeSet StoreSet, region *co
 	if cache, ok := manager.regionCaches[region.GetID()]; ok {
 		cache.hitCount++
 		if cache.hitCount >= minHitCountToCacheHit {
+			if !allStoresLive(storeSet, fit.regionStores) {
+				// fit may have been computed from a stale, pre-bury snapshot
+				// held by an in-flight FitRegion call. Promoting it (or
+				// leaving the entry as-is for another in-flight caller with
+				// an equally stale snapshot to consume via CheckAndGetCache,
+				// which compares against this cache's own frozen
+				// regionStores rather than re-checking storeSet) would let a
+				// removed store's placement result leak into a real
+				// scheduling decision. Evict the entry instead, so the next
+				// caller recomputes and re-validates through the cacheable
+				// path below.
+				delete(manager.regionCaches, region.GetID())
+				return
+			}
 			cache.bestFit = fit
 		}
 		return
@@ -104,6 +118,17 @@ func (manager *RegionRuleFitCacheManager) SetCache(storeSet StoreSet, region *co
 		return
 	}
 	manager.regionCaches[region.GetID()] = newCache
+}
+
+// allStoresLive reports whether every store is currently known and not removed.
+func allStoresLive(storeSet StoreSet, stores []*core.StoreInfo) bool {
+	for _, s := range stores {
+		current := storeSet.GetStore(s.GetID())
+		if current == nil || current.IsRemoved() {
+			return false
+		}
+	}
+	return true
 }
 
 // regionRuleFitCache stores regions RegionFit result and involving variables

--- a/pkg/schedule/placement/region_rule_cache.go
+++ b/pkg/schedule/placement/region_rule_cache.go
@@ -53,6 +53,13 @@ func NewRegionRuleFitCacheManager() *RegionRuleFitCacheManager {
 	}
 }
 
+// RemoveStoreCache removes the store cache with a given store ID.
+func (manager *RegionRuleFitCacheManager) RemoveStoreCache(storeID uint64) {
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	delete(manager.storeCaches, storeID)
+}
+
 // Invalid cache by regionID
 func (manager *RegionRuleFitCacheManager) Invalid(regionID uint64) {
 	manager.mu.Lock()
@@ -203,7 +210,13 @@ func (manager *RegionRuleFitCacheManager) toStoreCacheList(stores []*core.StoreI
 				labels:  m,
 				state:   s.GetState(),
 			}
-			manager.storeCaches[s.GetID()] = sCache
+			// A removed store's entry is only ever cleared once, when it's
+			// buried or finally removed; a stale RegionInfo snapshot that
+			// still lists it as a peer must not re-add it here, or it would
+			// linger in storeCaches for good since nothing sweeps it again.
+			if !s.IsRemoved() {
+				manager.storeCaches[s.GetID()] = sCache
+			}
 		}
 		c = append(c, sCache)
 	}

--- a/pkg/schedule/placement/region_rule_cache.go
+++ b/pkg/schedule/placement/region_rule_cache.go
@@ -43,28 +43,70 @@ type RegionRuleFitCacheManager struct {
 	mu           syncutil.RWMutex
 	regionCaches map[uint64]*regionRuleFitCache
 	storeCaches  map[uint64]*storeCache
+	// storesOfRegion is a reverse index from storeID to the IDs of cached
+	// regions whose fit references it. SetCache's existing-entry promotion
+	// path (the hitCount>=minHitCountToCacheHit branch) re-checks storeSet
+	// freshness through allStoresLive, but that read is not synchronized
+	// with a concurrent bury: allStoresLive/storeSet.GetStore reads
+	// StoresInfo's own lock, entirely independent of manager.mu, so a
+	// promotion can still land using a pre-bury snapshot after the bury
+	// completed. Unlike storeCaches, regionCaches has no other path that
+	// gets swept when a store is removed, so RemoveStoreCache uses this
+	// index to evict any region cache entry that referenced the removed
+	// store, closing that gap.
+	storesOfRegion map[uint64]map[uint64]struct{}
 }
 
 // NewRegionRuleFitCacheManager returns RegionRuleFitCacheManager
 func NewRegionRuleFitCacheManager() *RegionRuleFitCacheManager {
 	return &RegionRuleFitCacheManager{
-		regionCaches: make(map[uint64]*regionRuleFitCache),
-		storeCaches:  make(map[uint64]*storeCache),
+		regionCaches:   make(map[uint64]*regionRuleFitCache),
+		storeCaches:    make(map[uint64]*storeCache),
+		storesOfRegion: make(map[uint64]map[uint64]struct{}),
 	}
 }
 
-// RemoveStoreCache removes the store cache with a given store ID.
+// RemoveStoreCache removes the store cache with a given store ID, and evicts
+// any region cache entry whose fit referenced it.
 func (manager *RegionRuleFitCacheManager) RemoveStoreCache(storeID uint64) {
 	manager.mu.Lock()
 	defer manager.mu.Unlock()
 	delete(manager.storeCaches, storeID)
+	regionIDs := make([]uint64, 0, len(manager.storesOfRegion[storeID]))
+	for regionID := range manager.storesOfRegion[storeID] {
+		regionIDs = append(regionIDs, regionID)
+	}
+	for _, regionID := range regionIDs {
+		manager.removeRegionCacheLocked(regionID)
+	}
+	delete(manager.storesOfRegion, storeID)
 }
 
 // Invalid cache by regionID
 func (manager *RegionRuleFitCacheManager) Invalid(regionID uint64) {
 	manager.mu.Lock()
 	defer manager.mu.Unlock()
+	manager.removeRegionCacheLocked(regionID)
+}
+
+// removeRegionCacheLocked deletes a region's cache entry and the
+// storesOfRegion index entries it registered. Callers must hold manager.mu.
+func (manager *RegionRuleFitCacheManager) removeRegionCacheLocked(regionID uint64) {
+	cache, ok := manager.regionCaches[regionID]
+	if !ok {
+		return
+	}
 	delete(manager.regionCaches, regionID)
+	for _, sc := range cache.regionStores {
+		regions, ok := manager.storesOfRegion[sc.storeID]
+		if !ok {
+			continue
+		}
+		delete(regions, regionID)
+		if len(regions) == 0 {
+			delete(manager.storesOfRegion, sc.storeID)
+		}
+	}
 }
 
 // CheckAndGetCache checks whether the region and rules are changed for the stored cache
@@ -106,7 +148,7 @@ func (manager *RegionRuleFitCacheManager) SetCache(storeSet StoreSet, region *co
 				// scheduling decision. Evict the entry instead, so the next
 				// caller recomputes and re-validates through the cacheable
 				// path below.
-				delete(manager.regionCaches, region.GetID())
+				manager.removeRegionCacheLocked(region.GetID())
 				return
 			}
 			cache.bestFit = fit
@@ -177,6 +219,17 @@ func storesEqual(a []*storeCache, b []*core.StoreInfo) bool {
 
 func (manager *RegionRuleFitCacheManager) toRegionRuleFitCache(storeSet StoreSet, region *core.RegionInfo, fit *RegionFit) (*regionRuleFitCache, bool) {
 	storeCacheList, cacheable := manager.toStoreCacheList(storeSet, fit.regionStores)
+	if cacheable {
+		regionID := region.GetID()
+		for _, sc := range storeCacheList {
+			regions, ok := manager.storesOfRegion[sc.storeID]
+			if !ok {
+				regions = make(map[uint64]struct{})
+				manager.storesOfRegion[sc.storeID] = regions
+			}
+			regions[regionID] = struct{}{}
+		}
+	}
 	return &regionRuleFitCache{
 		region:       toRegionCache(region),
 		regionStores: storeCacheList,

--- a/pkg/schedule/placement/region_rule_cache.go
+++ b/pkg/schedule/placement/region_rule_cache.go
@@ -99,7 +99,11 @@ func (manager *RegionRuleFitCacheManager) SetCache(storeSet StoreSet, region *co
 		}
 		return
 	}
-	manager.regionCaches[region.GetID()] = manager.toRegionRuleFitCache(storeSet, region, fit)
+	newCache, cacheable := manager.toRegionRuleFitCache(storeSet, region, fit)
+	if !cacheable {
+		return
+	}
+	manager.regionCaches[region.GetID()] = newCache
 }
 
 // regionRuleFitCache stores regions RegionFit result and involving variables
@@ -146,14 +150,15 @@ func storesEqual(a []*storeCache, b []*core.StoreInfo) bool {
 	})
 }
 
-func (manager *RegionRuleFitCacheManager) toRegionRuleFitCache(storeSet StoreSet, region *core.RegionInfo, fit *RegionFit) *regionRuleFitCache {
+func (manager *RegionRuleFitCacheManager) toRegionRuleFitCache(storeSet StoreSet, region *core.RegionInfo, fit *RegionFit) (*regionRuleFitCache, bool) {
+	storeCacheList, cacheable := manager.toStoreCacheList(storeSet, fit.regionStores)
 	return &regionRuleFitCache{
 		region:       toRegionCache(region),
-		regionStores: manager.toStoreCacheList(storeSet, fit.regionStores),
+		regionStores: storeCacheList,
 		rules:        toRuleCacheList(fit.rules),
 		bestFit:      nil,
 		hitCount:     0,
-	}
+	}, cacheable
 }
 
 type ruleCache struct {
@@ -197,8 +202,21 @@ func (s storeCache) storeEqual(store *core.StoreInfo) bool {
 		labelEqual(s.labels, store.GetLabels())
 }
 
-func (manager *RegionRuleFitCacheManager) toStoreCacheList(storeSet StoreSet, stores []*core.StoreInfo) (c []*storeCache) {
+func (manager *RegionRuleFitCacheManager) toStoreCacheList(storeSet StoreSet, stores []*core.StoreInfo) (c []*storeCache, cacheable bool) {
+	cacheable = true
 	for _, s := range stores {
+		// The stores slice can be a stale RegionInfo/FitRegion snapshot taken
+		// before a store was buried, so re-check the store fresh through
+		// storeSet rather than trusting s.IsRemoved(). If any current store is
+		// missing or removed, the caller must not persist a region-level cache
+		// entry either -- one built from this stale snapshot would otherwise
+		// look valid (region/rule/store-state comparisons all pass) and never
+		// get re-evaluated until an unrelated region-level change invalidates
+		// it.
+		current := storeSet.GetStore(s.GetID())
+		if current == nil || current.IsRemoved() {
+			cacheable = false
+		}
 		sCache, ok := manager.storeCaches[s.GetID()]
 		if !ok || !sCache.storeEqual(s) {
 			m := make(map[string]string)
@@ -212,18 +230,13 @@ func (manager *RegionRuleFitCacheManager) toStoreCacheList(storeSet StoreSet, st
 			}
 			// A removed store's entry is only ever cleared once, when it's
 			// buried or finally removed; nothing sweeps it again after that.
-			// The stores slice can be a stale RegionInfo snapshot taken before
-			// a store was buried, so re-check the store fresh through storeSet
-			// here rather than trusting s.IsRemoved() -- otherwise a store that
-			// was buried while this same FitRegion call was still computing
-			// could get re-added and linger in storeCaches for good.
-			if current := storeSet.GetStore(s.GetID()); current != nil && !current.IsRemoved() {
+			if current != nil && !current.IsRemoved() {
 				manager.storeCaches[s.GetID()] = sCache
 			}
 		}
 		c = append(c, sCache)
 	}
-	return c
+	return c, cacheable
 }
 
 func labelEqual(label1 map[string]string, label2 []*metapb.StoreLabel) bool {

--- a/pkg/schedule/placement/region_rule_cache_test.go
+++ b/pkg/schedule/placement/region_rule_cache_test.go
@@ -217,9 +217,13 @@ func TestPublicStoreCaches(t *testing.T) {
 }
 
 func (manager *RegionRuleFitCacheManager) mockRegionRuleFitCache(region *core.RegionInfo, rules []*Rule, regionStores []*core.StoreInfo) *regionRuleFitCache {
+	storeSet := core.NewStoresInfo()
+	for _, s := range regionStores {
+		storeSet.PutStore(s)
+	}
 	return &regionRuleFitCache{
 		region:       toRegionCache(region),
-		regionStores: manager.toStoreCacheList(regionStores),
+		regionStores: manager.toStoreCacheList(storeSet, regionStores),
 		rules:        toRuleCacheList(rules),
 		bestFit: &RegionFit{
 			regionStores: regionStores,

--- a/pkg/schedule/placement/region_rule_cache_test.go
+++ b/pkg/schedule/placement/region_rule_cache_test.go
@@ -265,6 +265,36 @@ func TestToStoreCacheListReturnsUncacheableForRemovedStore(t *testing.T) {
 	re.False(cacheable)
 }
 
+func TestSetCacheDoesNotPromoteStaleFitAfterStoreRemoval(t *testing.T) {
+	re := require.New(t)
+	manager := NewRegionRuleFitCacheManager()
+
+	stores := mockStores(3)
+	storeSet := core.NewStoresInfo()
+	for _, store := range stores {
+		storeSet.PutStore(store)
+	}
+	region := mockRegion(3, 0)
+	rules := addExtraRules(0)
+	fit := fitRegion(stores, region, rules, false)
+	fit.regionStores = stores
+	fit.rules = rules
+
+	manager.SetCache(storeSet, region, fit)
+	cache := manager.regionCaches[region.GetID()]
+	re.NotNil(cache)
+	cache.hitCount = minHitCountToCacheHit - 1
+
+	manager.RemoveStoreCache(stores[0].GetID())
+	storeSet.PutStore(stores[0].Clone(
+		core.SetStoreState(metapb.StoreState_Tombstone),
+	))
+
+	manager.SetCache(storeSet, region, fit) // stale pre-bury fit
+	cache, ok := manager.regionCaches[region.GetID()]
+	re.False(ok && cache.bestFit != nil)
+}
+
 func (manager *RegionRuleFitCacheManager) mockRegionRuleFitCache(region *core.RegionInfo, rules []*Rule, regionStores []*core.StoreInfo) *regionRuleFitCache {
 	storeSet := core.NewStoresInfo()
 	for _, s := range regionStores {

--- a/pkg/schedule/placement/region_rule_cache_test.go
+++ b/pkg/schedule/placement/region_rule_cache_test.go
@@ -295,6 +295,63 @@ func TestSetCacheDoesNotPromoteStaleFitAfterStoreRemoval(t *testing.T) {
 	re.False(ok && cache.bestFit != nil)
 }
 
+// buryAfterReadStoreSet wraps a *core.StoresInfo and buries the target store
+// as a side effect of the first GetStore(target) call, but still returns the
+// pre-bury snapshot from that same call -- modeling allStoresLive's read
+// racing a concurrent bury that completes between its read and SetCache
+// using the result, since the two are not synchronized by manager.mu.
+type buryAfterReadStoreSet struct {
+	*core.StoresInfo
+	target uint64
+	buried bool
+}
+
+func (s *buryAfterReadStoreSet) GetStore(id uint64) *core.StoreInfo {
+	store := s.StoresInfo.GetStore(id)
+	if id == s.target && !s.buried {
+		s.buried = true
+		s.StoresInfo.PutStore(store.Clone(
+			core.SetStoreState(metapb.StoreState_Tombstone),
+		))
+	}
+	return store
+}
+
+func TestSetCachePromotionCannotRaceStoreRemoval(t *testing.T) {
+	re := require.New(t)
+	manager := NewRegionRuleFitCacheManager()
+
+	stores := mockStores(3)
+	storeSet := core.NewStoresInfo()
+	for _, store := range stores {
+		storeSet.PutStore(store)
+	}
+	region := mockRegion(3, 0)
+	rules := addExtraRules(0)
+	fit := fitRegion(stores, region, rules, false)
+	fit.regionStores = stores
+	fit.rules = rules
+
+	manager.SetCache(storeSet, region, fit)
+	cache := manager.regionCaches[region.GetID()]
+	re.NotNil(cache)
+	cache.hitCount = minHitCountToCacheHit - 1
+
+	// allStoresLive reads the last store as still live (the pre-bury
+	// snapshot), then the bury completes as a side effect of that same read;
+	// the promotion below still goes through and writes cache.bestFit.
+	target := stores[len(stores)-1].GetID()
+	racingStoreSet := &buryAfterReadStoreSet{StoresInfo: storeSet, target: target}
+	manager.SetCache(racingStoreSet, region, fit)
+
+	// The cleanup that would normally run right after the bury completes.
+	manager.RemoveStoreCache(target)
+
+	hit, cachedFit := manager.CheckAndGetCache(region, rules, stores)
+	re.False(hit)
+	re.Nil(cachedFit)
+}
+
 func (manager *RegionRuleFitCacheManager) mockRegionRuleFitCache(region *core.RegionInfo, rules []*Rule, regionStores []*core.StoreInfo) *regionRuleFitCache {
 	storeSet := core.NewStoresInfo()
 	for _, s := range regionStores {

--- a/pkg/schedule/placement/region_rule_cache_test.go
+++ b/pkg/schedule/placement/region_rule_cache_test.go
@@ -240,14 +240,40 @@ func TestToStoreCacheListDoesNotReinsertStaleStore(t *testing.T) {
 	re.False(ok)
 }
 
+func TestToStoreCacheListReturnsUncacheableForRemovedStore(t *testing.T) {
+	re := require.New(t)
+	manager := NewRegionRuleFitCacheManager()
+	live := core.NewStoreInfo(&metapb.Store{
+		Id:        1,
+		NodeState: metapb.NodeState_Serving,
+	})
+	storeSet := core.NewStoresInfo()
+	storeSet.PutStore(live)
+
+	_, cacheable := manager.toStoreCacheList(storeSet, []*core.StoreInfo{live})
+	re.True(cacheable)
+
+	// storeSet now shows the store removed while the stores slice still holds
+	// the stale (pre-bury) snapshot -- SetCache must not persist a
+	// region-level cache built from this call, or it would look valid
+	// (region/rule/store-state comparisons all pass against the same stale
+	// snapshot) and never get re-evaluated until an unrelated region-level
+	// change invalidates it.
+	removed := live.Clone(core.SetStoreState(metapb.StoreState_Tombstone))
+	storeSet.PutStore(removed)
+	_, cacheable = manager.toStoreCacheList(storeSet, []*core.StoreInfo{live})
+	re.False(cacheable)
+}
+
 func (manager *RegionRuleFitCacheManager) mockRegionRuleFitCache(region *core.RegionInfo, rules []*Rule, regionStores []*core.StoreInfo) *regionRuleFitCache {
 	storeSet := core.NewStoresInfo()
 	for _, s := range regionStores {
 		storeSet.PutStore(s)
 	}
+	storeCacheList, _ := manager.toStoreCacheList(storeSet, regionStores)
 	return &regionRuleFitCache{
 		region:       toRegionCache(region),
-		regionStores: manager.toStoreCacheList(storeSet, regionStores),
+		regionStores: storeCacheList,
 		rules:        toRuleCacheList(rules),
 		bestFit: &RegionFit{
 			regionStores: regionStores,

--- a/pkg/schedule/placement/region_rule_cache_test.go
+++ b/pkg/schedule/placement/region_rule_cache_test.go
@@ -216,6 +216,30 @@ func TestPublicStoreCaches(t *testing.T) {
 	}
 }
 
+func TestToStoreCacheListDoesNotReinsertStaleStore(t *testing.T) {
+	re := require.New(t)
+	manager := NewRegionRuleFitCacheManager()
+	live := core.NewStoreInfo(&metapb.Store{
+		Id:        1,
+		NodeState: metapb.NodeState_Serving,
+	})
+	// storeSet reflects the live, current cluster state; the stores slice
+	// passed to toStoreCacheList simulates a FitRegion call still holding an
+	// older StoreInfo snapshot taken before the store was buried.
+	storeSet := core.NewStoresInfo()
+	storeSet.PutStore(live)
+
+	manager.toStoreCacheList(storeSet, []*core.StoreInfo{live})
+	manager.RemoveStoreCache(1)
+
+	removed := live.Clone(core.SetStoreState(metapb.StoreState_Tombstone))
+	storeSet.PutStore(removed)
+	manager.toStoreCacheList(storeSet, []*core.StoreInfo{live}) // stale FitRegion snapshot
+
+	_, ok := manager.storeCaches[1]
+	re.False(ok)
+}
+
 func (manager *RegionRuleFitCacheManager) mockRegionRuleFitCache(region *core.RegionInfo, rules []*Rule, regionStores []*core.StoreInfo) *regionRuleFitCache {
 	storeSet := core.NewStoresInfo()
 	for _, s := range regionStores {

--- a/pkg/schedule/placement/region_rule_cache_test.go
+++ b/pkg/schedule/placement/region_rule_cache_test.go
@@ -310,7 +310,7 @@ func (s *buryAfterReadStoreSet) GetStore(id uint64) *core.StoreInfo {
 	store := s.StoresInfo.GetStore(id)
 	if id == s.target && !s.buried {
 		s.buried = true
-		s.StoresInfo.PutStore(store.Clone(
+		s.PutStore(store.Clone(
 			core.SetStoreState(metapb.StoreState_Tombstone),
 		))
 	}

--- a/pkg/schedule/placement/rule_manager.go
+++ b/pkg/schedule/placement/rule_manager.go
@@ -453,14 +453,14 @@ func (m *RuleManager) FitRegion(storeSet StoreSet, region *core.RegionInfo) (fit
 	fit.regionStores = regionStores
 	fit.rules = rules
 	if isCached {
-		m.SetRegionFitCache(region, fit)
+		m.SetRegionFitCache(storeSet, region, fit)
 	}
 	return fit
 }
 
 // SetRegionFitCache sets RegionFitCache
-func (m *RuleManager) SetRegionFitCache(region *core.RegionInfo, fit *RegionFit) {
-	m.cache.SetCache(region, fit)
+func (m *RuleManager) SetRegionFitCache(storeSet StoreSet, region *core.RegionInfo, fit *RegionFit) {
+	m.cache.SetCache(storeSet, region, fit)
 }
 
 // InvalidCache invalids the cache.

--- a/pkg/schedule/placement/rule_manager.go
+++ b/pkg/schedule/placement/rule_manager.go
@@ -468,6 +468,11 @@ func (m *RuleManager) InvalidCache(regionID uint64) {
 	m.cache.Invalid(regionID)
 }
 
+// RemoveStoreCache removes the store cache with a given store ID.
+func (m *RuleManager) RemoveStoreCache(storeID uint64) {
+	m.cache.RemoveStoreCache(storeID)
+}
+
 // SetPlaceholderRegionFitCache sets a placeholder region fit cache information
 // Only used for testing
 func (m *RuleManager) SetPlaceholderRegionFitCache(region *core.RegionInfo) {

--- a/pkg/schedule/placement/rule_manager_test.go
+++ b/pkg/schedule/placement/rule_manager_test.go
@@ -482,7 +482,7 @@ func TestCacheManager(t *testing.T) {
 	}
 	region := core.NewRegionInfo(regionMeta, regionMeta.Peers[0])
 	fit := manager.FitRegion(stores, region)
-	manager.SetRegionFitCache(region, fit)
+	manager.SetRegionFitCache(stores, region, fit)
 	// bestFit is not stored when the total number of hits is insufficient.
 	for i := 1; i < minHitCountToCacheHit/2; i++ {
 		manager.FitRegion(stores, region)

--- a/pkg/schedule/schedulers/evict_slow_store.go
+++ b/pkg/schedule/schedulers/evict_slow_store.go
@@ -662,6 +662,17 @@ func (s *evictSlowStoreScheduler) detectAndHandleNetworkSlowStores(cluster sche.
 		if isNetworkSlowStore(cluster, store, liveStores, problematicNetwork, networkSlowStoreRecoverStartAts) {
 			storeID := store.GetID()
 
+			// liveStores is a snapshot taken at the top of this function; the
+			// evaluation above can still run against a store's stale, frozen
+			// data if it was tombstoned after the snapshot but before this
+			// point. Re-check right before acting narrows, but doesn't
+			// eliminate, that window -- the next round's
+			// tryRecoverNetworkSlowStores would undo a slip-through, so any
+			// residual publication is bounded to one round.
+			if current := cluster.GetStore(storeID); current == nil || current.IsRemoved() {
+				continue
+			}
+
 			if len(pausedNetworkSlowStores) >= defaultMaxNetworkSlowStore {
 				failpoint.InjectCall("evictSlowStoreTriggerLimit")
 				slowStoreTriggerLimitGauge.WithLabelValues(strconv.FormatUint(storeID, 10), string(networkSlowStore)).Inc()

--- a/pkg/schedule/schedulers/evict_slow_store.go
+++ b/pkg/schedule/schedulers/evict_slow_store.go
@@ -585,7 +585,7 @@ func (s *evictSlowStoreScheduler) tryRecoverNetworkSlowStores(cluster sche.Sched
 			continue
 		}
 
-		networkSlowScores := filterNetworkSlowScores(store.GetNetworkSlowScores(), networkSlowStoreRecoverStartAts)
+		networkSlowScores := filterNetworkSlowScores(cluster, store.GetNetworkSlowScores(), networkSlowStoreRecoverStartAts)
 		avgScore := calculateAvgScore(networkSlowScores)
 
 		// Recover the slow store only if the recoveryGap time is
@@ -651,7 +651,7 @@ func (s *evictSlowStoreScheduler) detectAndHandleNetworkSlowStores(cluster sche.
 	pausedNetworkSlowStores := s.conf.PausedNetworkSlowStores
 
 	// Build problematic network map
-	problematicNetwork := buildProblematicNetworkMap(liveStores, networkSlowStoreRecoverStartAts)
+	problematicNetwork := buildProblematicNetworkMap(cluster, liveStores, networkSlowStoreRecoverStartAts)
 
 	// Evaluate each store for network slowness
 	for _, store := range liveStores {
@@ -659,7 +659,7 @@ func (s *evictSlowStoreScheduler) detectAndHandleNetworkSlowStores(cluster sche.
 			continue
 		}
 
-		if isNetworkSlowStore(store, liveStores, problematicNetwork, networkSlowStoreRecoverStartAts) {
+		if isNetworkSlowStore(cluster, store, liveStores, problematicNetwork, networkSlowStoreRecoverStartAts) {
 			storeID := store.GetID()
 
 			if len(pausedNetworkSlowStores) >= defaultMaxNetworkSlowStore {
@@ -676,6 +676,7 @@ func (s *evictSlowStoreScheduler) detectAndHandleNetworkSlowStores(cluster sche.
 
 // buildProblematicNetworkMap builds a map of stores with problematic network connections
 func buildProblematicNetworkMap(
+	cluster sche.SchedulerCluster,
 	stores []*core.StoreInfo,
 	networkSlowStoreRecoverStartAts map[uint64]*time.Time,
 ) map[uint64]map[uint64]struct{} {
@@ -687,7 +688,7 @@ func buildProblematicNetworkMap(
 			continue
 		}
 
-		networkSlowScores := filterNetworkSlowScores(store.GetNetworkSlowScores(), networkSlowStoreRecoverStartAts)
+		networkSlowScores := filterNetworkSlowScores(cluster, store.GetNetworkSlowScores(), networkSlowStoreRecoverStartAts)
 		if len(networkSlowScores) < 2 {
 			continue
 		}
@@ -727,21 +728,38 @@ func shouldSkipStoreEvaluation(
 
 // isNetworkSlowStore determines if a store should be considered a network slow store
 func isNetworkSlowStore(
+	cluster sche.SchedulerCluster,
 	store *core.StoreInfo,
 	allStores []*core.StoreInfo,
 	problematicNetwork map[uint64]map[uint64]struct{},
 	networkSlowStoreRecoverStartAts map[uint64]*time.Time,
 ) bool {
 	storeID := store.GetID()
-	networkSlowScores := filterNetworkSlowScores(store.GetNetworkSlowScores(), networkSlowStoreRecoverStartAts)
+	networkSlowScores := filterNetworkSlowScores(cluster, store.GetNetworkSlowScores(), networkSlowStoreRecoverStartAts)
 
 	// Can not detect slow stores with less than 3 scores
 	if len(networkSlowScores) <= 2 {
 		return false
 	}
 
-	// Check if all other stores report problems with this store
-	if len(problematicNetwork[storeID]) >= len(allStores)-1-len(networkSlowStoreRecoverStartAts) {
+	// Check if all other stores report problems with this store. Only count
+	// networkSlowStoreRecoverStartAts entries that are also part of allStores
+	// (the live population): a store already excluded from allStores (e.g.
+	// removed, or one whose rollback path in persistLocked left it in this
+	// map) would otherwise be subtracted a second time, shrinking the
+	// denominator below what the live population actually supports and
+	// making consensus easier to reach than it should be.
+	liveIDs := make(map[uint64]struct{}, len(allStores))
+	for _, s := range allStores {
+		liveIDs[s.GetID()] = struct{}{}
+	}
+	liveRecovering := 0
+	for id := range networkSlowStoreRecoverStartAts {
+		if _, ok := liveIDs[id]; ok {
+			liveRecovering++
+		}
+	}
+	if len(problematicNetwork[storeID]) >= len(allStores)-1-liveRecovering {
 		return true
 	}
 
@@ -763,13 +781,22 @@ func isNetworkSlowStore(
 	return fluctuationCount >= 2
 }
 
-// filterNetworkSlowScores removes already slow stores from network slow scores to avoid duplicate detection
+// filterNetworkSlowScores removes already slow stores, and stores confirmed
+// removed from the cluster, from network slow scores to avoid duplicate
+// detection and evaluating a target that can no longer be evicted. A target
+// missing from GetStore (nil) is ambiguous -- e.g. a store referenced only as
+// a NetworkSlowScores map key before it has ever registered -- so only a
+// store known to be removed is filtered; nil is kept.
 func filterNetworkSlowScores(
+	cluster sche.SchedulerCluster,
 	scores map[uint64]uint64,
 	networkSlowStoreRecoverStartAts map[uint64]*time.Time,
 ) map[uint64]uint64 {
 	filteredScores := make(map[uint64]uint64)
 	for storeID, score := range scores {
+		if target := cluster.GetStore(storeID); target != nil && target.IsRemoved() {
+			continue
+		}
 		if _, isSlowStore := networkSlowStoreRecoverStartAts[storeID]; !isSlowStore {
 			filteredScores[storeID] = score
 		}

--- a/pkg/schedule/schedulers/evict_slow_store.go
+++ b/pkg/schedule/schedulers/evict_slow_store.go
@@ -640,6 +640,15 @@ func (s *evictSlowStoreScheduler) detectAndHandleNetworkSlowStores(cluster sche.
 
 	// Evaluate each store for network slowness
 	for _, store := range stores {
+		// A tombstoned store stops heartbeating, so its GetNetworkSlowScores()
+		// is frozen at its last reported value; without this check, a frozen
+		// score that still looks slow would add it to
+		// networkSlowStoreRecoverStartAts and publish evictedSlowStoreStatusGauge
+		// for it here, even though tryRecoverNetworkSlowStores would just remove
+		// it again on the very next scheduling round.
+		if store.IsRemoved() {
+			continue
+		}
 		if shouldSkipStoreEvaluation(store, problematicNetwork, networkSlowStoreRecoverStartAts) {
 			continue
 		}

--- a/pkg/schedule/schedulers/evict_slow_store.go
+++ b/pkg/schedule/schedulers/evict_slow_store.go
@@ -632,28 +632,34 @@ func (s *evictSlowStoreScheduler) activatePausedNetworkSlowStores(cluster sche.S
 // detectAndHandleNetworkSlowStores detects new network slow stores and handles them
 func (s *evictSlowStoreScheduler) detectAndHandleNetworkSlowStores(cluster sche.SchedulerCluster) {
 	stores := cluster.GetStores()
+	// A tombstoned store stops heartbeating, so its GetNetworkSlowScores() is
+	// frozen at its last reported value. Restrict candidate evaluation, the
+	// "who reports whom" map, and the denominator used to decide consensus to
+	// stores that are still actually part of the cluster: otherwise a
+	// tombstoned store's frozen score could get it added to
+	// networkSlowStoreRecoverStartAts directly (even though
+	// tryRecoverNetworkSlowStores would just undo that on the very next
+	// round), and its presence in the denominator can also mask a genuinely
+	// slow live store from ever being detected in the first place.
+	liveStores := make([]*core.StoreInfo, 0, len(stores))
+	for _, store := range stores {
+		if !store.IsRemoved() {
+			liveStores = append(liveStores, store)
+		}
+	}
 	networkSlowStoreRecoverStartAts := s.conf.networkSlowStoreRecoverStartAts
 	pausedNetworkSlowStores := s.conf.PausedNetworkSlowStores
 
 	// Build problematic network map
-	problematicNetwork := buildProblematicNetworkMap(stores, networkSlowStoreRecoverStartAts)
+	problematicNetwork := buildProblematicNetworkMap(liveStores, networkSlowStoreRecoverStartAts)
 
 	// Evaluate each store for network slowness
-	for _, store := range stores {
-		// A tombstoned store stops heartbeating, so its GetNetworkSlowScores()
-		// is frozen at its last reported value; without this check, a frozen
-		// score that still looks slow would add it to
-		// networkSlowStoreRecoverStartAts and publish evictedSlowStoreStatusGauge
-		// for it here, even though tryRecoverNetworkSlowStores would just remove
-		// it again on the very next scheduling round.
-		if store.IsRemoved() {
-			continue
-		}
+	for _, store := range liveStores {
 		if shouldSkipStoreEvaluation(store, problematicNetwork, networkSlowStoreRecoverStartAts) {
 			continue
 		}
 
-		if isNetworkSlowStore(store, stores, problematicNetwork, networkSlowStoreRecoverStartAts) {
+		if isNetworkSlowStore(store, liveStores, problematicNetwork, networkSlowStoreRecoverStartAts) {
 			storeID := store.GetID()
 
 			if len(pausedNetworkSlowStores) >= defaultMaxNetworkSlowStore {

--- a/pkg/schedule/schedulers/evict_slow_store_test.go
+++ b/pkg/schedule/schedulers/evict_slow_store_test.go
@@ -412,6 +412,54 @@ func (suite *evictSlowStoreTestSuite) TestNetworkSlowStoreSkipsRemovedStore() {
 	re.False(ok)
 }
 
+func (suite *evictSlowStoreTestSuite) TestNetworkSlowStoreUsesOnlyLiveStores() {
+	re := suite.Require()
+	es := suite.es.(*evictSlowStoreScheduler)
+
+	suite.tc.AddLeaderStore(storeID5, 0)
+	scores := map[uint64]map[uint64]uint64{
+		storeID1: {
+			storeID2: 100,
+			storeID3: 100,
+			storeID4: 100,
+		},
+		storeID2: {
+			storeID1: 100,
+			storeID3: 1,
+		},
+		storeID3: {
+			storeID1: 100,
+			storeID2: 1,
+		},
+		storeID4: {
+			storeID1: 100,
+			storeID2: 1,
+		},
+		storeID5: {
+			storeID1: 1,
+			storeID2: 1,
+		},
+	}
+
+	for storeID, networkScores := range scores {
+		store := suite.tc.GetStore(storeID)
+		suite.tc.PutStore(store.Clone(func(store *core.StoreInfo) {
+			store.GetStoreStats().NetworkSlowScores = networkScores
+		}))
+	}
+	// storeID5 is tombstoned after seeding scores above, so its own report is
+	// stale data, and it must not count toward the denominator that decides
+	// whether the three live peers reporting storeID1 as problematic (2, 3,
+	// 4) form a large-enough majority.
+	suite.tc.PutStore(suite.tc.GetStore(storeID5).Clone(
+		core.SetStoreState(metapb.StoreState_Tombstone),
+	))
+
+	es.scheduleNetworkSlowStore(suite.tc)
+
+	re.Contains(es.conf.networkSlowStoreRecoverStartAts, uint64(storeID1))
+}
+
 func (suite *evictSlowStoreTestSuite) TestNetworkSlowStoreReachLimit() {
 	re := suite.Require()
 	reachedLimit := false

--- a/pkg/schedule/schedulers/evict_slow_store_test.go
+++ b/pkg/schedule/schedulers/evict_slow_store_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/mock/mockcluster"
+	sche "github.com/tikv/pd/pkg/schedule/core"
 	"github.com/tikv/pd/pkg/schedule/operator"
 	"github.com/tikv/pd/pkg/schedule/types"
 	"github.com/tikv/pd/pkg/storage"
@@ -987,6 +988,57 @@ func TestRecoveryTime(t *testing.T) {
 	re.NoError(err)
 	re.Zero(persistValue.evictStore())
 	re.True(persistValue.readyForRecovery())
+}
+
+// buryAfterGetStoresCluster wraps a sche.SchedulerCluster and buries the
+// target store as a side effect of the first GetStores() call, but still
+// returns the pre-bury snapshot from that call -- modeling
+// detectAndHandleNetworkSlowStores's liveStores snapshot racing a concurrent
+// bury that completes before the store is actually acted on.
+type buryAfterGetStoresCluster struct {
+	sche.SchedulerCluster
+	tc     *mockcluster.Cluster
+	target uint64
+	buried bool
+}
+
+func (c *buryAfterGetStoresCluster) GetStores() []*core.StoreInfo {
+	stores := c.SchedulerCluster.GetStores()
+	if !c.buried {
+		c.buried = true
+		if target := c.tc.GetStore(c.target); target != nil {
+			c.tc.PutStore(target.Clone(core.SetStoreState(metapb.StoreState_Tombstone)))
+		}
+	}
+	return stores
+}
+
+func (suite *evictSlowStoreTestSuite) TestDetectAndHandleNetworkSlowStoresSkipsBuriedTarget() {
+	re := suite.Require()
+	es := suite.es.(*evictSlowStoreScheduler)
+
+	// storeID2/3/4 unanimously report storeID1 as problematic -- the same
+	// consensus setup as TestNetworkSlowStoreUsesOnlyLiveStores, enough to
+	// make isNetworkSlowStore return true for storeID1 via the "all others
+	// report problems" branch.
+	scores := map[uint64]map[uint64]uint64{
+		storeID1: {storeID2: 100, storeID3: 100, storeID4: 100},
+		storeID2: {storeID1: 100},
+		storeID3: {storeID1: 100},
+		storeID4: {storeID1: 100},
+	}
+	for storeID, networkScores := range scores {
+		store := suite.tc.GetStore(storeID)
+		suite.tc.PutStore(store.Clone(func(store *core.StoreInfo) {
+			store.GetStoreStats().NetworkSlowScores = networkScores
+		}))
+	}
+
+	wrapped := &buryAfterGetStoresCluster{SchedulerCluster: suite.tc, tc: suite.tc, target: storeID1}
+	es.detectAndHandleNetworkSlowStores(wrapped)
+
+	re.NotContains(es.conf.PausedNetworkSlowStores, uint64(storeID1))
+	re.NotContains(es.conf.networkSlowStoreRecoverStartAts, uint64(storeID1))
 }
 
 func TestCalculateAvgScore(t *testing.T) {

--- a/pkg/schedule/schedulers/evict_slow_store_test.go
+++ b/pkg/schedule/schedulers/evict_slow_store_test.go
@@ -412,6 +412,69 @@ func (suite *evictSlowStoreTestSuite) TestNetworkSlowStoreSkipsRemovedStore() {
 	re.False(ok)
 }
 
+func (suite *evictSlowStoreTestSuite) TestNetworkSlowStoreIgnoresKnownRemovedTargets() {
+	re := suite.Require()
+
+	// storeID4 is buried (known removed); the unregistered ID 99 is only
+	// ambiguous, not proof of removal -- it must stay included (see
+	// TestNetworkSlowStoreReachLimit's scale-out storeID5 case, which relies
+	// on an unregistered target staying included too).
+	suite.tc.PutStore(suite.tc.GetStore(storeID4).Clone(
+		core.SetStoreState(metapb.StoreState_Tombstone),
+	))
+
+	scores := map[uint64]uint64{
+		storeID2: 10,
+		storeID3: 10,
+		storeID4: 100,
+		99:       100,
+	}
+	filtered := filterNetworkSlowScores(suite.tc, scores, nil)
+
+	re.NotContains(filtered, uint64(storeID4))
+	re.Contains(filtered, uint64(99))
+	re.Contains(filtered, uint64(storeID2))
+	re.Contains(filtered, uint64(storeID3))
+}
+
+func (suite *evictSlowStoreTestSuite) TestNetworkSlowDenominatorIgnoresRemovedRecoveryEntries() {
+	re := suite.Require()
+
+	// storeID4 was already removed, but a concurrent tryRecoverNetworkSlowStores
+	// round hasn't cleaned up its recovery-map entry yet.
+	suite.tc.PutStore(suite.tc.GetStore(storeID4).Clone(
+		core.SetStoreState(metapb.StoreState_Tombstone),
+	))
+	networkSlowStoreRecoverStartAts := map[uint64]*time.Time{
+		storeID4: nil,
+	}
+
+	allStores := []*core.StoreInfo{
+		suite.tc.GetStore(storeID1),
+		suite.tc.GetStore(storeID2),
+		suite.tc.GetStore(storeID3),
+	}
+	// Only storeID2 actually reports storeID1 as problematic; storeID3 does
+	// not, so consensus (all live peers, excluding this store and any live
+	// recovering peer) is not reached.
+	problematicNetwork := map[uint64]map[uint64]struct{}{
+		storeID1: {storeID2: {}},
+	}
+
+	store := suite.tc.GetStore(storeID1).Clone(func(s *core.StoreInfo) {
+		s.GetStoreStats().NetworkSlowScores = map[uint64]uint64{
+			storeID2: 10,
+			// Kept below networkSlowStoreFluctuationThreshold so the
+			// fallback fluctuation check can't independently return true --
+			// this test isolates the "all others report problems" branch.
+			storeID3: 5,
+			99:       5,
+		}
+	})
+
+	re.False(isNetworkSlowStore(suite.tc, store, allStores, problematicNetwork, networkSlowStoreRecoverStartAts))
+}
+
 func (suite *evictSlowStoreTestSuite) TestNetworkSlowStoreUsesOnlyLiveStores() {
 	re := suite.Require()
 	es := suite.es.(*evictSlowStoreScheduler)

--- a/pkg/schedule/schedulers/evict_slow_store_test.go
+++ b/pkg/schedule/schedulers/evict_slow_store_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/log"
 
 	"github.com/tikv/pd/pkg/core"
@@ -373,6 +374,42 @@ func (suite *evictSlowStoreTestSuite) TestNetworkSlowStore() {
 		checkNetworkSlowStore(re, es, suite.tc, storeID1, tc.expectedSlow, tc.expectedSlow, tc.recovery)
 	}
 	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/schedule/schedulers/transientRecoveryGap"))
+}
+
+func (suite *evictSlowStoreTestSuite) TestNetworkSlowStoreSkipsRemovedStore() {
+	re := suite.Require()
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/schedule/schedulers/transientRecoveryGap", "return(true)"))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/schedule/schedulers/transientRecoveryGap"))
+	}()
+
+	es, ok := suite.es.(*evictSlowStoreScheduler)
+	re.True(ok)
+
+	storeInfo := suite.tc.GetStore(storeID1)
+	// This score pattern is the same "definitely slow" case already proven to
+	// trigger detection when the store is live (see the third case in
+	// TestNetworkSlowStore).
+	slow := storeInfo.Clone(func(store *core.StoreInfo) {
+		store.GetStoreStats().NetworkSlowScores = map[uint64]uint64{
+			storeID2: 10,
+			storeID3: 10,
+			storeID4: 100,
+		}
+	})
+	removed := slow.Clone(core.SetStoreState(metapb.StoreState_Tombstone))
+	suite.tc.PutStore(removed)
+
+	// A tombstoned store stops heartbeating, so its NetworkSlowScores are
+	// frozen at this still-qualifying-as-slow value. Without the guard, the
+	// very first scheduleNetworkSlowStore call -- before
+	// tryRecoverNetworkSlowStores ever gets a chance to clean it up on a
+	// later round -- would add it to networkSlowStoreRecoverStartAts and
+	// publish evictedSlowStoreStatusGauge for it.
+	es.scheduleNetworkSlowStore(suite.tc)
+
+	_, ok = es.conf.networkSlowStoreRecoverStartAts[storeID1]
+	re.False(ok)
 }
 
 func (suite *evictSlowStoreTestSuite) TestNetworkSlowStoreReachLimit() {

--- a/pkg/schedule/schedulers/hot_region.go
+++ b/pkg/schedule/schedulers/hot_region.go
@@ -187,6 +187,14 @@ func (s *baseHotScheduler) summaryPendingInfluence(storeInfos map[uint64]*statis
 	}
 	// for metrics
 	for storeID, info := range storeInfos {
+		// storeInfos comes from SummaryStoreInfos(cluster.GetStores()), which
+		// includes tombstoned stores; without this check a pending influence
+		// entry still in its zombie period keeps republishing HotPendingSum
+		// for a removed store every Schedule() round, even after bury/final
+		// -removal or collectHotMetrics deletes the series.
+		if info.IsRemoved() {
+			continue
+		}
 		storeLabel := strconv.FormatUint(storeID, 10)
 		if infl := info.PendingSum; infl != nil && len(infl.Loads) != 0 {
 			utils.ForeachRegionStats(func(rwTy utils.RWType, dim int, kind utils.RegionStatKind) {

--- a/pkg/schedule/schedulers/hot_region.go
+++ b/pkg/schedule/schedulers/hot_region.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 
 	"github.com/pingcap/log"
@@ -200,6 +201,14 @@ func (s *baseHotScheduler) summaryPendingInfluence(cluster sche.SchedulerCluster
 			utils.ForeachRegionStats(func(rwTy utils.RWType, dim int, kind utils.RegionStatKind) {
 				HotPendingSum.WithLabelValues(storeLabel, rwTy.String(), utils.DimToString(dim)).Set(infl.Loads[kind])
 			})
+			// The check above and this write are not atomic with DeleteStoreMetrics,
+			// so a bury landing in between can still let this write recreate the
+			// series after cleanup ran. Re-check right after writing to narrow that
+			// window; a store buried later still leaves a bounded residual until the
+			// next tick, which is an accepted, documented limitation.
+			if store := cluster.GetStore(storeID); store == nil || store.IsRemoved() {
+				HotPendingSum.DeletePartialMatch(prometheus.Labels{"store": storeLabel})
+			}
 		}
 	}
 }

--- a/pkg/schedule/schedulers/hot_region.go
+++ b/pkg/schedule/schedulers/hot_region.go
@@ -102,7 +102,7 @@ func newBaseHotScheduler(
 func (s *baseHotScheduler) prepareForBalance(typ resourceType, cluster sche.SchedulerCluster) {
 	stores := cluster.GetStores()
 	storeInfos := statistics.SummaryStoreInfos(stores)
-	s.summaryPendingInfluence(storeInfos)
+	s.summaryPendingInfluence(cluster, storeInfos)
 	s.stHistoryLoads.GC(stores)
 	storesLoads := cluster.GetStoresLoads()
 	isTraceRegionFlow := cluster.GetSchedulerConfig().IsTraceRegionFlow()
@@ -162,7 +162,7 @@ func (s *baseHotScheduler) getEffectivePendingWeight() float64 {
 // summaryPendingInfluence calculate the summary of pending Influence for each store
 // and clean the region from regionInfluence if they have ended operator.
 // It makes each dim rate or count become `weight` times to the origin value.
-func (s *baseHotScheduler) summaryPendingInfluence(storeInfos map[uint64]*statistics.StoreSummaryInfo) {
+func (s *baseHotScheduler) summaryPendingInfluence(cluster sche.SchedulerCluster, storeInfos map[uint64]*statistics.StoreSummaryInfo) {
 	pendingWeight := s.getEffectivePendingWeight()
 	for id, p := range s.regionPendings {
 		for _, from := range p.froms {
@@ -187,12 +187,12 @@ func (s *baseHotScheduler) summaryPendingInfluence(storeInfos map[uint64]*statis
 	}
 	// for metrics
 	for storeID, info := range storeInfos {
-		// storeInfos comes from SummaryStoreInfos(cluster.GetStores()), which
-		// includes tombstoned stores; without this check a pending influence
-		// entry still in its zombie period keeps republishing HotPendingSum
-		// for a removed store every Schedule() round, even after bury/final
-		// -removal or collectHotMetrics deletes the series.
-		if info.IsRemoved() {
+		// storeInfos is built from a snapshot taken at the top of
+		// prepareForBalance, so info.IsRemoved() can be stale by the time
+		// this loop runs; re-check the store fresh through cluster instead,
+		// otherwise a store buried after the snapshot was taken but before
+		// this write can still recreate HotPendingSum for it.
+		if store := cluster.GetStore(storeID); store == nil || store.IsRemoved() {
 			continue
 		}
 		storeLabel := strconv.FormatUint(storeID, 10)

--- a/pkg/schedule/schedulers/hot_region.go
+++ b/pkg/schedule/schedulers/hot_region.go
@@ -100,8 +100,10 @@ func newBaseHotScheduler(
 // prepareForBalance calculate the summary of pending Influence for each store and prepare the load detail for
 // each store, only update read or write load detail
 func (s *baseHotScheduler) prepareForBalance(typ resourceType, cluster sche.SchedulerCluster) {
-	storeInfos := statistics.SummaryStoreInfos(cluster.GetStores())
+	stores := cluster.GetStores()
+	storeInfos := statistics.SummaryStoreInfos(stores)
 	s.summaryPendingInfluence(storeInfos)
+	s.stHistoryLoads.GC(stores)
 	storesLoads := cluster.GetStoresLoads()
 	isTraceRegionFlow := cluster.GetSchedulerConfig().IsTraceRegionFlow()
 

--- a/pkg/schedule/schedulers/hot_region_test.go
+++ b/pkg/schedule/schedulers/hot_region_test.go
@@ -2664,11 +2664,19 @@ func TestSummaryPendingInfluenceSkipsRemovedStoreMetric(t *testing.T) {
 		NodeState: metapb.NodeState_Removed,
 	})
 	tc.PutStore(removed)
+	// storeInfos holds a stale snapshot still showing the store as serving,
+	// simulating one taken before the store was buried -- this only passes
+	// if the check re-reads the store fresh through cluster instead of
+	// trusting info.IsRemoved() on the snapshot.
+	stale := core.NewStoreInfo(&metapb.Store{
+		Id:        storeID,
+		NodeState: metapb.NodeState_Serving,
+	})
 	loads := make([]float64, utils.RegionStatCount)
 	loads[utils.RegionWriteBytes] = 1
 	storeInfos := map[uint64]*statistics.StoreSummaryInfo{
 		storeID: {
-			StoreInfo:  removed,
+			StoreInfo:  stale,
 			PendingSum: &statistics.Influence{Loads: loads},
 		},
 	}

--- a/pkg/schedule/schedulers/hot_region_test.go
+++ b/pkg/schedule/schedulers/hot_region_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/docker/go-units"
+	"github.com/prometheus/client_golang/prometheus"
 	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 
@@ -30,6 +31,7 @@ import (
 
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/mock/mockcluster"
+	sche "github.com/tikv/pd/pkg/schedule/core"
 	"github.com/tikv/pd/pkg/schedule/operator"
 	"github.com/tikv/pd/pkg/schedule/placement"
 	"github.com/tikv/pd/pkg/schedule/types"
@@ -2686,4 +2688,60 @@ func TestSummaryPendingInfluenceSkipsRemovedStoreMetric(t *testing.T) {
 	hb.summaryPendingInfluence(tc, storeInfos)
 
 	re.Equal(float64(42), promtestutil.ToFloat64(metric))
+}
+
+// buryAfterGetStoreCluster wraps a sche.SchedulerCluster and buries the
+// target store as a side effect of the first GetStore(target) call, but
+// still returns the pre-bury snapshot from that same call -- modeling a
+// GetStore that raced a concurrent bury completing between its read and its
+// caller using the result.
+type buryAfterGetStoreCluster struct {
+	sche.SchedulerCluster
+	tc     *mockcluster.Cluster
+	target uint64
+	buried bool
+}
+
+func (c *buryAfterGetStoreCluster) GetStore(id uint64) *core.StoreInfo {
+	store := c.SchedulerCluster.GetStore(id)
+	if id == c.target && !c.buried {
+		c.buried = true
+		c.tc.PutStore(store.Clone(core.SetStoreState(metapb.StoreState_Tombstone)))
+	}
+	return store
+}
+
+func TestSummaryPendingInfluenceCannotRepublishAfterBury(t *testing.T) {
+	re := require.New(t)
+	defer HotPendingSum.Reset()
+
+	cancel, _, tc, _ := prepareSchedulersTest()
+	defer cancel()
+	hb := newBaseHotScheduler(nil, 0, 0, initHotRegionScheduleConfig())
+	storeID := uint64(1)
+	tc.PutStore(core.NewStoreInfo(&metapb.Store{
+		Id:        storeID,
+		NodeState: metapb.NodeState_Serving,
+	}))
+
+	loads := make([]float64, utils.RegionStatCount)
+	loads[utils.RegionWriteBytes] = 1
+	storeInfos := map[uint64]*statistics.StoreSummaryInfo{
+		storeID: {
+			StoreInfo:  tc.GetStore(storeID),
+			PendingSum: &statistics.Influence{Loads: loads},
+		},
+	}
+
+	// Simulate DeleteStoreMetrics having already run for this store, then a
+	// bury landing exactly between summaryPendingInfluence's pre-write check
+	// and the write completing.
+	racingCluster := &buryAfterGetStoreCluster{SchedulerCluster: tc, tc: tc, target: storeID}
+	hb.summaryPendingInfluence(racingCluster, storeInfos)
+
+	// The write must have happened for this to be a meaningful check: assert
+	// via DeletePartialMatch's return value (a series count), rather than
+	// reading the already-obtained Gauge handle, since a deleted series still
+	// reports its last-set value through that handle.
+	re.Equal(0, HotPendingSum.DeletePartialMatch(prometheus.Labels{"store": "1"}))
 }

--- a/pkg/schedule/schedulers/hot_region_test.go
+++ b/pkg/schedule/schedulers/hot_region_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/docker/go-units"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 
 	"github.com/pingcap/kvproto/pkg/metapb"
@@ -2648,4 +2649,29 @@ func TestEncodeConfig(t *testing.T) {
 	data, err := sche.EncodeConfig()
 	re.NoError(err)
 	re.NotEqual("null", string(data))
+}
+
+func TestSummaryPendingInfluenceSkipsRemovedStoreMetric(t *testing.T) {
+	re := require.New(t)
+	defer HotPendingSum.Reset()
+
+	hb := newBaseHotScheduler(nil, 0, 0, initHotRegionScheduleConfig())
+	storeID := uint64(1)
+	loads := make([]float64, utils.RegionStatCount)
+	loads[utils.RegionWriteBytes] = 1
+	storeInfos := map[uint64]*statistics.StoreSummaryInfo{
+		storeID: {
+			StoreInfo: core.NewStoreInfo(&metapb.Store{
+				Id:        storeID,
+				NodeState: metapb.NodeState_Removed,
+			}),
+			PendingSum: &statistics.Influence{Loads: loads},
+		},
+	}
+
+	metric := HotPendingSum.WithLabelValues("1", utils.Write.String(), utils.DimToString(utils.ByteDim))
+	metric.Set(42)
+	hb.summaryPendingInfluence(storeInfos)
+
+	re.Equal(float64(42), promtestutil.ToFloat64(metric))
 }

--- a/pkg/schedule/schedulers/hot_region_test.go
+++ b/pkg/schedule/schedulers/hot_region_test.go
@@ -243,7 +243,7 @@ func checkGCPendingOpInfos(re *require.Assertions, enablePlacementRules bool) {
 	}
 
 	storeInfos := statistics.SummaryStoreInfos(tc.GetStores())
-	hb.summaryPendingInfluence(storeInfos) // Calling this function will GC.
+	hb.summaryPendingInfluence(tc, storeInfos) // Calling this function will GC.
 
 	for i := range opInfluenceCreators {
 		for j, typ := range typs {
@@ -2093,7 +2093,7 @@ func TestInfluenceByRWType(t *testing.T) {
 	re.NotNil(op)
 
 	storeInfos := statistics.SummaryStoreInfos(tc.GetStores())
-	hb.(*hotScheduler).summaryPendingInfluence(storeInfos)
+	hb.(*hotScheduler).summaryPendingInfluence(tc, storeInfos)
 	re.True(nearlyAbout(storeInfos[1].PendingSum.Loads[utils.RegionWriteKeys], -0.5*units.MiB))
 	re.True(nearlyAbout(storeInfos[1].PendingSum.Loads[utils.RegionWriteBytes], -0.5*units.MiB))
 	re.True(nearlyAbout(storeInfos[4].PendingSum.Loads[utils.RegionWriteKeys], 0.5*units.MiB))
@@ -2118,7 +2118,7 @@ func TestInfluenceByRWType(t *testing.T) {
 	re.NotNil(op)
 
 	storeInfos = statistics.SummaryStoreInfos(tc.GetStores())
-	hb.(*hotScheduler).summaryPendingInfluence(storeInfos)
+	hb.(*hotScheduler).summaryPendingInfluence(tc, storeInfos)
 	// assert read/write influence is the sum of write peer and write leader
 	re.True(nearlyAbout(storeInfos[1].PendingSum.Loads[utils.RegionWriteKeys], -1.2*units.MiB))
 	re.True(nearlyAbout(storeInfos[1].PendingSum.Loads[utils.RegionWriteBytes], -1.2*units.MiB))
@@ -2655,23 +2655,27 @@ func TestSummaryPendingInfluenceSkipsRemovedStoreMetric(t *testing.T) {
 	re := require.New(t)
 	defer HotPendingSum.Reset()
 
+	cancel, _, tc, _ := prepareSchedulersTest()
+	defer cancel()
 	hb := newBaseHotScheduler(nil, 0, 0, initHotRegionScheduleConfig())
 	storeID := uint64(1)
+	removed := core.NewStoreInfo(&metapb.Store{
+		Id:        storeID,
+		NodeState: metapb.NodeState_Removed,
+	})
+	tc.PutStore(removed)
 	loads := make([]float64, utils.RegionStatCount)
 	loads[utils.RegionWriteBytes] = 1
 	storeInfos := map[uint64]*statistics.StoreSummaryInfo{
 		storeID: {
-			StoreInfo: core.NewStoreInfo(&metapb.Store{
-				Id:        storeID,
-				NodeState: metapb.NodeState_Removed,
-			}),
+			StoreInfo:  removed,
 			PendingSum: &statistics.Influence{Loads: loads},
 		},
 	}
 
 	metric := HotPendingSum.WithLabelValues("1", utils.Write.String(), utils.DimToString(utils.ByteDim))
 	metric.Set(42)
-	hb.summaryPendingInfluence(storeInfos)
+	hb.summaryPendingInfluence(tc, storeInfos)
 
 	re.Equal(float64(42), promtestutil.ToFloat64(metric))
 }

--- a/pkg/statistics/hot_peer_cache.go
+++ b/pkg/statistics/hot_peer_cache.go
@@ -584,6 +584,17 @@ func (f *HotPeerCache) gc() {
 		}
 	}
 	for storeID := range removed {
+		// regionsOfStore[storeID] is the exact set of regions this store is still
+		// referenced from in storesOfRegion; read it before deleting so the reverse
+		// index doesn't keep a stale storeID around for regions that are still active.
+		for regionID := range f.regionsOfStore[storeID] {
+			if stores, ok := f.storesOfRegion[regionID]; ok {
+				delete(stores, storeID)
+				if len(stores) == 0 {
+					delete(f.storesOfRegion, regionID)
+				}
+			}
+		}
 		delete(f.peersOfStore, storeID)
 		delete(f.regionsOfStore, storeID)
 		delete(f.thresholdsOfStore, storeID)

--- a/pkg/statistics/store_collection.go
+++ b/pkg/statistics/store_collection.go
@@ -322,6 +322,11 @@ func (s *storeStatistics) collect() {
 // previous address.
 func ResetStoreStatistics(id string) {
 	storeStatusGauge.DeletePartialMatch(utils.SingleLabel("store", id))
+	// placementStatusGauge's "name" label is an arbitrary, unbounded label-rule
+	// name (unlike clusterStatusGauge's small, fixed engine set below), so an
+	// exact DeleteLabelValues per combination isn't feasible here either --
+	// same tradeoff as storeStatusGauge above.
+	placementStatusGauge.DeletePartialMatch(utils.SingleLabel("store", id))
 	// clusterStatusGauge's complete label tuples are bounded by the two
 	// possible core.StoreInfo.Engine() outputs, so an exact DeleteLabelValues
 	// per (type, engine) is enough to cover every series for this store --

--- a/pkg/statistics/store_collection.go
+++ b/pkg/statistics/store_collection.go
@@ -368,6 +368,7 @@ func Reset() {
 	storeStatusGauge.Reset()
 	placementStatusGauge.Reset()
 	clusterStatusGauge.Reset()
+	StoreLimitGauge.Reset()
 	ResetRegionStatsMetrics()
 	ResetLabelStatsMetrics()
 	ResetHotCacheStatusMetrics()

--- a/pkg/statistics/store_collection.go
+++ b/pkg/statistics/store_collection.go
@@ -211,6 +211,15 @@ func (s *storeStatistics) observe(store *core.StoreInfo) {
 
 // ObserveHotStat records the hot region metrics for the store.
 func ObserveHotStat(store *core.StoreInfo, stats *StoresStats) {
+	// A store's RollingStoreStats can be recreated after bury by a StoreHeartbeat
+	// that was already in flight (HandleStoreHeartbeat only rejects a fully
+	// unknown store, not a tombstoned one). Without this check, that would make
+	// this function keep republishing storeStatusGauge every collection tick for
+	// as long as the entry exists, up to 30 days until final removal, instead of
+	// stopping once the store is known tombstoned like observe() already does.
+	if store.IsRemoved() {
+		return
+	}
 	// Store flows.
 	storeAddress := store.GetAddress()
 	id := strconv.FormatUint(store.GetID(), 10)

--- a/pkg/statistics/store_collection_test.go
+++ b/pkg/statistics/store_collection_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/docker/go-units"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 
 	"github.com/pingcap/kvproto/pkg/metapb"
@@ -86,6 +87,22 @@ func TestStoreStatistics(t *testing.T) {
 	re.Equal([]uint64{1, 3, 5, 7}, stats.LabelCounter["host:h1"])
 	re.Len(stats.LabelCounter["host:h2"], 4)
 	re.Len(stats.LabelCounter["zone:unknown"], 2)
+}
+
+func TestResetStoreStatisticsClearsPlacementStatusGauge(t *testing.T) {
+	re := require.New(t)
+	defer placementStatusGauge.Reset()
+
+	metric := placementStatusGauge.WithLabelValues("label-type", "label-name", "1")
+	metric.Set(1)
+	re.NotZero(testutil.ToFloat64(metric))
+
+	ResetStoreStatistics("1")
+	// DeletePartialMatch returns how many series it found and removed, so a
+	// zero return here proves ResetStoreStatistics already deleted it --
+	// unlike checking WithLabelValues' value, which would recreate a fresh
+	// (zero-valued) series regardless of whether the old one was cleaned up.
+	re.Zero(placementStatusGauge.DeletePartialMatch(utils.SingleLabel("store", "1")))
 }
 
 func TestSummaryStoreInfos(t *testing.T) {

--- a/pkg/statistics/store_hot_peers_infos.go
+++ b/pkg/statistics/store_hot_peers_infos.go
@@ -195,7 +195,14 @@ func summaryStoresLoadByEngine(
 					allStoreHistoryLoadSum[i][j] += historyLoad
 				}
 			}
-			storesHistoryLoads.Add(id, rwTy, kind, currentLoads)
+			// GC(stores) runs earlier in the same prepareForBalance call and
+			// clears a removed store's entry; without this check, this write
+			// -- unconditional on the collector's own filter, which doesn't
+			// reject removed stores for RegionKind -- recreates it in the
+			// same call, making that GC a no-op for this store.
+			if !store.IsRemoved() {
+				storesHistoryLoads.Add(id, rwTy, kind, currentLoads)
+			}
 		}
 
 		for i := range allStoreLoadSum {

--- a/pkg/statistics/store_load.go
+++ b/pkg/statistics/store_load.go
@@ -303,6 +303,27 @@ func (s *StoreHistoryLoads) Add(storeID uint64, rwTp utils.RWType, kind constant
 	load.add(pointLoad)
 }
 
+// GC removes history load entries for stores that are no longer alive, so a
+// store that's gone doesn't keep its entry for the scheduler's entire
+// lifetime (there's otherwise no periodic sweep of this cache at all).
+func (s *StoreHistoryLoads) GC(stores []*core.StoreInfo) {
+	alive := make(map[uint64]struct{}, len(stores))
+	for _, store := range stores {
+		if !store.IsRemoved() {
+			alive[store.GetID()] = struct{}{}
+		}
+	}
+	for i := range s.loads {
+		for j := range s.loads[i] {
+			for storeID := range s.loads[i][j] {
+				if _, ok := alive[storeID]; !ok {
+					delete(s.loads[i][j], storeID)
+				}
+			}
+		}
+	}
+}
+
 // Get returns the store loads from the history, not one time point.
 // In another word, the result is [dim][time].
 func (s *StoreHistoryLoads) Get(storeID uint64, rwTp utils.RWType, kind constant.ResourceKind) HistoryLoads {

--- a/pkg/statistics/store_load_test.go
+++ b/pkg/statistics/store_load_test.go
@@ -20,6 +20,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/pingcap/kvproto/pkg/metapb"
+
+	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/core/constant"
 	"github.com/tikv/pd/pkg/statistics/utils"
 )
@@ -60,4 +63,36 @@ func TestHistoryLoads(t *testing.T) {
 	historyLoads = NewStoreHistoryLoads(0, 0)
 	historyLoads.Add(1, rwTp, kind, loads)
 	re.Empty(historyLoads.Get(1, rwTp, kind)[0])
+}
+
+func TestHistoryGCDoesNotReaddRemovedStore(t *testing.T) {
+	re := require.New(t)
+	history := NewStoreHistoryLoads(time.Minute, 0)
+	rw := utils.Read
+	kind := constant.RegionKind
+	storeID := uint64(1)
+
+	live := core.NewStoreInfo(&metapb.Store{
+		Id:        storeID,
+		NodeState: metapb.NodeState_Serving,
+	})
+	infos := map[uint64]*StoreSummaryInfo{
+		storeID: {StoreInfo: live},
+	}
+	loads := map[uint64]StoreKindLoads{
+		storeID: {1, 0, 0, 0, 0},
+	}
+
+	SummaryStoresLoad(infos, loads, history, nil, false, rw, kind)
+	re.NotEmpty(history.Get(storeID, rw, kind)[0])
+
+	removed := live.Clone(core.SetStoreState(metapb.StoreState_Tombstone))
+	history.GC([]*core.StoreInfo{removed})
+	re.Empty(history.Get(storeID, rw, kind)[0])
+
+	SummaryStoresLoad(
+		map[uint64]*StoreSummaryInfo{storeID: {StoreInfo: removed}},
+		loads, history, nil, false, rw, kind,
+	)
+	re.Empty(history.Get(storeID, rw, kind)[0])
 }

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1525,11 +1525,24 @@ func (c *RaftCluster) DeleteStoreLabel(storeID uint64, labelKey string) error {
 
 // PutMetaStore puts a store.
 func (c *RaftCluster) PutMetaStore(store *metapb.Store) error {
+	// A tombstoned store's config entry is only ever cleared once, at bury time
+	// (RemoveStoreLimit); nothing sweeps it again afterward. The gRPC PutStore
+	// preflight isn't synchronized with BuryStore, so a request that observed
+	// an already-known store as live can still reach here after a concurrent
+	// bury tombstoned it and cleared its limit -- putStoreImpl won't resurrect
+	// the tombstone state for an existing store, but AddStoreLimit would
+	// recreate the entry unless skipped. Only guard that case: a store that
+	// was never registered before must still get a limit even if it's already
+	// tombstoned at first sight (e.g. state replayed from storage), since
+	// there's no prior entry to protect from resurrection.
+	wasKnown := c.GetStore(store.GetId()) != nil
 	if err := c.putStoreImpl(store, false); err != nil {
 		return err
 	}
 	c.OnStoreVersionChange()
-	c.AddStoreLimit(store)
+	if current := c.GetStore(store.GetId()); !wasKnown || current == nil || !current.IsRemoved() {
+		c.AddStoreLimit(store)
+	}
 	return nil
 }
 
@@ -2434,20 +2447,14 @@ func (c *RaftCluster) GetAllStoresLimit() map[uint64]sc.StoreLimitConfig {
 	return c.opt.GetAllStoresLimit()
 }
 
-// AddStoreLimit add a store limit for a given store ID.
+// AddStoreLimit add a store limit for a given store ID if it doesn't already
+// have one. It unconditionally (re)creates a default entry -- callers that
+// must not resurrect a deliberately-removed entry for an already-known store
+// (see PutMetaStore) are responsible for guarding that themselves; a store
+// that's genuinely new here, even if already tombstoned at first sight (e.g.
+// state replayed from storage), is still expected to get one.
 func (c *RaftCluster) AddStoreLimit(store *metapb.Store) {
 	storeID := store.GetId()
-	// A tombstoned store's config entry is only ever cleared once, at bury time
-	// (RemoveStoreLimit); nothing sweeps it again afterward. PutMetaStore calls
-	// AddStoreLimit unconditionally after putStoreImpl, which -- for a store
-	// that already exists -- never resurrects State/NodeState, so a PutStore
-	// whose preflight raced a concurrent BuryStore still leaves the store
-	// tombstoned here. The incoming `store` argument is the caller's request
-	// payload, not the authoritative post-putStoreImpl state, so it can't be
-	// used for this check; re-fetch instead.
-	if existing := c.GetStore(storeID); existing != nil && existing.IsRemoved() {
-		return
-	}
 	var err error
 	for range persistLimitRetryTimes {
 		added := false

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1790,6 +1790,7 @@ func (c *RaftCluster) BuryStoreLocked(storeID uint64, forceBury bool) error {
 		// clean up the residual information.
 		c.prevStoreLimit.Delete(storeID)
 		c.RemoveStoreLimit(storeID)
+		c.ruleManager.RemoveStoreCache(storeID)
 		storeIDStr := strconv.FormatUint(storeID, 10)
 		statistics.ResetStoreStatistics(storeIDStr)
 		filter.DeleteStoreMetrics(storeIDStr)
@@ -2182,7 +2183,6 @@ func (c *RaftCluster) RemoveTombStoneRecords() error {
 					errs.ZapError(err))
 				return err
 			}
-			c.RemoveStoreLimit(store.GetID())
 			log.Info("delete store succeeded",
 				zap.Stringer("store", store.GetMeta()))
 		}
@@ -2212,6 +2212,13 @@ func (c *RaftCluster) deleteStore(store *core.StoreInfo) error {
 	// leaving a series this cleanup just deleted with no later event able to
 	// find and remove it again.
 	c.DeleteStore(store)
+	c.ruleManager.RemoveStoreCache(store.GetID())
+	// The auto-GC path (checkStores' NodeState_Removed branch) only ever calls
+	// deleteStore, never RemoveTombStoneRecords, so the store-limit config entry
+	// needs to be cleared here rather than by the manual remove-tombstone caller
+	// alone -- otherwise a store reclaimed purely by the 30-day auto-GC timer
+	// never gets this cleanup at all.
+	c.RemoveStoreLimit(store.GetID())
 	storeIDStr := strconv.FormatUint(store.GetID(), 10)
 	statistics.DeleteClusterStatusMetrics(store)
 	statistics.ResetStoreStatistics(storeIDStr)
@@ -2621,6 +2628,18 @@ func (c *RaftCluster) loadExternalTS() {
 
 // SetStoreLimit sets a store limit for a given type and rate.
 func (c *RaftCluster) SetStoreLimit(storeID uint64, typ storelimit.Type, ratePerMin float64) error {
+	// A tombstoned store's config entry is only ever cleared once, at bury time
+	// (RemoveStoreLimit); nothing sweeps it again afterward. Without this check,
+	// setting a limit for an already-tombstoned store re-adds it, and
+	// StoreLimitGauge stays republished for it until final removal.
+	//
+	// GetStore returning nil is deliberately NOT treated the same as removed
+	// here: callers legitimately set a store's limit before the store itself
+	// is registered (see testCluster.addRegionStore), so nil just means
+	// "not created yet," not "already gone."
+	if store := c.GetStore(storeID); store != nil && store.IsRemoved() {
+		return errs.ErrStoreRemoved.FastGenByArgs(storeID)
+	}
 	old := c.opt.GetScheduleConfig().Clone()
 	c.opt.SetStoreLimit(storeID, typ, ratePerMin)
 	if err := c.opt.Persist(c.storage); err != nil {
@@ -2800,6 +2819,15 @@ func (c *RaftCluster) UnsetServiceIndependent(name string) {
 const networkSlowStoreEvictThreshold = 99
 
 func (c *RaftCluster) adjustNetworkSlowStore(storeID uint64) {
+	// The gRPC handler's own IsRemoved() check isn't atomic with this call, so an
+	// in-flight StoreHeartbeat that already passed it can still reach here after
+	// bury. BuryStoreLocked only clears storeTriggerNetworkSlowEvict once, so a
+	// re-check here (unlike the metric write below, which has no such guard) is
+	// the only thing that can stop it from staying republished until final
+	// removal.
+	if store := c.GetStore(storeID); store == nil || store.IsRemoved() {
+		return
+	}
 	if c.GetAvgNetworkSlowScore(storeID) >= networkSlowStoreEvictThreshold {
 		c.TriggerNetworkSlowEvict(storeID)
 		storeTriggerNetworkSlowEvict.WithLabelValues(strconv.FormatUint(storeID, 10)).Inc()

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1531,18 +1531,16 @@ func (c *RaftCluster) PutMetaStore(store *metapb.Store) error {
 	// an already-known store as live can still reach here after a concurrent
 	// bury tombstoned it and cleared its limit -- putStoreImpl won't resurrect
 	// the tombstone state for an existing store, but AddStoreLimit would
-	// recreate the entry unless skipped. Only guard that case: a store that
-	// was never registered before must still get a limit even if it's already
-	// tombstoned at first sight (e.g. state replayed from storage), since
-	// there's no prior entry to protect from resurrection.
+	// recreate the entry unless guarded. Only guard the "already known" case:
+	// a store that was never registered before must still get a limit even if
+	// it's already tombstoned at first sight (e.g. state replayed from
+	// storage), since there's no prior entry to protect from resurrection.
 	wasKnown := c.GetStore(store.GetId()) != nil
 	if err := c.putStoreImpl(store, false); err != nil {
 		return err
 	}
 	c.OnStoreVersionChange()
-	if current := c.GetStore(store.GetId()); !wasKnown || current == nil || !current.IsRemoved() {
-		c.AddStoreLimit(store)
-	}
+	c.addStoreLimit(store, wasKnown)
 	return nil
 }
 
@@ -2448,17 +2446,41 @@ func (c *RaftCluster) GetAllStoresLimit() map[uint64]sc.StoreLimitConfig {
 }
 
 // AddStoreLimit add a store limit for a given store ID if it doesn't already
-// have one. It unconditionally (re)creates a default entry -- callers that
-// must not resurrect a deliberately-removed entry for an already-known store
-// (see PutMetaStore) are responsible for guarding that themselves; a store
-// that's genuinely new here, even if already tombstoned at first sight (e.g.
-// state replayed from storage), is still expected to get one.
+// have one. It unconditionally (re)creates a default entry for a store that's
+// genuinely new here, even if already tombstoned at first sight (e.g. state
+// replayed from storage) -- there's no prior entry to protect from
+// resurrection in that case. Callers that must guard an already-known store
+// against resurrecting a deliberately-removed entry should use
+// addStoreLimit(store, true) instead (see PutMetaStore).
 func (c *RaftCluster) AddStoreLimit(store *metapb.Store) {
+	c.addStoreLimit(store, false)
+}
+
+// addStoreLimit is AddStoreLimit's implementation. When skipIfRemoved is
+// true, it re-checks the store's current tombstone state on every retry
+// attempt, from inside the same UpdateScheduleConfig closure that
+// RemoveStoreLimit's own deletion runs under -- not just once before the
+// loop. That closes the race completely, not just narrows it: persistMu
+// serializes the two closures, and RemoveStoreLimit always runs as part of
+// any bury, so whichever of the two closures runs first, the outcome is
+// still correct -- an entry this call adds just before a bury still gets
+// deleted by that same bury's (unconditional) RemoveStoreLimit call, and an
+// entry it would add after a bury already completed is skipped by the
+// recheck instead. A check done only once before entering the retry loop (as
+// PutMetaStore's guard originally did) doesn't have this property: a bury
+// landing during persistLimitWaitTime's sleep between failed attempts can
+// still race a later retry that never re-reads store state.
+func (c *RaftCluster) addStoreLimit(store *metapb.Store, skipIfRemoved bool) {
 	storeID := store.GetId()
 	var err error
 	for range persistLimitRetryTimes {
 		added := false
 		err = c.opt.UpdateScheduleConfig(c.storage, func(_ *sc.ScheduleConfig, cfg *sc.ScheduleConfig) (bool, error) {
+			if skipIfRemoved {
+				if existing := c.GetStore(storeID); existing == nil || existing.IsRemoved() {
+					return false, nil
+				}
+			}
 			if _, ok := cfg.StoreLimit[storeID]; ok {
 				return false, nil
 			}

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -2708,7 +2708,12 @@ func (c *RaftCluster) refreshStoreRateLimit(storeID uint64, limitType storelimit
 	}
 	// Schedule config stores the unit in rate-per-minute, but limiter uses rate-per-second.
 	const storeBalanceBaseTime = float64(60)
-	ratePerSec := c.opt.GetStoreLimitByType(storeID, limitType) / storeBalanceBaseTime
+	// Peek, not Get: this runs for every currently-known store (SetAllStoresLimit
+	// loops all of them), including one whose config entry RemoveStoreLimit just
+	// deleted but that hasn't been finally removed from StoresInfo yet (tombstone
+	// is not deletion). Get's create-on-miss side effect would resurrect that
+	// entry here.
+	ratePerSec := c.opt.PeekStoreLimitByType(storeID, limitType) / storeBalanceBaseTime
 	if limit.Rate(limitType) != ratePerSec {
 		c.ResetStoreLimit(storeID, limitType, ratePerSec)
 	}

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -2437,6 +2437,17 @@ func (c *RaftCluster) GetAllStoresLimit() map[uint64]sc.StoreLimitConfig {
 // AddStoreLimit add a store limit for a given store ID.
 func (c *RaftCluster) AddStoreLimit(store *metapb.Store) {
 	storeID := store.GetId()
+	// A tombstoned store's config entry is only ever cleared once, at bury time
+	// (RemoveStoreLimit); nothing sweeps it again afterward. PutMetaStore calls
+	// AddStoreLimit unconditionally after putStoreImpl, which -- for a store
+	// that already exists -- never resurrects State/NodeState, so a PutStore
+	// whose preflight raced a concurrent BuryStore still leaves the store
+	// tombstoned here. The incoming `store` argument is the caller's request
+	// payload, not the authoritative post-putStoreImpl state, so it can't be
+	// used for this check; re-fetch instead.
+	if existing := c.GetStore(storeID); existing != nil && existing.IsRemoved() {
+		return
+	}
 	var err error
 	for range persistLimitRetryTimes {
 		added := false

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1525,17 +1525,33 @@ func (c *RaftCluster) DeleteStoreLabel(storeID uint64, labelKey string) error {
 
 // PutMetaStore puts a store.
 func (c *RaftCluster) PutMetaStore(store *metapb.Store) error {
+	storeID := store.GetId()
+	// wasKnown alone isn't enough to decide whether to guard addStoreLimit
+	// against resurrecting a removed entry: a plain pre-putStoreImpl snapshot
+	// can't distinguish a genuine first registration from one that raced a
+	// full concurrent register-then-bury of the same ID landing in between
+	// the snapshot and putStoreImpl actually running -- wasKnown would read
+	// false either way, incorrectly skipping the guard for the second case.
+	// storeStateLock (the same per-store lock RemoveStore/BuryStore/UpStore/
+	// checkStore hold) makes the whole snapshot-then-act sequence below
+	// atomic with respect to any of those for this store ID, closing that
+	// window. This is a plain top-level entry point (only called from the
+	// gRPC PutStore handler), never invoked while already holding
+	// storeStateLock, so acquiring it here can't deadlock against them.
+	c.storeStateLock.Lock(uint32(storeID))
+	defer c.storeStateLock.Unlock(uint32(storeID))
+
 	// A tombstoned store's config entry is only ever cleared once, at bury time
-	// (RemoveStoreLimit); nothing sweeps it again afterward. The gRPC PutStore
-	// preflight isn't synchronized with BuryStore, so a request that observed
-	// an already-known store as live can still reach here after a concurrent
-	// bury tombstoned it and cleared its limit -- putStoreImpl won't resurrect
-	// the tombstone state for an existing store, but AddStoreLimit would
-	// recreate the entry unless guarded. Only guard the "already known" case:
-	// a store that was never registered before must still get a limit even if
-	// it's already tombstoned at first sight (e.g. state replayed from
+	// (RemoveStoreLimit); nothing sweeps it again afterward. putStoreImpl won't
+	// resurrect the tombstone state for an existing store, but AddStoreLimit
+	// would recreate the entry unless guarded. Only guard the "already known"
+	// case: a store that was never registered before must still get a limit
+	// even if it's already tombstoned at first sight (e.g. state replayed from
 	// storage), since there's no prior entry to protect from resurrection.
-	wasKnown := c.GetStore(store.GetId()) != nil
+	wasKnown := c.GetStore(storeID) != nil
+	failpoint.Inject("putMetaStoreAfterStoreStateLock", func() {
+		time.Sleep(300 * time.Millisecond)
+	})
 	if err := c.putStoreImpl(store, false); err != nil {
 		return err
 	}

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -159,7 +159,20 @@ type Server interface {
 type RaftCluster struct {
 	syncutil.RWMutex
 	storeStateLock *syncutil.LockGroup
-	wg             sync.WaitGroup
+	// storeLimitMu serializes the store-limit config's read-clone-mutate-
+	// persist cycle across AddStoreLimit/RemoveStoreLimit/SetStoreLimit/
+	// SetAllStoresLimit. Persist snapshots every PersistOptions field fresh
+	// at call time and writes it unconditionally (no version/CAS), so two of
+	// these methods racing can let a late writer's stale snapshot silently
+	// overwrite another's already-persisted, newer result -- e.g. an
+	// in-flight SetAllStoresLimit clobbering a concurrent deleteStore's
+	// RemoveStoreLimit cleanup with no later event to retry it. This lock
+	// only covers store-limit config writers; a Persist() caller for any
+	// other config section (scheduler config, keyspace config, and others --
+	// see the PR description's Known limitations) is not synchronized with
+	// these and can still race them the same way.
+	storeLimitMu syncutil.Mutex
+	wg           sync.WaitGroup
 
 	serverCtx context.Context
 	ctx       context.Context
@@ -2436,6 +2449,8 @@ func (c *RaftCluster) GetAllStoresLimit() map[uint64]sc.StoreLimitConfig {
 
 // AddStoreLimit add a store limit for a given store ID.
 func (c *RaftCluster) AddStoreLimit(store *metapb.Store) {
+	c.storeLimitMu.Lock()
+	defer c.storeLimitMu.Unlock()
 	storeID := store.GetId()
 	cfg := c.opt.GetScheduleConfig().Clone()
 	if _, ok := cfg.StoreLimit[storeID]; ok {
@@ -2468,6 +2483,8 @@ func (c *RaftCluster) AddStoreLimit(store *metapb.Store) {
 
 // RemoveStoreLimit remove a store limit for a given store ID.
 func (c *RaftCluster) RemoveStoreLimit(storeID uint64) {
+	c.storeLimitMu.Lock()
+	defer c.storeLimitMu.Unlock()
 	cfg := c.opt.GetScheduleConfig().Clone()
 	for _, limitType := range storelimit.TypeNameValue {
 		c.ResetStoreLimit(storeID, limitType)
@@ -2640,6 +2657,8 @@ func (c *RaftCluster) SetStoreLimit(storeID uint64, typ storelimit.Type, ratePer
 	if store := c.GetStore(storeID); store != nil && store.IsRemoved() {
 		return errs.ErrStoreRemoved.FastGenByArgs(storeID)
 	}
+	c.storeLimitMu.Lock()
+	defer c.storeLimitMu.Unlock()
 	old := c.opt.GetScheduleConfig().Clone()
 	c.opt.SetStoreLimit(storeID, typ, ratePerMin)
 	if err := c.opt.Persist(c.storage); err != nil {
@@ -2655,6 +2674,8 @@ func (c *RaftCluster) SetStoreLimit(storeID uint64, typ storelimit.Type, ratePer
 
 // SetAllStoresLimit sets all store limit for a given type and rate.
 func (c *RaftCluster) SetAllStoresLimit(typ storelimit.Type, ratePerMin float64) error {
+	c.storeLimitMu.Lock()
+	defer c.storeLimitMu.Unlock()
 	old := c.opt.GetScheduleConfig().Clone()
 	oldAdd := sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer)
 	oldRemove := sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer)

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1530,16 +1530,21 @@ func (c *RaftCluster) PutMetaStore(store *metapb.Store) error {
 	// addStoreLimitInternal against resurrecting a removed entry: a plain
 	// pre-putStoreImpl snapshot can't distinguish a genuine first
 	// registration from one that raced a full concurrent register-then-bury
-	// (or manual tombstone removal, see RemoveTombStoneRecords) of the same
-	// ID landing in between the snapshot and putStoreImpl actually running --
-	// wasKnown would read false either way, incorrectly skipping the guard
-	// for the second case. storeStateLock (the same per-store lock
-	// RemoveStore/BuryStore/UpStore/checkStore/RemoveTombStoneRecords hold)
-	// makes the whole snapshot-then-act sequence below atomic with respect to
-	// any of those for this store ID, closing that window. This is a plain
+	// of the same ID landing in between the snapshot and putStoreImpl
+	// actually running -- wasKnown would read false either way, incorrectly
+	// skipping the guard for the second case. storeStateLock (the same
+	// per-store lock RemoveStore/BuryStore/UpStore/checkStore hold) makes the
+	// whole snapshot-then-act sequence below atomic with respect to any of
+	// those for this store ID, closing that window. This is a plain
 	// top-level entry point (only called from the gRPC PutStore handler),
 	// never invoked while already holding storeStateLock, so acquiring it
 	// here can't deadlock against them.
+	//
+	// This does NOT close the gRPC preflight gap: the PutStore handler's
+	// checkStore runs before this call, so a store fully removed (by bury +
+	// RemoveTombStoneRecords) between that check and here reads as absent,
+	// not tombstoned, and is indistinguishable from a genuine new
+	// registration -- see the PR's Known limitations.
 	c.storeStateLock.Lock(uint32(storeID))
 	defer c.storeStateLock.Unlock(uint32(storeID))
 
@@ -2197,28 +2202,13 @@ func (c *RaftCluster) RemoveTombStoneRecords() error {
 	var failedStores []uint64
 	for _, store := range c.GetStores() {
 		if store.IsRemoved() {
-			storeID := store.GetID()
-			if c.GetStoreRegionCount(storeID) > 0 {
+			if c.GetStoreRegionCount(store.GetID()) > 0 {
 				log.Warn("skip removing tombstone", zap.Stringer("store", store.GetMeta()))
-				failedStores = append(failedStores, storeID)
+				failedStores = append(failedStores, store.GetID())
 				continue
 			}
 			// the store has already been tombstone
-			//
-			// deleteStore's other caller (checkStore) already holds
-			// storeStateLock for this ID; PutMetaStore also holds it for its
-			// whole snapshot-then-act sequence (see its comment). Without
-			// this lock here too, a PutMetaStore call whose gRPC preflight
-			// observed this store as known-but-live before this deletion
-			// completes could still read a stale wasKnown=true and reach
-			// putStoreImpl after the store is fully gone -- putStoreImpl
-			// would then take the brand-new-store path and durably recreate
-			// both the store and its limit.
-			err := func() error {
-				c.storeStateLock.Lock(uint32(storeID))
-				defer c.storeStateLock.Unlock(uint32(storeID))
-				return c.deleteStore(store)
-			}()
+			err := c.deleteStore(store)
 			if err != nil {
 				log.Error("delete store failed",
 					zap.Stringer("store", store.GetMeta()),

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1528,17 +1528,18 @@ func (c *RaftCluster) PutMetaStore(store *metapb.Store) error {
 	storeID := store.GetId()
 	// wasKnown alone isn't enough to decide whether to guard
 	// addStoreLimitInternal against resurrecting a removed entry: a plain
-	// pre-putStoreImpl snapshot
-	// can't distinguish a genuine first registration from one that raced a
-	// full concurrent register-then-bury of the same ID landing in between
-	// the snapshot and putStoreImpl actually running -- wasKnown would read
-	// false either way, incorrectly skipping the guard for the second case.
-	// storeStateLock (the same per-store lock RemoveStore/BuryStore/UpStore/
-	// checkStore hold) makes the whole snapshot-then-act sequence below
-	// atomic with respect to any of those for this store ID, closing that
-	// window. This is a plain top-level entry point (only called from the
-	// gRPC PutStore handler), never invoked while already holding
-	// storeStateLock, so acquiring it here can't deadlock against them.
+	// pre-putStoreImpl snapshot can't distinguish a genuine first
+	// registration from one that raced a full concurrent register-then-bury
+	// (or manual tombstone removal, see RemoveTombStoneRecords) of the same
+	// ID landing in between the snapshot and putStoreImpl actually running --
+	// wasKnown would read false either way, incorrectly skipping the guard
+	// for the second case. storeStateLock (the same per-store lock
+	// RemoveStore/BuryStore/UpStore/checkStore/RemoveTombStoneRecords hold)
+	// makes the whole snapshot-then-act sequence below atomic with respect to
+	// any of those for this store ID, closing that window. This is a plain
+	// top-level entry point (only called from the gRPC PutStore handler),
+	// never invoked while already holding storeStateLock, so acquiring it
+	// here can't deadlock against them.
 	c.storeStateLock.Lock(uint32(storeID))
 	defer c.storeStateLock.Unlock(uint32(storeID))
 
@@ -1550,9 +1551,7 @@ func (c *RaftCluster) PutMetaStore(store *metapb.Store) error {
 	// even if it's already tombstoned at first sight (e.g. state replayed from
 	// storage), since there's no prior entry to protect from resurrection.
 	wasKnown := c.GetStore(storeID) != nil
-	failpoint.Inject("putMetaStoreAfterStoreStateLock", func() {
-		time.Sleep(300 * time.Millisecond)
-	})
+	failpoint.InjectCall("putMetaStoreAfterWasKnownRead")
 	if err := c.putStoreImpl(store, false); err != nil {
 		return err
 	}
@@ -2198,13 +2197,28 @@ func (c *RaftCluster) RemoveTombStoneRecords() error {
 	var failedStores []uint64
 	for _, store := range c.GetStores() {
 		if store.IsRemoved() {
-			if c.GetStoreRegionCount(store.GetID()) > 0 {
+			storeID := store.GetID()
+			if c.GetStoreRegionCount(storeID) > 0 {
 				log.Warn("skip removing tombstone", zap.Stringer("store", store.GetMeta()))
-				failedStores = append(failedStores, store.GetID())
+				failedStores = append(failedStores, storeID)
 				continue
 			}
 			// the store has already been tombstone
-			err := c.deleteStore(store)
+			//
+			// deleteStore's other caller (checkStore) already holds
+			// storeStateLock for this ID; PutMetaStore also holds it for its
+			// whole snapshot-then-act sequence (see its comment). Without
+			// this lock here too, a PutMetaStore call whose gRPC preflight
+			// observed this store as known-but-live before this deletion
+			// completes could still read a stale wasKnown=true and reach
+			// putStoreImpl after the store is fully gone -- putStoreImpl
+			// would then take the brand-new-store path and durably recreate
+			// both the store and its limit.
+			err := func() error {
+				c.storeStateLock.Lock(uint32(storeID))
+				defer c.storeStateLock.Unlock(uint32(storeID))
+				return c.deleteStore(store)
+			}()
 			if err != nil {
 				log.Error("delete store failed",
 					zap.Stringer("store", store.GetMeta()),

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1526,8 +1526,9 @@ func (c *RaftCluster) DeleteStoreLabel(storeID uint64, labelKey string) error {
 // PutMetaStore puts a store.
 func (c *RaftCluster) PutMetaStore(store *metapb.Store) error {
 	storeID := store.GetId()
-	// wasKnown alone isn't enough to decide whether to guard addStoreLimit
-	// against resurrecting a removed entry: a plain pre-putStoreImpl snapshot
+	// wasKnown alone isn't enough to decide whether to guard
+	// addStoreLimitInternal against resurrecting a removed entry: a plain
+	// pre-putStoreImpl snapshot
 	// can't distinguish a genuine first registration from one that raced a
 	// full concurrent register-then-bury of the same ID landing in between
 	// the snapshot and putStoreImpl actually running -- wasKnown would read
@@ -1556,7 +1557,7 @@ func (c *RaftCluster) PutMetaStore(store *metapb.Store) error {
 		return err
 	}
 	c.OnStoreVersionChange()
-	c.addStoreLimit(store, wasKnown)
+	c.addStoreLimitInternal(store, wasKnown)
 	return nil
 }
 
@@ -2467,12 +2468,12 @@ func (c *RaftCluster) GetAllStoresLimit() map[uint64]sc.StoreLimitConfig {
 // replayed from storage) -- there's no prior entry to protect from
 // resurrection in that case. Callers that must guard an already-known store
 // against resurrecting a deliberately-removed entry should use
-// addStoreLimit(store, true) instead (see PutMetaStore).
+// addStoreLimitInternal(store, true) instead (see PutMetaStore).
 func (c *RaftCluster) AddStoreLimit(store *metapb.Store) {
-	c.addStoreLimit(store, false)
+	c.addStoreLimitInternal(store, false)
 }
 
-// addStoreLimit is AddStoreLimit's implementation. When skipIfRemoved is
+// addStoreLimitInternal is AddStoreLimit's implementation. When skipIfRemoved is
 // true, it re-checks the store's current tombstone state on every retry
 // attempt, from inside the same UpdateScheduleConfig closure that
 // RemoveStoreLimit's own deletion runs under -- not just once before the
@@ -2486,7 +2487,7 @@ func (c *RaftCluster) AddStoreLimit(store *metapb.Store) {
 // PutMetaStore's guard originally did) doesn't have this property: a bury
 // landing during persistLimitWaitTime's sleep between failed attempts can
 // still race a later retry that never re-reads store state.
-func (c *RaftCluster) addStoreLimit(store *metapb.Store, skipIfRemoved bool) {
+func (c *RaftCluster) addStoreLimitInternal(store *metapb.Store, skipIfRemoved bool) {
 	storeID := store.GetId()
 	var err error
 	for range persistLimitRetryTimes {

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -3618,6 +3618,69 @@ func TestPutMetaStoreDoesNotRestoreRemovedStoreLimit(t *testing.T) {
 	re.False(ok)
 }
 
+// TestPutMetaStoreCannotRaceConcurrentRegistrationAndBury guards against
+// PutMetaStore's wasKnown snapshot going stale: a request that reads
+// wasKnown=false, then pauses before putStoreImpl, can't let a second,
+// fully-completed register-then-bury of the same store ID land in between --
+// storeStateLock must serialize the whole thing. Proven by showing a
+// concurrent BuryStore for the same ID cannot complete while PutMetaStore is
+// paused mid-call, not just by checking the eventual outcome (which the
+// no-guard code also happens to get right if the race doesn't actually
+// interleave).
+func TestPutMetaStoreCannotRaceConcurrentRegistrationAndBury(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, opt, err := newTestScheduleConfig()
+	re.NoError(err)
+	backend := storage.NewStorageWithMemoryBackend()
+	rc := newTestRaftCluster(ctx, mockid.NewIDAllocator(), opt, backend)
+
+	const storeID = uint64(1)
+	meta := &metapb.Store{
+		Id:      storeID,
+		Address: "mock://tikv-1:1",
+		State:   metapb.StoreState_Up,
+		Version: "2.0.0",
+	}
+
+	re.NoError(failpoint.Enable("github.com/tikv/pd/server/cluster/putMetaStoreAfterStoreStateLock", "return(true)"))
+	defer failpoint.Disable("github.com/tikv/pd/server/cluster/putMetaStoreAfterStoreStateLock") //nolint:errcheck
+
+	putDone := make(chan error, 1)
+	go func() {
+		putDone <- rc.PutMetaStore(meta)
+	}()
+
+	// Give PutMetaStore time to acquire storeStateLock, read wasKnown (false,
+	// since the store doesn't exist yet), and reach the failpoint's sleep.
+	time.Sleep(50 * time.Millisecond)
+
+	// A full register-then-bury of the same ID must not be able to complete
+	// while PutMetaStore is paused holding storeStateLock for it.
+	buryDone := make(chan error, 1)
+	go func() {
+		store := core.NewStoreInfo(&metapb.Store{Id: storeID, State: metapb.StoreState_Up})
+		rc.PutStore(store)
+		rc.PutStore(store.Clone(core.SetStoreState(metapb.StoreState_Offline, true)))
+		buryDone <- rc.BuryStore(storeID, false)
+	}()
+
+	select {
+	case err := <-buryDone:
+		re.Fail("BuryStore returned before PutMetaStore released storeStateLock", "err: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	re.NoError(<-putDone)
+	re.NoError(<-buryDone)
+
+	re.True(rc.GetStore(storeID).IsRemoved())
+	_, ok := opt.GetScheduleConfig().StoreLimit[storeID]
+	re.False(ok, "the bury that ran after PutMetaStore released the lock must be the final word on this store's limit")
+}
+
 func TestPatrolRegionConcurrency(t *testing.T) {
 	re := require.New(t)
 

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -3540,6 +3540,45 @@ func TestInitSchedulersPreservesConcurrentScheduleUpdate(t *testing.T) {
 	re.Equal(float64(60), reloadedOpt.GetScheduleConfig().DefaultStoreLimit.AddPeer)
 }
 
+// TestSetAllStoresLimitDoesNotRestoreRemovedStoreLimit guards against
+// PersistOptions.GetStoreLimit's create-on-miss side effect leaking into
+// SetAllStoresLimit's refreshStoreRateLimit loop. A tombstoned store stays in
+// GetStoreIDs() until its final removal, so that loop still visits it after
+// RemoveStoreLimit has deliberately deleted its config entry; a mutating
+// lookup there would resurrect the entry. No concurrency is needed to trigger
+// this -- it's deterministic within a single goroutine.
+func TestSetAllStoresLimitDoesNotRestoreRemovedStoreLimit(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, opt, err := newTestScheduleConfig()
+	re.NoError(err)
+	backend := storage.NewStorageWithMemoryBackend()
+	rc := newTestRaftCluster(ctx, mockid.NewIDAllocator(), opt, backend)
+
+	const storeID = uint64(1)
+	store := core.NewStoreInfo(&metapb.Store{Id: storeID, State: metapb.StoreState_Up})
+	rc.PutStore(store)
+	rc.AddStoreLimit(store.GetMeta())
+
+	rc.PutStore(store.Clone(core.SetStoreState(metapb.StoreState_Tombstone)))
+	rc.RemoveStoreLimit(storeID)
+	_, ok := opt.GetScheduleConfig().StoreLimit[storeID]
+	re.False(ok)
+
+	re.NoError(rc.SetAllStoresLimit(storelimit.AddPeer, 60))
+	_, ok = opt.GetScheduleConfig().StoreLimit[storeID]
+	re.False(ok)
+
+	re.NoError(opt.Persist(backend))
+	_, reloaded, err := newTestScheduleConfig()
+	re.NoError(err)
+	re.NoError(reloaded.Reload(backend))
+	_, ok = reloaded.GetScheduleConfig().StoreLimit[storeID]
+	re.False(ok)
+}
+
 func TestPatrolRegionConcurrency(t *testing.T) {
 	re := require.New(t)
 

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -3579,6 +3579,45 @@ func TestSetAllStoresLimitDoesNotRestoreRemovedStoreLimit(t *testing.T) {
 	re.False(ok)
 }
 
+// TestPutMetaStoreDoesNotRestoreRemovedStoreLimit guards against
+// AddStoreLimit recreating a StoreLimit entry for an already-tombstoned
+// store. PutMetaStore calls AddStoreLimit unconditionally after
+// putStoreImpl, and putStoreImpl never resurrects an existing store's
+// State/NodeState -- so a PutStore whose gRPC preflight raced a concurrent
+// BuryStore still lands on a store that's tombstoned by the time
+// AddStoreLimit runs. AddStoreLimit's own `store` argument is the caller's
+// request payload, not the authoritative post-putStoreImpl state, so it
+// can't be used to detect this; the fix re-fetches instead.
+func TestPutMetaStoreDoesNotRestoreRemovedStoreLimit(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, opt, err := newTestScheduleConfig()
+	re.NoError(err)
+	backend := storage.NewStorageWithMemoryBackend()
+	rc := newTestRaftCluster(ctx, mockid.NewIDAllocator(), opt, backend)
+
+	store := newTestStores(1, "2.0.0")[0]
+	rc.PutStore(store)
+	rc.AddStoreLimit(store.GetMeta())
+	rc.PutStore(store.Clone(core.SetStoreState(metapb.StoreState_Offline, true)))
+	re.NoError(rc.BuryStore(store.GetID(), false))
+	_, ok := opt.GetScheduleConfig().StoreLimit[store.GetID()]
+	re.False(ok)
+
+	re.NoError(rc.PutMetaStore(store.GetMeta()))
+	re.True(rc.GetStore(store.GetID()).IsRemoved())
+	_, ok = opt.GetScheduleConfig().StoreLimit[store.GetID()]
+	re.False(ok)
+
+	_, reloaded, err := newTestScheduleConfig()
+	re.NoError(err)
+	re.NoError(reloaded.Reload(backend))
+	_, ok = reloaded.GetScheduleConfig().StoreLimit[store.GetID()]
+	re.False(ok)
+}
+
 func TestPatrolRegionConcurrency(t *testing.T) {
 	re := require.New(t)
 

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -3349,6 +3350,87 @@ func TestStoreLimitChangeRefreshLimiter(t *testing.T) {
 	store = rc.GetStore(storeID)
 	re.NotNil(store)
 	re.True(store.IsAvailable(storelimit.AddPeer, constant.Low))
+}
+
+// blockingConfigStorage wraps a storage.Storage and pauses the first
+// SaveConfig call until release is closed, letting a second, concurrent
+// SaveConfig call complete first -- modeling PersistOptions.Persist's
+// snapshot-then-write gap, where a paused caller's stale snapshot can
+// overwrite a faster caller's already-persisted, newer result.
+type blockingConfigStorage struct {
+	storage.Storage
+	entered chan struct{}
+	release chan struct{}
+	first   atomic.Bool
+}
+
+func (s *blockingConfigStorage) SaveConfig(cfg any) error {
+	if s.first.CompareAndSwap(false, true) {
+		close(s.entered)
+		<-s.release
+	}
+	return s.Storage.SaveConfig(cfg)
+}
+
+func TestDeleteStoreLimitDoesNotLoseConcurrentAllStoreUpdate(t *testing.T) {
+	re := require.New(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, opt, err := newTestScheduleConfig()
+	re.NoError(err)
+
+	backend := storage.NewStorageWithMemoryBackend()
+	rc := newTestRaftCluster(ctx, mockid.NewIDAllocator(), opt, backend)
+	const storeID = uint64(1)
+	tombstone := core.NewStoreInfo(&metapb.Store{
+		Id:        storeID,
+		State:     metapb.StoreState_Tombstone,
+		NodeState: metapb.NodeState_Removed,
+	})
+	rc.PutStore(tombstone)
+
+	// Seed a durable per-store limit before installing the barrier.
+	opt.SetStoreLimit(storeID, storelimit.AddPeer, 60)
+	re.NoError(backend.SaveStoreMeta(tombstone.GetMeta()))
+	re.NoError(opt.Persist(backend))
+
+	blocked := &blockingConfigStorage{
+		Storage: backend,
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	rc.storage = blocked
+
+	setDone := make(chan error, 1)
+	go func() {
+		setDone <- rc.SetAllStoresLimit(storelimit.AddPeer, 120)
+	}()
+	<-blocked.entered // SetAllStoresLimit holds storeLimitMu, paused inside SaveConfig.
+
+	// deleteStore -> RemoveStoreLimit must not be able to read, mutate, and
+	// persist while SetAllStoresLimit is mid-cycle: storeLimitMu should make
+	// it block here until the barrier below releases SetAllStoresLimit.
+	deleteDone := make(chan error, 1)
+	go func() {
+		deleteDone <- rc.deleteStore(tombstone)
+	}()
+	select {
+	case err := <-deleteDone:
+		re.Fail("deleteStore returned before SetAllStoresLimit released storeLimitMu", "err: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(blocked.release)
+	re.NoError(<-setDone)
+	re.NoError(<-deleteDone)
+
+	_, reloaded, err := newTestScheduleConfig()
+	re.NoError(err)
+	re.NoError(reloaded.Reload(backend))
+	_, ok := reloaded.GetScheduleConfig().StoreLimit[storeID]
+	re.False(ok)
 }
 
 func TestPatrolRegionConcurrency(t *testing.T) {

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -3618,9 +3618,32 @@ func TestPutMetaStoreDoesNotRestoreRemovedStoreLimit(t *testing.T) {
 	re.False(ok)
 }
 
+// enablePutMetaStoreAfterWasKnownReadBarrier registers a real callback for
+// PutMetaStore's putMetaStoreAfterWasKnownRead InjectCall, invoked
+// synchronously exactly once wasKnown has been read and before putStoreImpl
+// runs -- proof of reaching that point, not a guess based on timing (a fixed
+// sleep can't guarantee a goroutine has been scheduled far enough on a slow
+// or delayed CI worker, and pausing anywhere inside putStoreImpl fires after
+// it has already decided new-vs-existing-store, too late to model a request
+// that raced a full concurrent register-then-remove of the same ID). Returns
+// the entered and release channels and a cleanup to disable the callback.
+func enablePutMetaStoreAfterWasKnownReadBarrier(t *testing.T) (entered, release chan struct{}) {
+	entered = make(chan struct{})
+	release = make(chan struct{})
+	const fp = "github.com/tikv/pd/server/cluster/putMetaStoreAfterWasKnownRead"
+	require.NoError(t, failpoint.EnableCall(fp, func() {
+		close(entered)
+		<-release
+	}))
+	t.Cleanup(func() {
+		require.NoError(t, failpoint.Disable(fp))
+	})
+	return entered, release
+}
+
 // TestPutMetaStoreCannotRaceConcurrentRegistrationAndBury guards against
 // PutMetaStore's wasKnown snapshot going stale: a request that reads
-// wasKnown=false, then pauses before putStoreImpl, can't let a second,
+// wasKnown=false, then pauses before putStoreImpl runs, can't let a second,
 // fully-completed register-then-bury of the same store ID land in between --
 // storeStateLock must serialize the whole thing. Proven by showing a
 // concurrent BuryStore for the same ID cannot complete while PutMetaStore is
@@ -3645,17 +3668,21 @@ func TestPutMetaStoreCannotRaceConcurrentRegistrationAndBury(t *testing.T) {
 		Version: "2.0.0",
 	}
 
-	re.NoError(failpoint.Enable("github.com/tikv/pd/server/cluster/putMetaStoreAfterStoreStateLock", "return(true)"))
-	defer failpoint.Disable("github.com/tikv/pd/server/cluster/putMetaStoreAfterStoreStateLock") //nolint:errcheck
+	entered, release := enablePutMetaStoreAfterWasKnownReadBarrier(t)
 
 	putDone := make(chan error, 1)
 	go func() {
 		putDone <- rc.PutMetaStore(meta)
 	}()
 
-	// Give PutMetaStore time to acquire storeStateLock, read wasKnown (false,
-	// since the store doesn't exist yet), and reach the failpoint's sleep.
-	time.Sleep(50 * time.Millisecond)
+	// Wait for PutMetaStore to actually reach the point right after reading
+	// wasKnown -- proof it already holds storeStateLock, not a guess based on
+	// timing.
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("PutMetaStore did not reach the wasKnown-read barrier")
+	}
 
 	// A full register-then-bury of the same ID must not be able to complete
 	// while PutMetaStore is paused holding storeStateLock for it.
@@ -3673,12 +3700,82 @@ func TestPutMetaStoreCannotRaceConcurrentRegistrationAndBury(t *testing.T) {
 	case <-time.After(100 * time.Millisecond):
 	}
 
+	close(release)
+
 	re.NoError(<-putDone)
 	re.NoError(<-buryDone)
 
 	re.True(rc.GetStore(storeID).IsRemoved())
 	_, ok := opt.GetScheduleConfig().StoreLimit[storeID]
 	re.False(ok, "the bury that ran after PutMetaStore released the lock must be the final word on this store's limit")
+}
+
+// TestPutMetaStoreCannotRaceConcurrentManualTombstoneRemoval guards against
+// RemoveTombStoneRecords' deleteStore call resurrecting a store PutMetaStore
+// is mid-flight on: without storeStateLock around it too, PutMetaStore could
+// read wasKnown=true for a store that's about to be (or just was) fully
+// deleted, then putStoreImpl's storage write and in-memory PutStore would
+// durably recreate both the store and its limit after the deletion already
+// ran. Proven the same way as the bury case: a concurrent
+// RemoveTombStoneRecords for the same store cannot complete while
+// PutMetaStore is paused mid-call.
+func TestPutMetaStoreCannotRaceConcurrentManualTombstoneRemoval(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, opt, err := newTestScheduleConfig()
+	re.NoError(err)
+	backend := storage.NewStorageWithMemoryBackend()
+	rc := newTestRaftCluster(ctx, mockid.NewIDAllocator(), opt, backend)
+
+	const storeID = uint64(1)
+	store := newTestStores(1, "2.0.0")[0]
+	rc.PutStore(store)
+	rc.AddStoreLimit(store.GetMeta())
+	rc.PutStore(store.Clone(core.SetStoreState(metapb.StoreState_Offline, true)))
+	re.NoError(rc.BuryStore(storeID, false))
+	_, ok := opt.GetScheduleConfig().StoreLimit[storeID]
+	re.False(ok)
+
+	entered, release := enablePutMetaStoreAfterWasKnownReadBarrier(t)
+
+	// Models a request whose gRPC preflight saw this store as known (it still
+	// is -- tombstoned, but not yet manually removed).
+	putDone := make(chan error, 1)
+	go func() {
+		putDone <- rc.PutMetaStore(store.GetMeta())
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("PutMetaStore did not reach the wasKnown-read barrier")
+	}
+
+	// A manual remove-tombstone for the same store must not be able to
+	// complete while PutMetaStore is paused holding storeStateLock for it.
+	removeDone := make(chan error, 1)
+	go func() {
+		removeDone <- rc.RemoveTombStoneRecords()
+	}()
+
+	select {
+	case err := <-removeDone:
+		re.Fail("RemoveTombStoneRecords returned before PutMetaStore released storeStateLock", "err: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(release)
+
+	re.NoError(<-putDone)
+	re.NoError(<-removeDone)
+
+	// The manual removal that ran after PutMetaStore released the lock must
+	// be the final word: the store is gone for good, not resurrected.
+	re.Nil(rc.GetStore(storeID))
+	_, ok = opt.GetScheduleConfig().StoreLimit[storeID]
+	re.False(ok)
 }
 
 func TestPatrolRegionConcurrency(t *testing.T) {

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -3618,38 +3618,20 @@ func TestPutMetaStoreDoesNotRestoreRemovedStoreLimit(t *testing.T) {
 	re.False(ok)
 }
 
-// enablePutMetaStoreAfterWasKnownReadBarrier registers a real callback for
-// PutMetaStore's putMetaStoreAfterWasKnownRead InjectCall, invoked
-// synchronously exactly once wasKnown has been read and before putStoreImpl
-// runs -- proof of reaching that point, not a guess based on timing (a fixed
-// sleep can't guarantee a goroutine has been scheduled far enough on a slow
-// or delayed CI worker, and pausing anywhere inside putStoreImpl fires after
-// it has already decided new-vs-existing-store, too late to model a request
-// that raced a full concurrent register-then-remove of the same ID). Returns
-// the entered and release channels and a cleanup to disable the callback.
-func enablePutMetaStoreAfterWasKnownReadBarrier(t *testing.T) (entered, release chan struct{}) {
-	entered = make(chan struct{})
-	release = make(chan struct{})
-	const fp = "github.com/tikv/pd/server/cluster/putMetaStoreAfterWasKnownRead"
-	require.NoError(t, failpoint.EnableCall(fp, func() {
-		close(entered)
-		<-release
-	}))
-	t.Cleanup(func() {
-		require.NoError(t, failpoint.Disable(fp))
-	})
-	return entered, release
-}
-
 // TestPutMetaStoreCannotRaceConcurrentRegistrationAndBury guards against
 // PutMetaStore's wasKnown snapshot going stale: a request that reads
 // wasKnown=false, then pauses before putStoreImpl runs, can't let a second,
 // fully-completed register-then-bury of the same store ID land in between --
-// storeStateLock must serialize the whole thing. Proven by showing a
-// concurrent BuryStore for the same ID cannot complete while PutMetaStore is
-// paused mid-call, not just by checking the eventual outcome (which the
-// no-guard code also happens to get right if the race doesn't actually
-// interleave).
+// storeStateLock must serialize the whole thing.
+//
+// Determinism: the contender's BuryStore runs synchronously on the test
+// goroutine (never scheduler-starved, unlike a `go func()` contender), and
+// BuryStore's very first statement is storeStateLock.Lock. The assertion is
+// on how long that blocked call takes: with the lock it can't return until a
+// timed goroutine releases PutMetaStore (time.Sleep is a floor, so a slow
+// worker only makes the wait longer); without the lock BuryStore takes the
+// uncontended lock and returns in well under a millisecond. There is no
+// timing window a slow worker can slip a false pass through.
 func TestPutMetaStoreCannotRaceConcurrentRegistrationAndBury(t *testing.T) {
 	re := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -3668,114 +3650,54 @@ func TestPutMetaStoreCannotRaceConcurrentRegistrationAndBury(t *testing.T) {
 		Version: "2.0.0",
 	}
 
-	entered, release := enablePutMetaStoreAfterWasKnownReadBarrier(t)
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	const fp = "github.com/tikv/pd/server/cluster/putMetaStoreAfterWasKnownRead"
+	re.NoError(failpoint.EnableCall(fp, func() {
+		close(entered)
+		<-release
+	}))
+	defer func() { re.NoError(failpoint.Disable(fp)) }()
 
 	putDone := make(chan error, 1)
 	go func() {
 		putDone <- rc.PutMetaStore(meta)
 	}()
 
-	// Wait for PutMetaStore to actually reach the point right after reading
-	// wasKnown -- proof it already holds storeStateLock, not a guess based on
-	// timing.
+	// Wait for PutMetaStore to reach the point right after reading wasKnown --
+	// proof it already holds storeStateLock.
 	select {
 	case <-entered:
 	case <-time.After(2 * time.Second):
 		t.Fatal("PutMetaStore did not reach the wasKnown-read barrier")
 	}
 
-	// A full register-then-bury of the same ID must not be able to complete
-	// while PutMetaStore is paused holding storeStateLock for it.
-	buryDone := make(chan error, 1)
+	// Release PutMetaStore (and thus storeStateLock) only after a delay.
+	const holdFor = 200 * time.Millisecond
 	go func() {
-		store := core.NewStoreInfo(&metapb.Store{Id: storeID, State: metapb.StoreState_Up})
-		rc.PutStore(store)
-		rc.PutStore(store.Clone(core.SetStoreState(metapb.StoreState_Offline, true)))
-		buryDone <- rc.BuryStore(storeID, false)
+		time.Sleep(holdFor)
+		close(release)
 	}()
 
-	select {
-	case err := <-buryDone:
-		re.Fail("BuryStore returned before PutMetaStore released storeStateLock", "err: %v", err)
-	case <-time.After(100 * time.Millisecond):
-	}
+	// A full register-then-bury of the same ID. The bury cannot proceed
+	// while PutMetaStore holds storeStateLock, so this synchronous call
+	// blocks until the goroutine above releases it.
+	store := core.NewStoreInfo(&metapb.Store{Id: storeID, State: metapb.StoreState_Up})
+	rc.PutStore(store)
+	rc.PutStore(store.Clone(core.SetStoreState(metapb.StoreState_Offline, true)))
+	start := time.Now()
+	buryErr := rc.BuryStore(storeID, false)
+	blocked := time.Since(start)
 
-	close(release)
+	re.NoError(buryErr)
+	re.GreaterOrEqual(blocked, holdFor-50*time.Millisecond,
+		"BuryStore returned too fast: it was not blocked on storeStateLock held by PutMetaStore")
 
 	re.NoError(<-putDone)
-	re.NoError(<-buryDone)
 
 	re.True(rc.GetStore(storeID).IsRemoved())
 	_, ok := opt.GetScheduleConfig().StoreLimit[storeID]
 	re.False(ok, "the bury that ran after PutMetaStore released the lock must be the final word on this store's limit")
-}
-
-// TestPutMetaStoreCannotRaceConcurrentManualTombstoneRemoval guards against
-// RemoveTombStoneRecords' deleteStore call resurrecting a store PutMetaStore
-// is mid-flight on: without storeStateLock around it too, PutMetaStore could
-// read wasKnown=true for a store that's about to be (or just was) fully
-// deleted, then putStoreImpl's storage write and in-memory PutStore would
-// durably recreate both the store and its limit after the deletion already
-// ran. Proven the same way as the bury case: a concurrent
-// RemoveTombStoneRecords for the same store cannot complete while
-// PutMetaStore is paused mid-call.
-func TestPutMetaStoreCannotRaceConcurrentManualTombstoneRemoval(t *testing.T) {
-	re := require.New(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	_, opt, err := newTestScheduleConfig()
-	re.NoError(err)
-	backend := storage.NewStorageWithMemoryBackend()
-	rc := newTestRaftCluster(ctx, mockid.NewIDAllocator(), opt, backend)
-
-	const storeID = uint64(1)
-	store := newTestStores(1, "2.0.0")[0]
-	rc.PutStore(store)
-	rc.AddStoreLimit(store.GetMeta())
-	rc.PutStore(store.Clone(core.SetStoreState(metapb.StoreState_Offline, true)))
-	re.NoError(rc.BuryStore(storeID, false))
-	_, ok := opt.GetScheduleConfig().StoreLimit[storeID]
-	re.False(ok)
-
-	entered, release := enablePutMetaStoreAfterWasKnownReadBarrier(t)
-
-	// Models a request whose gRPC preflight saw this store as known (it still
-	// is -- tombstoned, but not yet manually removed).
-	putDone := make(chan error, 1)
-	go func() {
-		putDone <- rc.PutMetaStore(store.GetMeta())
-	}()
-
-	select {
-	case <-entered:
-	case <-time.After(2 * time.Second):
-		t.Fatal("PutMetaStore did not reach the wasKnown-read barrier")
-	}
-
-	// A manual remove-tombstone for the same store must not be able to
-	// complete while PutMetaStore is paused holding storeStateLock for it.
-	removeDone := make(chan error, 1)
-	go func() {
-		removeDone <- rc.RemoveTombStoneRecords()
-	}()
-
-	select {
-	case err := <-removeDone:
-		re.Fail("RemoveTombStoneRecords returned before PutMetaStore released storeStateLock", "err: %v", err)
-	case <-time.After(100 * time.Millisecond):
-	}
-
-	close(release)
-
-	re.NoError(<-putDone)
-	re.NoError(<-removeDone)
-
-	// The manual removal that ran after PutMetaStore released the lock must
-	// be the final word: the store is gone for good, not resurrected.
-	re.Nil(rc.GetStore(storeID))
-	_, ok = opt.GetScheduleConfig().StoreLimit[storeID]
-	re.False(ok)
 }
 
 func TestPatrolRegionConcurrency(t *testing.T) {

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -557,6 +557,28 @@ func (o *PersistOptions) GetStoreLimit(storeID uint64) (returnSC sc.StoreLimitCo
 // GetStoreLimitByType returns the limit of a store with a given type.
 func (o *PersistOptions) GetStoreLimitByType(storeID uint64, typ storelimit.Type) (returned float64) {
 	limit := o.GetStoreLimit(storeID)
+	return storeLimitByType(limit, typ)
+}
+
+// PeekStoreLimitByType returns the limit of a store with a given type without
+// the create-on-miss side effect GetStoreLimitByType has: it never adds a
+// StoreLimit entry for storeID, falling back to the config's default in
+// memory only. Callers that refresh in-memory rate limiters for every
+// currently-known store (as opposed to looking up one specific store the
+// caller is about to act on) must use this -- GetStoreLimitByType would
+// otherwise resurrect an entry a concurrent-or-prior RemoveStoreLimit
+// deliberately removed, since a tombstoned store stays in that "known store"
+// set until its final removal.
+func (o *PersistOptions) PeekStoreLimitByType(storeID uint64, typ storelimit.Type) float64 {
+	cfg := o.GetScheduleConfig()
+	limit, ok := cfg.StoreLimit[storeID]
+	if !ok {
+		limit = cfg.GetDefaultStoreLimit()
+	}
+	return storeLimitByType(limit, typ)
+}
+
+func storeLimitByType(limit sc.StoreLimitConfig, typ storelimit.Type) float64 {
 	switch typ {
 	case storelimit.AddPeer:
 		return limit.AddPeer

--- a/server/handler.go
+++ b/server/handler.go
@@ -265,6 +265,14 @@ func (h *Handler) SetLabelStoresLimit(ratePerMin float64, limitType storelimit.T
 		return err
 	}
 	for _, store := range c.GetStores() {
+		if store.IsRemoved() {
+			// A tombstoned store with no engine label is still classified
+			// TiKV by IsTiKV(), and SetStoreLimit now rejects it. Skip it
+			// here instead of letting that rejection abort the whole batch
+			// below (the engine=tikv branch returns err on the first
+			// failure).
+			continue
+		}
 		for _, label := range labels {
 			// set limit for tikv stores
 			if label.Key == core.EngineKey && label.Value == core.EngineTiKV {

--- a/tests/server/api/store_test.go
+++ b/tests/server/api/store_test.go
@@ -207,6 +207,46 @@ func (suite *storeTestSuite) checkGetAllLimit(cluster *tests.TestCluster) {
 	}
 }
 
+func (suite *storeTestSuite) TestSetLabelStoresLimitSkipsRemovedStore() {
+	suite.env.RunTestInNonMicroserviceEnv(suite.checkSetLabelStoresLimitSkipsRemovedStore)
+}
+
+func (suite *storeTestSuite) checkSetLabelStoresLimitSkipsRemovedStore(cluster *tests.TestCluster) {
+	re := suite.Require()
+	for _, store := range initStores() {
+		tests.MustPutStore(re, cluster, store)
+	}
+
+	leader := cluster.GetLeaderServer()
+	rc := leader.GetRaftCluster()
+	rc.RemoveStoreLimit(7)
+
+	// Store 7 is tombstoned with no engine label, so IsTiKV() still
+	// classifies it as TiKV -- without skipping removed stores up front,
+	// SetStoreLimit's tombstone rejection for store 7 would abort this
+	// whole request before the live TiKV stores below it get processed.
+	body, err := json.Marshal(map[string]any{
+		"rate":   60,
+		"type":   "add-peer",
+		"labels": map[string]string{"engine": "tikv"},
+	})
+	re.NoError(err)
+	err = testutil.CheckPostJSON(
+		tests.TestDialClient,
+		leader.GetAddr()+"/pd/api/v1/stores/limit",
+		body,
+		testutil.StatusOK(re),
+	)
+	re.NoError(err)
+
+	limits := rc.GetAllStoresLimit()
+	liveLimit, ok := limits[1]
+	re.True(ok)
+	re.Equal(float64(60), liveLimit.AddPeer)
+	_, ok = limits[7]
+	re.False(ok)
+}
+
 func (suite *storeTestSuite) checkStoreLabel(cluster *tests.TestCluster) {
 	re := suite.Require()
 

--- a/tests/server/cluster/cluster_test.go
+++ b/tests/server/cluster/cluster_test.go
@@ -544,6 +544,13 @@ func testStateAndLimit(re *require.Assertions, clusterID uint64, rc *cluster.Raf
 	// prepare
 	storeID := store.GetId()
 	oc := rc.GetOperatorController()
+	// The store can be left tombstoned by a previous call to this helper (the
+	// tombstone beforeState block runs it twice on the same store); reset it
+	// to a non-removed baseline first so these SetStoreLimit calls -- which
+	// only exist to seed a limit before resetStoreState below establishes the
+	// state this specific case actually wants to test -- aren't rejected by
+	// SetStoreLimit's own tombstone check.
+	resetStoreState(re, rc, storeID, metapb.StoreState_Up)
 	err := rc.SetStoreLimit(storeID, storelimit.AddPeer, 60)
 	re.NoError(err)
 	err = rc.SetStoreLimit(storeID, storelimit.RemovePeer, 60)

--- a/tests/server/cluster/cluster_test.go
+++ b/tests/server/cluster/cluster_test.go
@@ -545,16 +545,19 @@ func testStateAndLimit(re *require.Assertions, clusterID uint64, rc *cluster.Raf
 	storeID := store.GetId()
 	oc := rc.GetOperatorController()
 	// The store can be left tombstoned by a previous call to this helper (the
-	// tombstone beforeState block runs it twice on the same store); reset it
-	// to a non-removed baseline first so these SetStoreLimit calls -- which
-	// only exist to seed a limit before resetStoreState below establishes the
-	// state this specific case actually wants to test -- aren't rejected by
-	// SetStoreLimit's own tombstone check.
-	resetStoreState(re, rc, storeID, metapb.StoreState_Up)
-	err := rc.SetStoreLimit(storeID, storelimit.AddPeer, 60)
-	re.NoError(err)
-	err = rc.SetStoreLimit(storeID, storelimit.RemovePeer, 60)
-	re.NoError(err)
+	// tombstone beforeState block runs it twice on the same store). Production
+	// never un-tombstones a store, so don't fake that transition here either --
+	// these SetStoreLimit calls only exist to seed a limit before resetStoreState
+	// below establishes the state this specific case actually wants to test, and
+	// resetStoreState's own Tombstone branch clears any limit anyway, so seeding
+	// one is pointless (and rejected by SetStoreLimit) once the store is already
+	// tombstoned.
+	if store := rc.GetStore(storeID); store == nil || !store.IsRemoved() {
+		err := rc.SetStoreLimit(storeID, storelimit.AddPeer, 60)
+		re.NoError(err)
+		err = rc.SetStoreLimit(storeID, storelimit.RemovePeer, 60)
+		re.NoError(err)
+	}
 	op := operator.NewTestOperator(2, &metapb.RegionEpoch{}, operator.OpRegion, operator.AddPeer{ToStore: storeID, PeerID: 3})
 	oc.AddOperator(op)
 	op = operator.NewTestOperator(2, &metapb.RegionEpoch{}, operator.OpRegion, operator.RemovePeer{FromStore: storeID})
@@ -563,7 +566,7 @@ func testStateAndLimit(re *require.Assertions, clusterID uint64, rc *cluster.Raf
 	resetStoreState(re, rc, store.GetId(), beforeState)
 	_, isOKBefore := rc.GetAllStoresLimit()[storeID]
 	// run
-	err = run(rc)
+	err := run(rc)
 	// judge
 	_, isOKAfter := rc.GetAllStoresLimit()[storeID]
 	if len(expectStates) != 0 {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #11126

### What is changed and how does it work?

```commit-message
#11127 closed most of the ways a store's per-store Prometheus metrics
could be republished after it was tombstoned, but two writers never
checked IsRemoved() at all, unlike statistics.storeStatistics.observe()'s
existing early return for the same fields:

- ObserveHotStat kept republishing storeStatusGauge every collection
  tick for as long as the store's RollingStoreStats entry existed.
  That entry can be recreated after bury by a StoreHeartbeat that was
  already in flight, since HandleStoreHeartbeat only rejects a fully
  unknown store (GetStore == nil), not a tombstoned one -- so this
  could keep refreshing a dead store's load numbers for up to 30 days,
  until final removal.

- collectHotMetrics kept republishing hotSpotStatusGauge from
  HotPeerCache's still-cached hot-peer data, since HotPeerCache.gc()
  only clears a tombstoned store's entries on its own TTL-throttled
  schedule (topNTTL), not on every collection tick.

Both now treat a known-tombstoned store as having nothing to publish,
closing the gap at the write source instead of relying on a periodic
backstop, matching observe()'s established pattern for these same
gauges.
```

Follow-up commits on this same PR close several more residuals in this
area found during review: `SetStoreLimit`/`adjustNetworkSlowStore`
guards, `hot_peer_cache`'s `storesOfRegion` reverse index,
`StoreHistoryLoads`'s per-store history cache, the rule fit cache's
per-store cache (including not persisting a region-level cache entry
built from a stale, pre-bury store snapshot), `summaryPendingInfluence`'s
`HotPendingSum` write, and `deleteStore`'s auto-GC path not clearing the
store-limit config.

A second round of review found four more gaps, now also closed:

- `region_rule_cache`'s region-level promotion path (`SetCache`'s
  existing-entry branch) re-checks store freshness via `allStoresLive`,
  but that read isn't synchronized with a concurrent bury (it goes
  through `StoresInfo`'s own lock, not `manager.mu`), and unlike the
  per-store cache, nothing else ever swept a poisoned region-level
  entry. Added a `storeID -> regionIDs` reverse index so
  `RemoveStoreCache` evicts any region cache entry that referenced the
  removed store.
- `filterNetworkSlowScores` didn't filter out neighbors that are
  already known-removed, letting a live store's stale scores against a
  tombstoned peer inflate its own problem-report count. Filtering only
  triggers on a confirmed-removed target (`!= nil && IsRemoved()`),
  never on a bare `nil`, since a target can also be legitimately
  unregistered (mid-scale-out).
- `isNetworkSlowStore`'s consensus denominator subtracted the full
  size of the in-flight recovery map, even when some of those entries
  belonged to stores no longer in the live population -- double
  counting them and making consensus easier to reach than it should
  be. Now only subtracts recovery-map entries still present in the
  live store set.
- `SetLabelStoresLimit` iterates every store including tombstoned
  ones, and its `engine=tikv` branch aborts the whole batch on the
  first `SetStoreLimit` error -- since a tombstoned store with no
  engine label still counts as TiKV, and `SetStoreLimit` now rejects
  tombstoned stores, any tombstoned store in the cluster broke setting
  limits for every other labeled store too. Now skips tombstoned
  stores up front.
- `AddStoreLimit`/`RemoveStoreLimit`/`SetStoreLimit`/`SetAllStoresLimit`
  now go through `PersistOptions.UpdateScheduleConfig`, a read-clone-persist
  transaction serialized by the `persistMu` lock that `Persist()` itself
  also holds (both landed independently in master via #10900, merged into
  this branch). A concurrent `SetAllStoresLimit` can no longer silently
  overwrite `deleteStore`'s `RemoveStoreLimit` cleanup with a stale
  snapshot -- see Known limitations below: this closes the race fully,
  not just the specific interleaving reviewers demonstrated.
- `PutMetaStore` used to call `AddStoreLimit` unconditionally after
  `putStoreImpl`, recreating a `StoreLimit` entry for a store that a
  concurrent `BuryStore` had just tombstoned and cleaned up. It now takes
  `storeStateLock` for the whole read-`wasKnown`-then-act sequence (the
  same per-store lock `RemoveStore`/`BuryStore`/`UpStore`/`checkStore`/
  `RemoveTombStoneRecords` hold -- the last of these needed the same lock
  added to it too, closing a distinct concurrent-overlap ordering an
  earlier, narrower fix missed), and `AddStoreLimit`'s internal helper
  re-checks the store's current tombstone state on every persist-retry
  attempt from inside the `UpdateScheduleConfig` closure. A store that's
  genuinely new -- even one already tombstoned at first sight (state
  replayed from storage) -- still gets a limit, since there's no prior
  entry to protect from resurrection.

A third round of review found two more gaps, now also closed:

- `detectAndHandleNetworkSlowStores`' "reached limit" branch re-checks
  the store right before writing `slowStoreTriggerLimitGauge`, but a
  bury landing between that check and the write could still resurrect
  the series. Unlike the sibling `addNetworkSlowStoreLocked` branch,
  nothing sweeps this metric on a later round -- only `deleteStore`'s
  final-removal cleanup does, which a mere tombstone never reaches.
  Added a post-write recheck keyed on `IsRemoved()`, mirroring
  `adjustNetworkSlowStore`'s pattern.
- The `assertBlockedThenReleased` test helper's "confirm the contender
  goroutine has started" signal only proved it ran its first statement,
  not that it reached the actual lock attempt -- it could still be
  descheduled in between, reintroducing the same "blocked vs.
  not-yet-scheduled" ambiguity one step later. Removed that
  intermediate signal; the wait now ties directly to the `acquiredFP`
  failpoint signal with a generous window, matching this package's own
  precedent (`TestScheduleConfigPersistenceIsSerialized`'s
  `saveStarted` wait).

A fourth round of review found two more gaps, now also closed:

- `addNetworkSlowStoreLocked` resumed the leader-transfer pause and let
  `persistLocked` roll back `networkSlowStoreRecoverStartAts` on a
  persist failure, but fell through to publish
  `evictedSlowStoreStatusGauge` unconditionally anyway -- misreporting
  a store that was never actually paused as evicted. Since the store
  never entered `networkSlowStoreRecoverStartAts`,
  `tryRecoverNetworkSlowStores` (the only place that later cleans this
  gauge) never revisits it; if the store is buried before a retry
  succeeds, the series is orphaned until final removal. Added the
  missing `return`, matching `deleteNetworkSlowStoreLocked`'s own
  pattern on the same failure path.
- `assertBlockedThenReleased`'s proof that a contender is blocked on
  `storeStateLock` relied on `acquiredFP` staying silent for a fixed
  window, but that window had to cover both scheduling delay and the
  contender's own setup code (e.g. two `PutStore` calls before
  `BuryStore` is even entered), with no way to distinguish "not yet
  scheduled" from "genuinely blocked". Added `buryStoreBeforeStateLock`
  and `removeTombStoneRecordsBeforeStateLock` failpoints immediately
  before each `storeStateLock.Lock()` call in production code, and wait
  for that signal first -- once it fires, only the adjacent `Lock()`
  call separates the contender from the lock, so the "hasn't acquired
  yet" check only needs a short window instead of one sized to cover
  arbitrary setup work. Verified empirically, not just by construction:
  with the production lock temporarily removed, both race tests
  reliably fail (3/3 runs each), confirming they exercise the
  serialization invariant rather than passing by scheduling luck.

`region_rule_cache`'s new `storesOfRegion` reverse index (above) doesn't add
a new asymptotic cost: each cached region already stores one `*storeCache`
per replica in `cache.regionStores`, so the reverse index is the same
`O(cached regions × replicas)` data, just indexed the other way. `RemoveStoreCache`'s
critical section is bounded by how many cached regions reference the removed
store, not by the whole cache.

### Known limitations

- `SetStoreLimit`'s tombstone check isn't atomic with the cluster's own store-removal machinery -- neither `BuryStoreLocked` nor final removal (`deleteStore`). An in-flight call that read the store as live can still persist after either transition completes: racing bury lands in a narrow window; racing final removal is reachable from the HTTP path too (`server/api/store.go`'s handler checks existence before parsing the request body, then calls `SetStoreLimit`), and since the store is then gone for good, nothing ever retries the cleanup. Closing either needs a dedicated lock or a locked/unlocked split (mirroring `BuryStore`/`BuryStoreLocked`) -- synchronizing with `storeStateLock` directly would deadlock, since `RemoveStore`/`UpStore` already hold it while calling `SetStoreLimit` internally, and the nil-vs-not-yet-registered ambiguity (see `testCluster.addRegionStore`) rules out a simple nil check.
- **Resolved.** `adjustNetworkSlowStore`'s recheck was believed bounded by `deleteStore`'s own `DeleteLabelValues` cleanup, but that reasoning only covered a write landing *before* `deleteStore` ran; one landing after (bury completing, without necessarily reaching final deletion, in the gap between the check and the write) had no later event to catch it, since nothing calls this function again once a store stops heartbeating. Added a post-write recheck keyed on `IsRemoved()` (not mere absence), mirroring `summaryPendingInfluence`'s pattern -- and proven complete, not just narrowed, given `deleteStore` always removes the store from `StoresInfo` before calling `DeleteLabelValues`, so any post-write read that observes the store gone is guaranteed to also mean that cleanup has already run or will find nothing left to do.
- `RemoveStoreLimit`'s persistence retry (5 attempts, 100ms apart) can be exhausted without any later retry path. If that happens after the store is fully removed, the stale config entry in storage has no further lifecycle event to trigger cleanup, and can be reloaded and republished after a future leader election or restart. Requires either a startup reconciliation between `StoresInfo` and the persisted `StoreLimit` config, or making the failure retryable/observable -- both out of scope here given how narrow the trigger is (the persist has to fail all 5 attempts, and the store has to already be fully removed with no future bury/deletion event left to retry it).
- **Resolved by merging master.** The `SetAllStoresLimit` vs. `RemoveStoreLimit` race above was initially closed here with a narrow, PR-local `storeLimitMu` covering only the 4 store-limit methods, and the broader class -- every one of the ~18 `PersistOptions.Persist()` call sites across `server/cluster/cluster.go`, `server/handler.go`, and `server/server.go` racing each other, since `Persist()` snapshots every config section fresh and writes it unconditionally with no version/CAS check -- was left open and filed as tikv/pd#11187. Merging master (#10900, unrelated: "persist default store limit for future stores") brought in a `persistMu` lock that `PersistOptions.Persist()` now holds for its own snapshot-then-write, shared with the new `UpdateScheduleConfig` transaction helper. That serializes *every* `Persist()` caller against every other one, not just the 4 store-limit methods -- so the general race is fully closed, and #11187 is superseded and being closed as resolved by #10900 rather than needing its own fix.
- `summaryPendingInfluence`'s post-write recheck (added in this round) narrows, but doesn't eliminate, the window where a bury landing between the pre-write check and the write can let it recreate `HotPendingSum` after cleanup ran -- the two checks and the write aren't atomic with the bury. The residual is bounded: the next `summaryPendingInfluence` tick re-checks and cleans it up.
- `PutMetaStore`'s `storeStateLock` closes races against *concurrent* store-lifecycle operations, but not the gap between the gRPC `PutStore` handler's `checkStore` preflight and `PutMetaStore` itself. A request that passed the preflight while the store was live can land after a full bury + manual `RemoveTombStoneRecords` completes: the store then reads as absent (not tombstoned), indistinguishable from a genuine new registration, so `putStoreImpl` recreates it and `AddStoreLimit` gives it a limit. Closing this needs the preflight and `PutMetaStore` to share a lock, or a way to tell "absent because deleted" from "absent because never registered" -- the same nil-vs-not-yet-registered ambiguity noted above. The residual is bounded: a resurrected phantom store has no real TiKV heartbeating it, so it goes down and is cleaned up again through the normal down-store lifecycle.
- `HotPeerCache.CheckPeerFlow`'s guard only skips a peer for a *known*-tombstoned store (`store != nil && store.IsRemoved()`), the same nil-vs-not-yet-registered ambiguity as above -- a store the cache doesn't know about yet is legitimately a different case (e.g. an add-peer target still in flight), so a bare `store == nil` check can't be added here either (tried the equivalent for `SetStoreLimit` above; it broke `TestDispatch`). A peer-flow task queued before `RemoveTombStoneRecords` fully deletes the store but executed afterward sees `GetStore` return nil, so the guard doesn't fire, and `UpdateStat` recreates the cache entry and `pd_hotcache_status` series. The residual is bounded to one `gc()` cycle: `gc()`'s live-store snapshot comes from `cluster.GetStores()`, which never returns a fully-deleted store, so the resurrected entry's ID falls out of that snapshot and gets swept on the very next TTL-gated pass (`topNTTL`, ~3x the report interval -- tens of seconds, not the original issue's 30-day window).

### Check List

Tests

- Unit test

### Release note

```release-note
Fix `pd_scheduler_store_status` and `pd_hotspot_status` metrics continuing to be republished for a tombstoned store for up to 30 days after removal, in two narrow races not covered by #11127.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed stale hot-spot metrics for removed stores.
  - Removed stores are no longer counted in leader or peer hot-statistics.
  - Prevented metrics from reappearing after a removed store is recreated in rolling statistics.
  - Cleaned up store limits, placement caches, and historical load data when stores are removed.
  - Prevented removed stores from receiving new limits or republishing network-related metrics.
  - Improved cleanup of stale scheduling and load-history data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->








