### PR TITLE
*: support enabling meta-service groups from config

### DIFF
--- a/conf/config.toml
+++ b/conf/config.toml
@@ -215,3 +215,8 @@
 ## Example:
 ## pre-alloc = ["admin", "user1", "user2"]
 # pre-alloc = []
+##
+## meta-service-groups maps group IDs to addresses and default enabled state.
+## Example:
+## [keyspace.meta-service-groups]
+## "etcd-group-0" = { addresses = "etcd-group-0.tidb-serverless.cluster.svc.local", enabled = true }

--- a/pkg/keyspace/keyspace.go
+++ b/pkg/keyspace/keyspace.go
@@ -41,6 +41,7 @@ import (
 	"github.com/tikv/pd/pkg/utils/keypath"
 	"github.com/tikv/pd/pkg/utils/syncutil"
 	"github.com/tikv/pd/pkg/versioninfo/kerneltype"
+	serverconfig "github.com/tikv/pd/server/config"
 )
 
 const (
@@ -79,10 +80,12 @@ type Config interface {
 	ToWaitRegionSplit() bool
 	GetWaitRegionSplitTimeout() time.Duration
 	GetCheckRegionSplitInterval() time.Duration
-	// GetMetaServiceGroups returns the meta-service groups for keyspace assignment.
-	// key is the meta-service group id and value is the meta-service group addresses.
-	SetMetaServiceGroups(map[string]string)
+	// SetMetaServiceGroups updates the configured meta-service groups.
+	SetMetaServiceGroups(map[string]serverconfig.MetaServiceGroupConfig)
+	// GetMetaServiceGroups returns the meta-service group addresses for keyspace assignment.
 	GetMetaServiceGroups() map[string]string
+	// GetMetaServiceGroupConfigs returns the full meta-service group config.
+	GetMetaServiceGroupConfigs() map[string]serverconfig.MetaServiceGroupConfig
 }
 
 // Manager manages keyspace related data.
@@ -244,7 +247,7 @@ func (manager *Manager) initReserveKeyspace(id uint32, name string) error {
 func (manager *Manager) UpdateConfig(cfg Config) {
 	manager.config = cfg
 	if manager.mgm != nil {
-		manager.mgm.updateGroups(cfg.GetMetaServiceGroups())
+		manager.mgm.updateGroups(cfg.GetMetaServiceGroupConfigs())
 	}
 }
 

--- a/pkg/keyspace/keyspace_test.go
+++ b/pkg/keyspace/keyspace_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/tikv/pd/pkg/utils/testutil"
 	"github.com/tikv/pd/pkg/utils/typeutil"
 	"github.com/tikv/pd/pkg/versioninfo/kerneltype"
+	serverconfig "github.com/tikv/pd/server/config"
 )
 
 func TestMain(m *testing.M) {
@@ -69,7 +70,7 @@ type mockConfig struct {
 	WaitRegionSplitTimeout   typeutil.Duration
 	CheckRegionSplitInterval typeutil.Duration
 	// MetaServiceGroups is used to mock the meta-service groups for keyspace assignment.
-	MetaServiceGroups map[string]string
+	MetaServiceGroups map[string]serverconfig.MetaServiceGroupConfig
 }
 
 func (m *mockConfig) GetPreAlloc() []string {
@@ -88,12 +89,24 @@ func (m *mockConfig) GetCheckRegionSplitInterval() time.Duration {
 	return m.CheckRegionSplitInterval.Duration
 }
 
-func (m *mockConfig) SetMetaServiceGroups(metaServiceGroups map[string]string) {
+func (m *mockConfig) SetMetaServiceGroups(metaServiceGroups map[string]serverconfig.MetaServiceGroupConfig) {
 	m.MetaServiceGroups = metaServiceGroups
 }
 
 func (m *mockConfig) GetMetaServiceGroups() map[string]string {
-	return m.MetaServiceGroups
+	ret := make(map[string]string, len(m.MetaServiceGroups))
+	for name, group := range m.MetaServiceGroups {
+		ret[name] = group.Addresses
+	}
+	return ret
+}
+
+func (m *mockConfig) GetMetaServiceGroupConfigs() map[string]serverconfig.MetaServiceGroupConfig {
+	ret := make(map[string]serverconfig.MetaServiceGroupConfig, len(m.MetaServiceGroups))
+	for name, group := range m.MetaServiceGroups {
+		ret[name] = group
+	}
+	return ret
 }
 
 func (suite *keyspaceTestSuite) SetupTest() {
@@ -1095,7 +1108,7 @@ func TestAssignGroupAndSaveKeyspace(t *testing.T) {
 	kgm := NewKeyspaceGroupManager(ctx, store, nil)
 
 	// No groups available: assign=true (stale pre-check) must not fail creation.
-	emptyMgm := NewMetaServiceGroupManager(store, map[string]string{})
+	emptyMgm := NewMetaServiceGroupManager(store, map[string]serverconfig.MetaServiceGroupConfig{})
 	managerNoGroup := NewKeyspaceManager(ctx, store, nil, mockid.NewIDAllocator(), &mockConfig{}, kgm, emptyMgm)
 	cfg := map[string]string{}
 	ks := &keyspacepb.KeyspaceMeta{Keyspace: &keyspacepb.KeyspaceMeta_Id{Id: 100}, Name: "ks-stale-precheck", Config: cfg}
@@ -1107,7 +1120,9 @@ func TestAssignGroupAndSaveKeyspace(t *testing.T) {
 
 	// A present, enabled group is still assigned. Groups are disabled by
 	// default, so it must be enabled before it is eligible for assignment.
-	mgm := NewMetaServiceGroupManager(store, map[string]string{"g1": "addr1"})
+	mgm := NewMetaServiceGroupManager(store, map[string]serverconfig.MetaServiceGroupConfig{
+		"g1": {Addresses: "addr1"},
+	})
 	enabled := true
 	re.NoError(mgm.PatchStatus(ctx, "g1", &MetaServiceGroupStatusPatch{Enabled: &enabled}))
 	managerWithGroup := NewKeyspaceManager(ctx, store, nil, mockid.NewIDAllocator(), &mockConfig{}, kgm, mgm)
@@ -1116,14 +1131,26 @@ func TestAssignGroupAndSaveKeyspace(t *testing.T) {
 	re.NoError(managerWithGroup.assignGroupAndSaveKeyspace(true, &cfg2, ks2))
 	re.Equal("g1", ks2.GetConfig()[MetaServiceGroupIDKey])
 
+	// A group enabled by config should also be assigned without needing a
+	// runtime status patch.
+	enabledByConfig := true
+	enabledByConfigMgm := NewMetaServiceGroupManager(store, map[string]serverconfig.MetaServiceGroupConfig{
+		"g2": {Addresses: "addr2", Enabled: &enabledByConfig},
+	})
+	managerEnabledByConfig := NewKeyspaceManager(ctx, store, nil, mockid.NewIDAllocator(), &mockConfig{}, kgm, enabledByConfigMgm)
+	cfg3 := map[string]string{}
+	ks3 := &keyspacepb.KeyspaceMeta{Keyspace: &keyspacepb.KeyspaceMeta_Id{Id: 102}, Name: "ks-enabled-by-config", Config: cfg3}
+	re.NoError(managerEnabledByConfig.assignGroupAndSaveKeyspace(true, &cfg3, ks3))
+	re.Equal("g2", ks3.GetConfig()[MetaServiceGroupIDKey])
+
 	// A group that exists but is disabled must not fail creation: the keyspace is
 	// created without a meta-service group assignment instead.
-	disabledMgm := NewMetaServiceGroupManager(store, map[string]string{"g2": "addr2"})
+	disabledMgm := NewMetaServiceGroupManager(store, map[string]serverconfig.MetaServiceGroupConfig{"g3": {Addresses: "addr3"}})
 	managerDisabled := NewKeyspaceManager(ctx, store, nil, mockid.NewIDAllocator(), &mockConfig{}, kgm, disabledMgm)
-	cfg3 := map[string]string{}
-	ks3 := &keyspacepb.KeyspaceMeta{Keyspace: &keyspacepb.KeyspaceMeta_Id{Id: 102}, Name: "ks-disabled-group", Config: cfg3}
-	re.NoError(managerDisabled.assignGroupAndSaveKeyspace(true, &cfg3, ks3))
-	re.NotContains(ks3.GetConfig(), MetaServiceGroupIDKey)
+	cfg4 := map[string]string{}
+	ks4 := &keyspacepb.KeyspaceMeta{Keyspace: &keyspacepb.KeyspaceMeta_Id{Id: 103}, Name: "ks-disabled-group", Config: cfg4}
+	re.NoError(managerDisabled.assignGroupAndSaveKeyspace(true, &cfg4, ks4))
+	re.NotContains(ks4.GetConfig(), MetaServiceGroupIDKey)
 }
 
 func (suite *keyspaceTestSuite) TestTombstoneKeyspaceUnassignsMetaServiceGroup() {
@@ -1135,7 +1162,7 @@ func (suite *keyspaceTestSuite) TestTombstoneKeyspaceUnassignsMetaServiceGroup()
 	re.True(ok)
 	// Start without any group so creation never auto-assigns: meta-service groups
 	// are disabled by default, and this keeps the test independent of that.
-	manager.mgm = NewMetaServiceGroupManager(metaServiceGroupStore, map[string]string{})
+	manager.mgm = NewMetaServiceGroupManager(metaServiceGroupStore, map[string]serverconfig.MetaServiceGroupConfig{})
 	manager.mgm.SetKeyspaceAssignmentCounter(manager.CountKeyspacesByMetaServiceGroup)
 
 	created, err := manager.CreateKeyspace(&CreateKeyspaceRequest{
@@ -1164,7 +1191,7 @@ func (suite *keyspaceTestSuite) TestTombstoneKeyspaceUnassignsMetaServiceGroup()
 			return manager.mgm.updateAssignmentTxn(txn, "", groupID)
 		}))
 	}
-	manager.mgm.updateGroups(map[string]string{groupID: groupEndpoint})
+	manager.mgm.updateGroups(map[string]serverconfig.MetaServiceGroupConfig{groupID: {Addresses: groupEndpoint}})
 	assignKeyspaceToGroup(created.GetId())
 
 	counts, err := manager.mgm.GetAssignmentCounts(suite.ctx)

--- a/pkg/keyspace/meta_service_group.go
+++ b/pkg/keyspace/meta_service_group.go
@@ -75,7 +75,7 @@ func (m *MetaServiceGroupManager) GetStatus(ctx context.Context) (map[string]*en
 	err = m.store.RunInTxn(ctx, func(txn kv.Txn) error {
 		statusMap = make(map[string]*endpoint.MetaServiceGroupStatus, len(m.metaServiceGroups))
 		for groupID, group := range m.metaServiceGroups {
-			status, err := m.loadGroupStatusLocked(txn, groupID, group)
+			status, err := loadGroupStatusLocked(txn, groupID, group)
 			if err != nil {
 				return err
 			}
@@ -126,7 +126,7 @@ func (m *MetaServiceGroupManager) PatchStatus(ctx context.Context, groupID strin
 		if !ok {
 			return ErrUnknownMetaServiceGroup
 		}
-		status, err := m.loadGroupStatusLocked(txn, groupID, group)
+		status, err := loadGroupStatusLocked(txn, groupID, group)
 		if err != nil {
 			return err
 		}
@@ -144,7 +144,7 @@ func (m *MetaServiceGroupManager) findMinMetaGroup(txn kv.Txn) (string, error) {
 	minCount := math.MaxInt
 	var assignedGroup string
 	for currentGroup, group := range m.metaServiceGroups {
-		status, err := m.loadGroupStatusLocked(txn, currentGroup, group)
+		status, err := loadGroupStatusLocked(txn, currentGroup, group)
 		if err != nil {
 			return "", err
 		}
@@ -211,7 +211,7 @@ func (m *MetaServiceGroupManager) AssignToGroup(ctx context.Context, count int) 
 		if !ok {
 			return ErrUnknownMetaServiceGroup
 		}
-		status, err := m.loadGroupStatusLocked(txn, assignedGroup, group)
+		status, err := loadGroupStatusLocked(txn, assignedGroup, group)
 		if err != nil {
 			return err
 		}
@@ -239,7 +239,7 @@ func (m *MetaServiceGroupManager) reassignKeyspaceLocked(txn kv.Txn, oldGroupID,
 		if !ok {
 			return ErrUnknownMetaServiceGroup
 		}
-		status, err := m.loadGroupStatusLocked(txn, newGroupID, group)
+		status, err := loadGroupStatusLocked(txn, newGroupID, group)
 		if err != nil {
 			return err
 		}
@@ -306,7 +306,7 @@ func (m *MetaServiceGroupManager) updateAssignmentTxnWithGroup(
 		}
 	}
 	if newGroupID != "" {
-		status, err := m.loadGroupStatusLocked(txn, newGroupID, newGroup)
+		status, err := loadGroupStatusLocked(txn, newGroupID, newGroup)
 		if err != nil {
 			return err
 		}
@@ -321,7 +321,7 @@ func (m *MetaServiceGroupManager) updateAssignmentTxnWithGroup(
 // loadGroupStatusLocked loads the persisted status of a single meta-service
 // group using the caller's snapshot of the config map. The caller must ensure
 // the corresponding group still exists in the current in-memory set.
-func (m *MetaServiceGroupManager) loadGroupStatusLocked(
+func loadGroupStatusLocked(
 	txn kv.Txn,
 	groupID string,
 	group config.MetaServiceGroupConfig,

--- a/pkg/keyspace/meta_service_group.go
+++ b/pkg/keyspace/meta_service_group.go
@@ -16,6 +16,7 @@ package keyspace
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math"
 
@@ -25,6 +26,7 @@ import (
 
 	"github.com/tikv/pd/pkg/storage/endpoint"
 	"github.com/tikv/pd/pkg/storage/kv"
+	"github.com/tikv/pd/pkg/utils/keypath"
 	"github.com/tikv/pd/pkg/utils/syncutil"
 	"github.com/tikv/pd/server/config"
 )
@@ -34,8 +36,9 @@ type MetaServiceGroupManager struct {
 	store endpoint.MetaServiceGroupStorage
 	syncutil.RWMutex
 	// metaServiceGroups is the available external meta-service groups.
-	// The key is the meta-service group name, and the value is the corresponding endpoint.
-	metaServiceGroups map[string]string
+	// The key is the meta-service group name, and the value is the corresponding
+	// endpoint plus the default enabled state.
+	metaServiceGroups map[string]config.MetaServiceGroupConfig
 	// keyspaceAssignmentCounter, when set, returns the actual number of keyspaces
 	// assigned to each of the given groups by scanning keyspace metadata. It is
 	// the authoritative source for the delete guard so a stale persisted counter
@@ -53,11 +56,11 @@ func (m *MetaServiceGroupManager) SetKeyspaceAssignmentCounter(counter func(grou
 // NewMetaServiceGroupManager creates a new MetaServiceGroupManager.
 func NewMetaServiceGroupManager(
 	store endpoint.MetaServiceGroupStorage,
-	metaServiceGroups map[string]string,
+	metaServiceGroups map[string]config.MetaServiceGroupConfig,
 ) *MetaServiceGroupManager {
 	return &MetaServiceGroupManager{
 		store:             store,
-		metaServiceGroups: metaServiceGroups,
+		metaServiceGroups: cloneMetaServiceGroupConfigs(metaServiceGroups),
 	}
 }
 
@@ -70,8 +73,15 @@ func (m *MetaServiceGroupManager) GetStatus(ctx context.Context) (map[string]*en
 		statusMap map[string]*endpoint.MetaServiceGroupStatus
 	)
 	err = m.store.RunInTxn(ctx, func(txn kv.Txn) error {
-		statusMap, err = m.store.LoadMetaServiceGroupStatus(txn, m.metaServiceGroups)
-		return err
+		statusMap = make(map[string]*endpoint.MetaServiceGroupStatus, len(m.metaServiceGroups))
+		for groupID, group := range m.metaServiceGroups {
+			status, err := m.loadGroupStatusLocked(txn, groupID, group)
+			if err != nil {
+				return err
+			}
+			statusMap[groupID] = status
+		}
+		return nil
 	})
 	return statusMap, err
 }
@@ -112,7 +122,11 @@ func (m *MetaServiceGroupManager) PatchStatus(ctx context.Context, groupID strin
 		return ErrUnknownMetaServiceGroup
 	}
 	return m.store.RunInTxn(ctx, func(txn kv.Txn) error {
-		status, err := m.loadGroupStatus(txn, groupID)
+		group, ok := m.metaServiceGroups[groupID]
+		if !ok {
+			return ErrUnknownMetaServiceGroup
+		}
+		status, err := m.loadGroupStatusLocked(txn, groupID, group)
 		if err != nil {
 			return err
 		}
@@ -127,13 +141,13 @@ func (m *MetaServiceGroupManager) PatchStatus(ctx context.Context, groupID strin
 }
 
 func (m *MetaServiceGroupManager) findMinMetaGroup(txn kv.Txn) (string, error) {
-	statusMap, err := m.store.LoadMetaServiceGroupStatus(txn, m.metaServiceGroups)
-	if err != nil {
-		return "", err
-	}
 	minCount := math.MaxInt
 	var assignedGroup string
-	for currentGroup, status := range statusMap {
+	for currentGroup, group := range m.metaServiceGroups {
+		status, err := m.loadGroupStatusLocked(txn, currentGroup, group)
+		if err != nil {
+			return "", err
+		}
 		if status.Enabled && status.AssignmentCount < minCount {
 			minCount = status.AssignmentCount
 			assignedGroup = currentGroup
@@ -170,7 +184,7 @@ func (m *MetaServiceGroupManager) pickGroupLocked(ctx context.Context) (string, 
 		if assignedGroup, err = m.findMinMetaGroup(txn); err != nil {
 			return err
 		}
-		return m.updateAssignmentTxn(txn, "", assignedGroup)
+		return m.updateAssignmentTxnLocked(txn, "", assignedGroup)
 	}); err != nil {
 		return "", err
 	}
@@ -193,11 +207,14 @@ func (m *MetaServiceGroupManager) AssignToGroup(ctx context.Context, count int) 
 		if err != nil {
 			return err
 		}
-		statusMap, err := m.store.LoadMetaServiceGroupStatus(txn, m.metaServiceGroups)
+		group, ok := m.metaServiceGroups[assignedGroup]
+		if !ok {
+			return ErrUnknownMetaServiceGroup
+		}
+		status, err := m.loadGroupStatusLocked(txn, assignedGroup, group)
 		if err != nil {
 			return err
 		}
-		status := statusMap[assignedGroup]
 		status.AssignmentCount += count
 		return m.store.SaveMetaServiceGroupStatus(txn, assignedGroup, status)
 	}); err != nil {
@@ -218,24 +235,61 @@ func (m *MetaServiceGroupManager) reassignKeyspaceLocked(txn kv.Txn, oldGroupID,
 		}
 		// Disabled groups are skipped by automatic assignment, so reject moving a
 		// keyspace into one to keep manual reassignment consistent with it.
-		statusMap, err := m.store.LoadMetaServiceGroupStatus(txn, map[string]string{newGroupID: ""})
+		group, ok := m.metaServiceGroups[newGroupID]
+		if !ok {
+			return ErrUnknownMetaServiceGroup
+		}
+		status, err := m.loadGroupStatusLocked(txn, newGroupID, group)
 		if err != nil {
 			return err
 		}
-		if status := statusMap[newGroupID]; status == nil || !status.Enabled {
+		if !status.Enabled {
 			return ErrMetaServiceGroupDisabled
 		}
 	}
-	return m.updateAssignmentTxn(txn, oldGroupID, newGroupID)
+	return m.updateAssignmentTxnLocked(txn, oldGroupID, newGroupID)
 }
 
 func (m *MetaServiceGroupManager) updateAssignmentTxn(txn kv.Txn, oldGroupID, newGroupID string) error {
+	var (
+		newGroup config.MetaServiceGroupConfig
+		hasNew   bool
+	)
+	if newGroupID != "" {
+		m.RLock()
+		newGroup, hasNew = m.metaServiceGroups[newGroupID]
+		m.RUnlock()
+		if !hasNew {
+			return ErrUnknownMetaServiceGroup
+		}
+	}
+	return m.updateAssignmentTxnWithGroup(txn, oldGroupID, newGroupID, newGroup)
+}
+
+func (m *MetaServiceGroupManager) updateAssignmentTxnLocked(txn kv.Txn, oldGroupID, newGroupID string) error {
+	var newGroup config.MetaServiceGroupConfig
+	if newGroupID != "" {
+		var ok bool
+		newGroup, ok = m.metaServiceGroups[newGroupID]
+		if !ok {
+			return ErrUnknownMetaServiceGroup
+		}
+	}
+	return m.updateAssignmentTxnWithGroup(txn, oldGroupID, newGroupID, newGroup)
+}
+
+func (m *MetaServiceGroupManager) updateAssignmentTxnWithGroup(
+	txn kv.Txn,
+	oldGroupID string,
+	newGroupID string,
+	newGroup config.MetaServiceGroupConfig,
+) error {
 	// Load only the affected groups instead of the whole m.metaServiceGroups map:
 	// some callers (e.g. RemoveKeyspace) reach this without holding the
 	// meta-service group lock, so reading the shared map here would race with
 	// UpdateGroupsSafely.
 	if oldGroupID != "" {
-		status, err := m.loadGroupStatus(txn, oldGroupID)
+		status, err := loadPersistedGroupStatus(txn, oldGroupID)
 		if err != nil {
 			return err
 		}
@@ -252,7 +306,7 @@ func (m *MetaServiceGroupManager) updateAssignmentTxn(txn kv.Txn, oldGroupID, ne
 		}
 	}
 	if newGroupID != "" {
-		status, err := m.loadGroupStatus(txn, newGroupID)
+		status, err := m.loadGroupStatusLocked(txn, newGroupID, newGroup)
 		if err != nil {
 			return err
 		}
@@ -264,14 +318,42 @@ func (m *MetaServiceGroupManager) updateAssignmentTxn(txn kv.Txn, oldGroupID, ne
 	return nil
 }
 
-// loadGroupStatus loads the persisted status of a single meta-service group
-// within txn, without touching the shared m.metaServiceGroups map.
-func (m *MetaServiceGroupManager) loadGroupStatus(txn kv.Txn, groupID string) (*endpoint.MetaServiceGroupStatus, error) {
-	statusMap, err := m.store.LoadMetaServiceGroupStatus(txn, map[string]string{groupID: ""})
+// loadGroupStatusLocked loads the persisted status of a single meta-service
+// group using the caller's snapshot of the config map. The caller must ensure
+// the corresponding group still exists in the current in-memory set.
+func (m *MetaServiceGroupManager) loadGroupStatusLocked(
+	txn kv.Txn,
+	groupID string,
+	group config.MetaServiceGroupConfig,
+) (*endpoint.MetaServiceGroupStatus, error) {
+	status, persisted, err := loadPersistedGroupStatusWithState(txn, groupID)
 	if err != nil {
 		return nil, err
 	}
-	return statusMap[groupID], nil
+	if !persisted {
+		status.Enabled = group.Enabled != nil && *group.Enabled
+	}
+	return status, nil
+}
+
+func loadPersistedGroupStatus(txn kv.Txn, groupID string) (*endpoint.MetaServiceGroupStatus, error) {
+	status, _, err := loadPersistedGroupStatusWithState(txn, groupID)
+	return status, err
+}
+
+func loadPersistedGroupStatusWithState(txn kv.Txn, groupID string) (*endpoint.MetaServiceGroupStatus, bool, error) {
+	statusVal, err := txn.Load(keypath.MetaServiceGroupStatusPath(groupID))
+	if err != nil {
+		return nil, false, err
+	}
+	if statusVal == "" {
+		return &endpoint.MetaServiceGroupStatus{}, false, nil
+	}
+	status := &endpoint.MetaServiceGroupStatus{}
+	if err := json.Unmarshal([]byte(statusVal), status); err != nil {
+		return nil, false, err
+	}
+	return status, true, nil
 }
 
 // AttachEndpoints append potential meta-service group endpoint to the given keyspace config map.
@@ -282,8 +364,8 @@ func (m *MetaServiceGroupManager) AttachEndpoints(keyspaceConfig map[string]stri
 	}
 	m.RLock()
 	defer m.RUnlock()
-	if endpoints := m.metaServiceGroups[groupID]; endpoints != "" {
-		keyspaceConfig[MetaServiceGroupAddressesKey] = endpoints
+	if group, ok := m.metaServiceGroups[groupID]; ok && group.Addresses != "" {
+		keyspaceConfig[MetaServiceGroupAddressesKey] = group.Addresses
 	}
 }
 
@@ -292,8 +374,8 @@ func (m *MetaServiceGroupManager) GetGroups() map[string]string {
 	m.RLock()
 	defer m.RUnlock()
 	groups := make(map[string]string, len(m.metaServiceGroups))
-	for id, endpoints := range m.metaServiceGroups {
-		groups[id] = endpoints
+	for id, group := range m.metaServiceGroups {
+		groups[id] = group.Addresses
 	}
 	return groups
 }
@@ -302,7 +384,7 @@ func (m *MetaServiceGroupManager) GetGroups() map[string]string {
 // blocking concurrent keyspace assignments.
 func (m *MetaServiceGroupManager) UpdateGroupsSafely(
 	ctx context.Context,
-	metaServiceGroups map[string]string,
+	metaServiceGroups map[string]config.MetaServiceGroupConfig,
 	deletedGroups []string,
 	persist func() error,
 	afterPersist func(),
@@ -324,7 +406,7 @@ func (m *MetaServiceGroupManager) UpdateGroupsSafely(
 // assignment (AssignToGroup/PickGroup/reassign all take the read lock).
 func (m *MetaServiceGroupManager) persistGroupsLocked(
 	ctx context.Context,
-	metaServiceGroups map[string]string,
+	metaServiceGroups map[string]config.MetaServiceGroupConfig,
 	deletedGroups []string,
 	persist func() error,
 ) error {
@@ -344,7 +426,7 @@ func (m *MetaServiceGroupManager) persistGroupsLocked(
 	if err := persist(); err != nil {
 		return err
 	}
-	m.metaServiceGroups = metaServiceGroups
+	m.metaServiceGroups = cloneMetaServiceGroupConfigs(metaServiceGroups)
 	// Clear the persisted status for deleted groups so re-adding a group with
 	// the same ID does not inherit a stale assignment count or enabled state,
 	// which would skew list output and PickGroup balancing. Best-effort: the
@@ -383,7 +465,11 @@ func (m *MetaServiceGroupManager) assignedKeyspaceCounts(ctx context.Context, gr
 	// lock (which would deadlock against the held write lock).
 	var counts map[string]int
 	if err := m.store.RunInTxn(ctx, func(txn kv.Txn) error {
-		statusMap, err := m.store.LoadMetaServiceGroupStatus(txn, m.metaServiceGroups)
+		lookup := make(map[string]string, len(m.metaServiceGroups))
+		for id := range m.metaServiceGroups {
+			lookup[id] = ""
+		}
+		statusMap, err := m.store.LoadMetaServiceGroupStatus(txn, lookup)
 		if err != nil {
 			return err
 		}
@@ -399,8 +485,19 @@ func (m *MetaServiceGroupManager) assignedKeyspaceCounts(ctx context.Context, gr
 }
 
 // updateGroups updates currently available meta-service groups.
-func (m *MetaServiceGroupManager) updateGroups(metaServiceGroups map[string]string) {
+func (m *MetaServiceGroupManager) updateGroups(metaServiceGroups map[string]config.MetaServiceGroupConfig) {
 	m.Lock()
 	defer m.Unlock()
-	m.metaServiceGroups = metaServiceGroups
+	m.metaServiceGroups = cloneMetaServiceGroupConfigs(metaServiceGroups)
+}
+
+func cloneMetaServiceGroupConfigs(metaServiceGroups map[string]config.MetaServiceGroupConfig) map[string]config.MetaServiceGroupConfig {
+	if metaServiceGroups == nil {
+		return nil
+	}
+	cloned := make(map[string]config.MetaServiceGroupConfig, len(metaServiceGroups))
+	for id, group := range metaServiceGroups {
+		cloned[id] = group.Clone()
+	}
+	return cloned
 }

--- a/pkg/keyspace/meta_service_group_test.go
+++ b/pkg/keyspace/meta_service_group_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/tikv/pd/pkg/storage/endpoint"
 	"github.com/tikv/pd/pkg/storage/kv"
+	serverconfig "github.com/tikv/pd/server/config"
 )
 
 type metaServiceGroupTestSuite struct {
@@ -35,11 +36,11 @@ func TestMetaServiceGroupTestSuite(t *testing.T) {
 	suite.Run(t, new(metaServiceGroupTestSuite))
 }
 
-func mockMetaServiceGroups() map[string]string {
-	return map[string]string{
-		"etcd-group-0": "etcd-group-0.tidb-serverless.cluster.svc.local",
-		"etcd-group-1": "etcd-group-1.tidb-serverless.cluster.svc.local",
-		"etcd-group-2": "etcd-group-2.tidb-serverless.cluster.svc.local",
+func mockMetaServiceGroups() map[string]serverconfig.MetaServiceGroupConfig {
+	return map[string]serverconfig.MetaServiceGroupConfig{
+		"etcd-group-0": {Addresses: "etcd-group-0.tidb-serverless.cluster.svc.local"},
+		"etcd-group-1": {Addresses: "etcd-group-1.tidb-serverless.cluster.svc.local"},
+		"etcd-group-2": {Addresses: "etcd-group-2.tidb-serverless.cluster.svc.local"},
 	}
 }
 
@@ -125,7 +126,7 @@ func (suite *metaServiceGroupTestSuite) TestAttachEndpoints() {
 
 	expected := mockMetaServiceGroups()["etcd-group-1"]
 	actual := keyspaceConfig[MetaServiceGroupAddressesKey]
-	re.Equal(expected, actual, "AttachEndpoints should set the metaServiceGroups value")
+	re.Equal(expected.Addresses, actual, "AttachEndpoints should set the metaServiceGroups value")
 }
 
 func (suite *metaServiceGroupTestSuite) TestAttachEndpointsMissingGroup() {
@@ -146,8 +147,8 @@ func (suite *metaServiceGroupTestSuite) TestAttachEndpointsMissingGroup() {
 
 func (suite *metaServiceGroupTestSuite) TestUpdateEndpoints() {
 	re := suite.Require()
-	newMap := map[string]string{
-		"foo": "foo.bar.local",
+	newMap := map[string]serverconfig.MetaServiceGroupConfig{
+		"foo": {Addresses: "foo.bar.local"},
 	}
 	suite.manager.updateGroups(newMap)
 	config := map[string]string{MetaServiceGroupIDKey: "foo"}
@@ -162,8 +163,8 @@ func (suite *metaServiceGroupTestSuite) TestGetGroupsReturnsCopy() {
 	delete(groups, "etcd-group-1")
 
 	currentGroups := suite.manager.GetGroups()
-	re.Equal(mockMetaServiceGroups()["etcd-group-0"], currentGroups["etcd-group-0"])
-	re.Equal(mockMetaServiceGroups()["etcd-group-1"], currentGroups["etcd-group-1"])
+	re.Equal(mockMetaServiceGroups()["etcd-group-0"].Addresses, currentGroups["etcd-group-0"])
+	re.Equal(mockMetaServiceGroups()["etcd-group-1"].Addresses, currentGroups["etcd-group-1"])
 }
 
 func (suite *metaServiceGroupTestSuite) TestUpdateEndpointsAndUpdateAssignment() {
@@ -179,7 +180,7 @@ func (suite *metaServiceGroupTestSuite) TestUpdateEndpointsAndUpdateAssignment()
 
 	// Add a new group "etcd-group-3"
 	newMap := mockMetaServiceGroups()
-	newMap["etcd-group-3"] = "etcd-group-3.tidb-serverless.cluster.svc.local"
+	newMap["etcd-group-3"] = serverconfig.MetaServiceGroupConfig{Addresses: "etcd-group-3.tidb-serverless.cluster.svc.local"}
 	suite.manager.updateGroups(newMap)
 
 	// Move the assignment from the originally assigned group to "etcd-group-3"

--- a/server/api/config.go
+++ b/server/api/config.go
@@ -264,6 +264,15 @@ func (h *confHandler) updateMetaServiceGroups(oldCfg, newCfg *config.KeyspaceCon
 	if err := config.AdjustMetaServiceGroups(newGroups); err != nil {
 		return err
 	}
+	oldGroups := oldCfg.GetMetaServiceGroupConfigs()
+	for id, group := range newGroups {
+		if group.Enabled == nil {
+			if oldGroup, ok := oldGroups[id]; ok {
+				group.Enabled = oldGroup.Enabled
+				newGroups[id] = group
+			}
+		}
+	}
 	deletedGroups := make([]string, 0)
 	for id := range oldCfg.GetMetaServiceGroups() {
 		if _, ok := newGroups[id]; !ok {

--- a/server/apiv2/handlers/meta_service_group.go
+++ b/server/apiv2/handlers/meta_service_group.go
@@ -121,7 +121,7 @@ func PatchMetaServiceGroups(c *gin.Context) {
 	}
 	oldCfg := svr.GetPersistOptions().GetKeyspaceConfig()
 	newCfg := oldCfg.Clone()
-	newGroups := oldCfg.GetMetaServiceGroups()
+	newGroups := oldCfg.GetMetaServiceGroupConfigs()
 	deletedGroups := make([]string, 0)
 	for id, addresses := range normalizedPatch {
 		if addresses == nil {
@@ -130,7 +130,9 @@ func PatchMetaServiceGroups(c *gin.Context) {
 			deletedGroups = append(deletedGroups, id)
 		} else {
 			// Add or update operation
-			newGroups[id] = *addresses
+			group := newGroups[id]
+			group.Addresses = *addresses
+			newGroups[id] = group
 		}
 	}
 	newCfg.MetaServiceGroups = newGroups

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -270,8 +270,11 @@ type MetaServiceGroupConfig struct {
 }
 
 // Clone returns a deep copy of the meta-service group config.
-func (c MetaServiceGroupConfig) Clone() MetaServiceGroupConfig {
-	cloned := c
+func (c *MetaServiceGroupConfig) Clone() MetaServiceGroupConfig {
+	if c == nil {
+		return MetaServiceGroupConfig{}
+	}
+	cloned := *c
 	if c.Enabled != nil {
 		enabled := *c.Enabled
 		cloned.Enabled = &enabled

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -261,6 +261,55 @@ var (
 	defaultRuntimeServices = []string{}
 )
 
+// MetaServiceGroupConfig stores the configured meta-service group endpoint and
+// whether the group should be enabled by default.
+type MetaServiceGroupConfig struct {
+	Addresses string `toml:"addresses" json:"addresses"`
+	// Enabled is nil when the config omits the field.
+	Enabled *bool `toml:"enabled" json:"enabled,omitempty"`
+}
+
+// Clone returns a deep copy of the meta-service group config.
+func (c MetaServiceGroupConfig) Clone() MetaServiceGroupConfig {
+	cloned := c
+	if c.Enabled != nil {
+		enabled := *c.Enabled
+		cloned.Enabled = &enabled
+	}
+	return cloned
+}
+
+// UnmarshalJSON accepts either a string address or an object with addresses
+// and enabled fields.
+func (c *MetaServiceGroupConfig) UnmarshalJSON(data []byte) error {
+	if strings.TrimSpace(string(data)) == "null" {
+		*c = MetaServiceGroupConfig{}
+		return nil
+	}
+	var address string
+	if err := json.Unmarshal(data, &address); err == nil {
+		c.Addresses = address
+		return nil
+	}
+	type alias MetaServiceGroupConfig
+	var cfg alias
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return err
+	}
+	*c = MetaServiceGroupConfig(cfg)
+	return nil
+}
+
+// UnmarshalTOML accepts either a string address or a table with addresses and
+// enabled fields.
+func (c *MetaServiceGroupConfig) UnmarshalTOML(data any) error {
+	raw, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	return c.UnmarshalJSON(raw)
+}
+
 func init() {
 	initByLDFlags(versioninfo.PDEdition)
 }
@@ -882,8 +931,9 @@ type KeyspaceConfig struct {
 	// CheckRegionSplitInterval indicates the interval to check whether the region split is complete
 	CheckRegionSplitInterval typeutil.Duration `toml:"check-region-split-interval" json:"check-region-split-interval"`
 	// MetaServiceGroups is the available external meta-service groups.
-	// The key is the meta-service group name, and the value is the corresponding endpoint.
-	MetaServiceGroups map[string]string `toml:"meta-service-groups" json:"meta-service-groups"`
+	// The key is the meta-service group name, and the value is the corresponding
+	// endpoint plus the default enabled state.
+	MetaServiceGroups map[string]MetaServiceGroupConfig `toml:"meta-service-groups" json:"meta-service-groups"`
 }
 
 // Validate checks if keyspace config falls within acceptable range.
@@ -921,9 +971,9 @@ func IsValidMetaServiceGroupID(id string) bool {
 }
 
 // AdjustMetaServiceGroups validates and adjusts the meta-service groups configuration.
-func AdjustMetaServiceGroups(metaGroups map[string]string) error {
-	dict := make(map[string]string, len(metaGroups))
-	for groupID, endpoint := range metaGroups {
+func AdjustMetaServiceGroups(metaGroups map[string]MetaServiceGroupConfig) error {
+	dict := make(map[string]MetaServiceGroupConfig, len(metaGroups))
+	for groupID, group := range metaGroups {
 		id := strings.TrimSpace(groupID)
 		if id == "" {
 			return errors.New("[keyspace] meta-service group ID cannot be empty")
@@ -931,21 +981,22 @@ func AdjustMetaServiceGroups(metaGroups map[string]string) error {
 		if !IsValidMetaServiceGroupID(id) {
 			return errors.New(fmt.Sprintf("[keyspace] meta-service group ID cannot contain '/': %s", id))
 		}
-		address := strings.TrimSpace(endpoint)
+		address := strings.TrimSpace(group.Addresses)
 		if address == "" {
 			return errors.New("[keyspace] meta-service group addresses cannot be empty")
 		}
 		if _, ok := dict[id]; ok {
 			return errors.New(fmt.Sprintf("[keyspace] meta-service group ID cannot be duplicated: %s", id))
 		}
-		dict[id] = address
+		group.Addresses = address
+		dict[id] = group
 	}
 	// Clear the original map and copy the validated values back to it.
 	for groupID := range metaGroups {
 		delete(metaGroups, groupID)
 	}
-	for groupID, endpoint := range dict {
-		metaGroups[groupID] = endpoint
+	for groupID, group := range dict {
+		metaGroups[groupID] = group
 	}
 
 	return nil
@@ -956,9 +1007,9 @@ func (c *KeyspaceConfig) Clone() *KeyspaceConfig {
 	cfg := *c
 	cfg.PreAlloc = append(c.PreAlloc[:0:0], c.PreAlloc...)
 	if c.MetaServiceGroups != nil {
-		cfg.MetaServiceGroups = make(map[string]string, len(c.MetaServiceGroups))
-		for name, endpoint := range c.MetaServiceGroups {
-			cfg.MetaServiceGroups[name] = endpoint
+		cfg.MetaServiceGroups = make(map[string]MetaServiceGroupConfig, len(c.MetaServiceGroups))
+		for name, group := range c.MetaServiceGroups {
+			cfg.MetaServiceGroups[name] = group.Clone()
 		}
 	}
 	return &cfg
@@ -986,16 +1037,26 @@ func (c *KeyspaceConfig) GetCheckRegionSplitInterval() time.Duration {
 	return c.CheckRegionSplitInterval.Duration
 }
 
-// GetMetaServiceGroups returns the current meta-service-group configuration.
+// GetMetaServiceGroups returns the current meta-service-group addresses.
 func (c *KeyspaceConfig) GetMetaServiceGroups() map[string]string {
 	ret := make(map[string]string, len(c.MetaServiceGroups))
-	for name, endpoint := range c.MetaServiceGroups {
-		ret[name] = endpoint
+	for name, group := range c.MetaServiceGroups {
+		ret[name] = group.Addresses
 	}
 	return ret
 }
 
 // SetMetaServiceGroups updates the current meta-service-group configuration.
-func (c *KeyspaceConfig) SetMetaServiceGroups(metaServiceGroups map[string]string) {
+func (c *KeyspaceConfig) SetMetaServiceGroups(metaServiceGroups map[string]MetaServiceGroupConfig) {
 	c.MetaServiceGroups = metaServiceGroups
+}
+
+// GetMetaServiceGroupConfigs returns the current meta-service-group
+// configuration.
+func (c *KeyspaceConfig) GetMetaServiceGroupConfigs() map[string]MetaServiceGroupConfig {
+	ret := make(map[string]MetaServiceGroupConfig, len(c.MetaServiceGroups))
+	for name, group := range c.MetaServiceGroups {
+		ret[name] = group.Clone()
+	}
+	return ret
 }

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -602,51 +602,66 @@ func TestRateLimitClone(t *testing.T) {
 }
 
 func TestAdjustMetaServiceGroups(t *testing.T) {
+	boolPtr := func(v bool) *bool { return &v }
 	testCases := []struct {
 		name      string
-		groups    map[string]string
-		expected  map[string]string
+		groups    map[string]MetaServiceGroupConfig
+		expected  map[string]MetaServiceGroupConfig
 		expectErr bool
 		errorMsg  string
 	}{
 		{
-			name:     "trim group ID and endpoint",
-			groups:   map[string]string{" group-1 ": " http://127.0.0.1:2379 "},
-			expected: map[string]string{"group-1": "http://127.0.0.1:2379"},
+			name: "trim group ID, endpoint, and preserve enabled",
+			groups: map[string]MetaServiceGroupConfig{
+				" group-1 ": {Addresses: " http://127.0.0.1:2379 ", Enabled: boolPtr(true)},
+			},
+			expected: map[string]MetaServiceGroupConfig{
+				"group-1": {Addresses: "http://127.0.0.1:2379", Enabled: boolPtr(true)},
+			},
 		},
 		{
-			name:     "multiple groups",
-			groups:   map[string]string{"group-1": "http://127.0.0.1:2379", " group-2 ": " http://127.0.0.1:2380 "}, //nolint:gocritic // intentional whitespace to verify trimming
-			expected: map[string]string{"group-1": "http://127.0.0.1:2379", "group-2": "http://127.0.0.1:2380"},
+			name: "multiple groups",
+			groups: map[string]MetaServiceGroupConfig{
+				"group-1":   {Addresses: "http://127.0.0.1:2379"},
+				" group-2 ": {Addresses: " http://127.0.0.1:2380 ", Enabled: boolPtr(false)}, //nolint:gocritic // intentional whitespace to verify trimming
+			},
+			expected: map[string]MetaServiceGroupConfig{
+				"group-1": {Addresses: "http://127.0.0.1:2379"},
+				"group-2": {Addresses: "http://127.0.0.1:2380", Enabled: boolPtr(false)},
+			},
 		},
 		{
 			name:      "empty group ID after trim",
-			groups:    map[string]string{" ": "http://127.0.0.1:2379"},
+			groups:    map[string]MetaServiceGroupConfig{" ": {Addresses: "http://127.0.0.1:2379"}},
 			expectErr: true,
 			errorMsg:  "[keyspace] meta-service group ID cannot be empty",
 		},
 		{
 			name:      "empty endpoint after trim",
-			groups:    map[string]string{"group-1": " "},
+			groups:    map[string]MetaServiceGroupConfig{"group-1": {Addresses: " "}},
 			expectErr: true,
 			errorMsg:  "[keyspace] meta-service group addresses cannot be empty",
 		},
 		{
 			name:      "duplicate group ID after trim",
-			groups:    map[string]string{"group-1": "http://127.0.0.1:2379", " group-1 ": "http://127.0.0.1:2380"}, //nolint:gocritic // intentional whitespace to verify trimming
+			groups:    map[string]MetaServiceGroupConfig{"group-1": {Addresses: "http://127.0.0.1:2379"}, " group-1 ": {Addresses: "http://127.0.0.1:2380"}}, //nolint:gocritic // intentional whitespace to verify trimming
 			expectErr: true,
 			errorMsg:  "[keyspace] meta-service group ID cannot be duplicated: group-1",
 		},
 		{
 			name:      "group ID with slash is rejected",
-			groups:    map[string]string{"group/1": "http://127.0.0.1:2379"},
+			groups:    map[string]MetaServiceGroupConfig{"group/1": {Addresses: "http://127.0.0.1:2379"}},
 			expectErr: true,
 			errorMsg:  "[keyspace] meta-service group ID cannot contain '/': group/1",
 		},
 		{
-			name:     "group ID with other special characters is allowed",
-			groups:   map[string]string{"group.1:8080": "http://127.0.0.1:2379"},
-			expected: map[string]string{"group.1:8080": "http://127.0.0.1:2379"},
+			name: "group ID with other special characters is allowed",
+			groups: map[string]MetaServiceGroupConfig{
+				"group.1:8080": {Addresses: "http://127.0.0.1:2379"},
+			},
+			expected: map[string]MetaServiceGroupConfig{
+				"group.1:8080": {Addresses: "http://127.0.0.1:2379"},
+			},
 		},
 	}
 
@@ -662,4 +677,23 @@ func TestAdjustMetaServiceGroups(t *testing.T) {
 			re.Equal(testCase.expected, testCase.groups)
 		})
 	}
+}
+
+func TestMetaServiceGroupsTOMLDecode(t *testing.T) {
+	re := require.New(t)
+	cfg := NewConfig()
+	raw := `
+[keyspace]
+[keyspace.meta-service-groups]
+"group-1" = { addresses = " http://127.0.0.1:2379 ", enabled = true }
+"group-2" = "http://127.0.0.1:2380"
+`
+	_, err := toml.Decode(raw, cfg)
+	re.NoError(err)
+	re.NoError(cfg.Adjust(nil, false))
+	re.Equal("http://127.0.0.1:2379", cfg.Keyspace.MetaServiceGroups["group-1"].Addresses)
+	re.NotNil(cfg.Keyspace.MetaServiceGroups["group-1"].Enabled)
+	re.True(*cfg.Keyspace.MetaServiceGroups["group-1"].Enabled)
+	re.Equal("http://127.0.0.1:2380", cfg.Keyspace.MetaServiceGroups["group-2"].Addresses)
+	re.Nil(cfg.Keyspace.MetaServiceGroups["group-2"].Enabled)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -534,7 +534,7 @@ func (s *Server) startServer(ctx context.Context) error {
 	if s.IsKeyspaceGroupEnabled() {
 		s.keyspaceGroupManager = keyspace.NewKeyspaceGroupManager(s.ctx, s.storage, s.client)
 	}
-	s.metaServiceGroupManager = keyspace.NewMetaServiceGroupManager(s.storage, s.cfg.Keyspace.GetMetaServiceGroups())
+	s.metaServiceGroupManager = keyspace.NewMetaServiceGroupManager(s.storage, s.cfg.Keyspace.GetMetaServiceGroupConfigs())
 	s.keyspaceManager = keyspace.NewKeyspaceManager(
 		s.ctx,
 		s.storage,

--- a/tests/server/apiv2/handlers/meta_service_group_test.go
+++ b/tests/server/apiv2/handlers/meta_service_group_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/tikv/pd/pkg/keyspace"
 	"github.com/tikv/pd/pkg/storage/endpoint"
 	"github.com/tikv/pd/server/apiv2/handlers"
-	"github.com/tikv/pd/server/config"
+	serverconfig "github.com/tikv/pd/server/config"
 	"github.com/tikv/pd/tests"
 )
 
@@ -46,7 +46,16 @@ func TestMetaServiceGroupTestSuite(t *testing.T) {
 	suite.Run(t, new(metaServiceGroupTestSuite))
 }
 
-func mockMetaServiceGroups() map[string]string {
+func mockMetaServiceGroups() map[string]serverconfig.MetaServiceGroupConfig {
+	enabled := true
+	return map[string]serverconfig.MetaServiceGroupConfig{
+		"etcd-group-0": {Addresses: "etcd-group-0.tidb-serverless.cluster.svc.local", Enabled: &enabled},
+		"etcd-group-1": {Addresses: "etcd-group-1.tidb-serverless.cluster.svc.local", Enabled: &enabled},
+		"etcd-group-2": {Addresses: "etcd-group-2.tidb-serverless.cluster.svc.local", Enabled: &enabled},
+	}
+}
+
+func mockMetaServiceGroupAddresses() map[string]string {
 	return map[string]string{
 		"etcd-group-0": "etcd-group-0.tidb-serverless.cluster.svc.local",
 		"etcd-group-1": "etcd-group-1.tidb-serverless.cluster.svc.local",
@@ -58,7 +67,7 @@ func (suite *metaServiceGroupTestSuite) SetupTest() {
 	re := suite.Require()
 	ctx, cancel := context.WithCancel(context.Background())
 	suite.cleanup = cancel
-	cluster, err := tests.NewTestCluster(ctx, 1, func(conf *config.Config, _ string) {
+	cluster, err := tests.NewTestCluster(ctx, 1, func(conf *serverconfig.Config, _ string) {
 		conf.Keyspace.WaitRegionSplit = false
 		conf.Keyspace.MetaServiceGroups = mockMetaServiceGroups()
 		conf.Keyspace.WaitRegionSplit = false
@@ -111,7 +120,7 @@ func collectStatus(re *require.Assertions, keyspaces []*keyspacepb.KeyspaceMeta)
 func (suite *metaServiceGroupTestSuite) TestUpdateMetaServiceGroupsViaConfigAPI() {
 	re := suite.Require()
 	// Adding a new group through /config should succeed and be visible via v2 API.
-	added := mockMetaServiceGroups()
+	added := mockMetaServiceGroupAddresses()
 	added["etcd-group-x"] = "etcd-group-x.example.local"
 	code, body := suite.setMetaServiceGroupsViaConfig(re, added)
 	re.Equal(http.StatusOK, code, body)
@@ -121,6 +130,8 @@ func (suite *metaServiceGroupTestSuite) TestUpdateMetaServiceGroupsViaConfigAPI(
 	for _, group := range groups {
 		if group.ID == "etcd-group-x" {
 			x = group
+		} else {
+			re.True(group.Status.Enabled)
 		}
 	}
 	re.NotNil(x, "etcd-group-x should be added via /config")
@@ -157,10 +168,9 @@ func (suite *metaServiceGroupTestSuite) TestMetaServiceGroupOperations() {
 	defaultKeyspace := mustLoadKeyspaces(re, suite.server, keyspace.GetBootstrapKeyspaceName())
 	re.NotContains(defaultKeyspace.GetConfig(), keyspace.MetaServiceGroupIDKey)
 	re.NotContains(defaultKeyspace.GetConfig(), keyspace.MetaServiceGroupAddressesKey)
-	// Meta-service groups are disabled by default and must be enabled before assignment.
+	// Meta-service groups are enabled from config before assignment.
 	for _, group := range mustLoadMetaServiceGroups(re, suite.server) {
-		re.False(group.Status.Enabled)
-		mustEnableMetaServiceGroup(re, suite.server, group.ID)
+		re.True(group.Status.Enabled)
 	}
 	// Create keyspaces and collect their meta-service group configs.
 	keyspaces := mustMakeTestKeyspaces(re, suite.server, 20)

--- a/tools/pd-ctl/tests/meta_service_group/meta_service_group_test.go
+++ b/tools/pd-ctl/tests/meta_service_group/meta_service_group_test.go
@@ -47,9 +47,9 @@ func (suite *metaServiceGroupCLITestSuite) SetupTest() {
 	suite.ctx, suite.cancel = context.WithCancel(context.Background())
 	re.NoError(failpoint.Enable("github.com/tikv/pd/server/delayStartServerLoop", `return(true)`))
 	tc, err := pdTests.NewTestCluster(suite.ctx, 1, func(conf *config.Config, _ string) {
-		conf.Keyspace.MetaServiceGroups = map[string]string{
-			"group-0": "addr0.example.com",
-			"group-1": "addr1.example.com",
+		conf.Keyspace.MetaServiceGroups = map[string]config.MetaServiceGroupConfig{
+			"group-0": {Addresses: "addr0.example.com"},
+			"group-1": {Addresses: "addr1.example.com"},
 		}
 		conf.Keyspace.WaitRegionSplit = false
 	})


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #11167

Allow meta-service groups to be configured with a default enabled state, so new groups can be assigned without a follow-up runtime patch during bootstrap or testing.

### What is changed and how does it work?

```commit-message
Allow meta-service groups to carry a default enabled state in config.
Keep the legacy address-only form working, preserve runtime status when it already exists, and update config and handler paths to carry enabled state through config updates.
```

### Check List

Tests

[x] Unit test
set pd.toml
```
[keyspace]
pre-alloc = ["ks1"]

[keyspace.meta-service-groups]
#etcd-group-0 = "127.0.0.1:2399"
#etcd-group-1 = "127.0.0.2:2379,127.0.0.2:2380,127.0.0.2:2381"
"etcd-group-0" = { addresses = "127.0.0.1:2399", enabled = true }

```

get keyspace list:
```
{
    "keyspaces": [
        {
            "id": 1,
            "name": "ks1",
            "state": "ENABLED",
            "created_at": 1787243594,
            "state_changed_at": 1787243594,
            "config": {
                "gc_management_type": "keyspace_level",
                "meta_service_group_addrs": "127.0.0.1:2399",
                "meta_service_group_id": "etcd-group-0"
            }
        },
        {
            "id": 16777214,
            "name": "SYSTEM",
            "state": "ENABLED",
            "created_at": 1787243594,
            "state_changed_at": 1787243594,
            "config": {
                "gc_management_type": "keyspace_level",
                "region_bound_type": "txn"
            }
        }
    ],
    "next_page_token": ""
}


```


- Integration test

Code changes

- Has the configuration change
- Has HTTP APIs changed

Side effects

- Increased code complexity

### Release note

```release-note
Allow PD config files to mark meta-service groups as enabled by default, so new groups can be assigned without a follow-up runtime patch.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional enabled-state settings for meta-service groups.
  * Added structured group configuration while retaining support for legacy address-only settings.
  * Initialized group status from configured defaults and prevented assignments to disabled groups.
  * Preserved existing enabled states when updating group addresses.

* **Bug Fixes**
  * Improved cleanup for removed groups and repeated tombstone transitions.
  * Prevented stale assignments and incorrect counter decrements.
  * Preserved complete group settings when modifying addresses through the API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->