### PR TITLE
*: delete per-store metrics when a store is tombstoned (#11127)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -147,6 +147,7 @@ require (
 	github.com/kkHAIKE/contextcheck v1.1.6 // indirect
 	github.com/kulti/thelper v0.6.3 // indirect
 	github.com/kunwardeep/paralleltest v1.0.10 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lasiar/canonicalheader v1.1.2 // indirect
 	github.com/ldez/exptostd v0.4.2 // indirect
 	github.com/ldez/gomoddirectives v0.6.1 // indirect

--- a/pkg/core/basic_cluster.go
+++ b/pkg/core/basic_cluster.go
@@ -51,12 +51,17 @@ func (bc *BasicCluster) GetLeaderStoreByRegionID(regionID uint64) *StoreInfo {
 func (bc *BasicCluster) getWriteRate(
 	f func(storeID uint64) (bytesRate, keysRate float64),
 ) (storeIDs []uint64, bytesRates, keysRates []float64) {
-	storeIDs = bc.GetStoreIDs()
-	count := len(storeIDs)
-	bytesRates = make([]float64, 0, count)
-	keysRates = make([]float64, 0, count)
-	for _, id := range storeIDs {
+	stores := bc.GetStores()
+	storeIDs = make([]uint64, 0, len(stores))
+	bytesRates = make([]float64, 0, len(stores))
+	keysRates = make([]float64, 0, len(stores))
+	for _, store := range stores {
+		if store.IsRemoved() {
+			continue
+		}
+		id := store.GetID()
 		bytesRate, keysRate := f(id)
+		storeIDs = append(storeIDs, id)
 		bytesRates = append(bytesRates, bytesRate)
 		keysRates = append(keysRates, keysRate)
 	}

--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"runtime"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -13,6 +14,8 @@ import (
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/kvproto/pkg/schedulingpb"
 	"github.com/pingcap/log"
+	"go.uber.org/zap"
+
 	"github.com/tikv/pd/pkg/cluster"
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/errs"
@@ -20,6 +23,7 @@ import (
 	"github.com/tikv/pd/pkg/ratelimit"
 	"github.com/tikv/pd/pkg/schedule"
 	sc "github.com/tikv/pd/pkg/schedule/config"
+	"github.com/tikv/pd/pkg/schedule/filter"
 	"github.com/tikv/pd/pkg/schedule/hbstream"
 	"github.com/tikv/pd/pkg/schedule/labeler"
 	"github.com/tikv/pd/pkg/schedule/operator"
@@ -35,7 +39,6 @@ import (
 	"github.com/tikv/pd/pkg/storage"
 	"github.com/tikv/pd/pkg/utils/keypath"
 	"github.com/tikv/pd/pkg/utils/logutil"
-	"go.uber.org/zap"
 )
 
 // Cluster is used to manage all information for scheduling purpose.
@@ -521,8 +524,42 @@ func (c *Cluster) collectMetrics() {
 	for _, s := range stores {
 		statsMap.Observe(s)
 		statistics.ObserveHotStat(s, c.hotStat.StoresStats)
+		// Observe/ObserveHotStat write from this snapshot unconditionally, so a
+		// concurrent bury or final removal of s between GetStores() above and
+		// this write can have its own metric cleanup undone by it. Re-checking
+		// right after the write and redoing the cleanup closes that race
+		// without needing synchronization with the bury/removal path.
+		current := c.GetStore(s.GetID())
+		// ResetStoreStatistics covers storeStatusGauge/storeStats, which
+		// observe() itself stops writing as soon as it sees a tombstoned
+		// store -- so, unlike the fields above, there's no legitimate write to
+		// preserve here once the store is IsRemoved(), not just once it's
+		// gone entirely. But storeStatusGauge's cleanup is a DeletePartialMatch
+		// full-vector scan, so only pay for it when this iteration's own s was
+		// still live (observe(s) could then have written using stale data);
+		// once a snapshot correctly shows IsRemoved(), observe() already
+		// skipped writing these fields and there's nothing to undo, so a
+		// tombstoned store sitting in GetStores() for up to 30 days doesn't
+		// cost a scan on every 10s tick.
+		if !s.IsRemoved() && (current == nil || current.IsRemoved()) {
+			statistics.ResetStoreStatistics(strconv.FormatUint(s.GetID(), 10))
+		}
 	}
 	statsMap.Collect()
+	// statsMap.Collect() writes statistics.StoreLimitGauge from its own
+	// GetStoresLimit() snapshot, taken independently of stores above and with
+	// no cluster reference of its own to re-check against. Reuse the stores
+	// snapshot already captured here to catch and undo it. Like
+	// ResetStoreStatistics above, a store limit has no legitimate reason to
+	// still be configured once the store is tombstoned, so this also checks
+	// IsRemoved(), not just full removal.
+	for _, s := range stores {
+		if store := c.GetStore(s.GetID()); store == nil || store.IsRemoved() {
+			id := strconv.FormatUint(s.GetID(), 10)
+			statistics.StoreLimitGauge.DeleteLabelValues(id, "add-peer")
+			statistics.StoreLimitGauge.DeleteLabelValues(id, "remove-peer")
+		}
+	}
 
 	c.coordinator.GetSchedulersController().CollectSchedulerMetrics()
 	c.coordinator.CollectHotSpotMetrics()
@@ -541,6 +578,8 @@ func resetMetrics() {
 	statistics.Reset()
 	schedulers.ResetSchedulerMetrics()
 	schedule.ResetHotSpotMetrics()
+	filter.ResetFilterMetrics()
+	hbstream.ResetHeartbeatStreamMetrics()
 }
 
 // StartBackgroundJobs starts background jobs.

--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -530,13 +530,13 @@ func (c *Cluster) collectMetrics() {
 		// right after the write and redoing the cleanup closes that race
 		// without needing synchronization with the bury/removal path.
 		current := c.GetStore(s.GetID())
-		// ResetStoreStatistics covers storeStatusGauge/storeStats, which
-		// observe() itself stops writing as soon as it sees a tombstoned
-		// store -- so, unlike the fields above, there's no legitimate write to
-		// preserve here once the store is IsRemoved(), not just once it's
-		// gone entirely. But storeStatusGauge's cleanup is a DeletePartialMatch
-		// full-vector scan, so only pay for it when this iteration's own s was
-		// still live (observe(s) could then have written using stale data);
+		// ResetStoreStatistics covers storeStatusGauge, which observe()
+		// itself stops writing as soon as it sees a tombstoned store, so
+		// there's no legitimate write to preserve here once the store is
+		// IsRemoved(), not just once it's gone entirely. But its cleanup is a
+		// DeletePartialMatch full-vector scan, so only pay for it when this
+		// iteration's own s was still live (observe(s) could then have written
+		// using stale data);
 		// once a snapshot correctly shows IsRemoved(), observe() already
 		// skipped writing these fields and there's nothing to undo, so a
 		// tombstoned store sitting in GetStores() for up to 30 days doesn't

--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -580,6 +580,7 @@ func resetMetrics() {
 	schedule.ResetHotSpotMetrics()
 	filter.ResetFilterMetrics()
 	hbstream.ResetHeartbeatStreamMetrics()
+	operator.ResetOperatorMetrics()
 }
 
 // StartBackgroundJobs starts background jobs.

--- a/pkg/mcs/scheduling/server/grpc_service.go
+++ b/pkg/mcs/scheduling/server/grpc_service.go
@@ -16,6 +16,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"sync/atomic"
@@ -25,6 +26,11 @@ import (
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/kvproto/pkg/schedulingpb"
 	"github.com/pingcap/log"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	bs "github.com/tikv/pd/pkg/basicserver"
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/errs"
@@ -33,10 +39,6 @@ import (
 	"github.com/tikv/pd/pkg/utils/keypath"
 	"github.com/tikv/pd/pkg/utils/logutil"
 	"github.com/tikv/pd/pkg/versioninfo"
-	"go.uber.org/zap"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // gRPC errors
@@ -156,6 +158,10 @@ func (s *Service) RegionHeartbeat(stream schedulingpb.Scheduling_RegionHeartbeat
 		if store == nil {
 			return errors.Errorf("invalid store ID %d, not found", storeID)
 		}
+		if store.IsRemoved() {
+			log.Debug("skip region heartbeat from tombstone store", zap.Uint64("store-id", storeID))
+			continue
+		}
 
 		if time.Since(lastBind) > time.Minute {
 			s.hbStreams.BindStream(storeID, server)
@@ -181,8 +187,21 @@ func (s *Service) StoreHeartbeat(_ context.Context, request *schedulingpb.StoreH
 		return &schedulingpb.StoreHeartbeatResponse{Header: notBootstrappedHeader()}, nil
 	}
 
-	if c.GetStore(request.GetStats().GetStoreId()) == nil {
+	storeID := request.GetStats().GetStoreId()
+	if c.GetStore(storeID) == nil {
 		s.metaWatcher.GetStoreWatcher().ForceLoad()
+	}
+
+	store := c.GetStore(storeID)
+	if store == nil {
+		return &schedulingpb.StoreHeartbeatResponse{
+			Header: wrapErrorToHeader(schedulingpb.ErrorType_UNKNOWN, fmt.Sprintf("store %v not found", storeID)),
+		}, nil
+	}
+	if store.IsRemoved() {
+		return &schedulingpb.StoreHeartbeatResponse{
+			Header: wrapErrorToHeader(schedulingpb.ErrorType_UNKNOWN, fmt.Sprintf("store %v is tombstone", storeID)),
+		}, nil
 	}
 
 	// TODO: add metrics

--- a/pkg/mcs/scheduling/server/meta/watcher.go
+++ b/pkg/mcs/scheduling/server/meta/watcher.go
@@ -22,13 +22,19 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/log"
-	"github.com/tikv/pd/pkg/core"
-	"github.com/tikv/pd/pkg/statistics"
-	"github.com/tikv/pd/pkg/utils/etcdutil"
-	"github.com/tikv/pd/pkg/utils/keypath"
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
+
+	"github.com/tikv/pd/pkg/core"
+	"github.com/tikv/pd/pkg/schedule"
+	"github.com/tikv/pd/pkg/schedule/filter"
+	"github.com/tikv/pd/pkg/schedule/hbstream"
+	"github.com/tikv/pd/pkg/schedule/scatter"
+	"github.com/tikv/pd/pkg/schedule/schedulers"
+	"github.com/tikv/pd/pkg/statistics"
+	"github.com/tikv/pd/pkg/utils/etcdutil"
+	"github.com/tikv/pd/pkg/utils/keypath"
 )
 
 // Watcher is used to watch the PD API server for any meta changes.
@@ -84,8 +90,13 @@ func (w *Watcher) initializeStoreWatcher() error {
 		}
 
 		if store.GetNodeState() == metapb.NodeState_Removed {
-			statistics.ResetStoreStatistics(store.GetAddress(), strconv.FormatUint(store.GetId(), 10))
-			// TODO: remove hot stats
+			storeIDStr := strconv.FormatUint(store.GetId(), 10)
+			statistics.ResetStoreStatistics(storeIDStr)
+			filter.DeleteStoreMetrics(storeIDStr)
+			hbstream.DeleteStoreMetrics(storeIDStr)
+			schedulers.DeleteStoreMetrics(storeIDStr)
+			schedule.DeleteStoreMetrics(storeIDStr)
+			scatter.DeleteStoreMetrics(storeIDStr)
 		}
 
 		return nil
@@ -98,7 +109,17 @@ func (w *Watcher) initializeStoreWatcher() error {
 		}
 		origin := w.basicCluster.GetStore(storeID)
 		if origin != nil {
+			// Remove the store before the metric cleanup below, not after: see
+			// the matching comment on RaftCluster.deleteStore for why the order
+			// matters for a concurrently-running metrics collection tick.
 			w.basicCluster.DeleteStore(origin)
+			storeIDStr := strconv.FormatUint(storeID, 10)
+			statistics.ResetStoreStatistics(storeIDStr)
+			filter.DeleteStoreMetrics(storeIDStr)
+			hbstream.DeleteStoreMetrics(storeIDStr)
+			schedulers.DeleteStoreMetrics(storeIDStr)
+			schedule.DeleteStoreMetrics(storeIDStr)
+			scatter.DeleteStoreMetrics(storeIDStr)
 			log.Info("delete store meta", zap.Uint64("store-id", storeID))
 		}
 		return nil

--- a/pkg/mcs/scheduling/server/meta/watcher.go
+++ b/pkg/mcs/scheduling/server/meta/watcher.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"strconv"
 	"sync"
+	"sync/atomic"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/pingcap/kvproto/pkg/metapb"
@@ -50,6 +51,13 @@ type Watcher struct {
 	etcdClient   *clientv3.Client
 	basicCluster *core.BasicCluster
 	storeWatcher *etcdutil.LoopWatcher
+
+	// onStoreTombstoned is late-bound via SetOnStoreTombstoned once the parent
+	// Cluster (which owns hotStat, unavailable to this package without an
+	// import cycle) finishes construction. The watcher itself starts watching
+	// before that point, so it's read through an atomic pointer to stay safe
+	// against a store event racing the setup.
+	onStoreTombstoned atomic.Pointer[func(storeID uint64)]
 }
 
 // NewWatcher creates a new watcher to watch the meta change from PD API server.
@@ -97,6 +105,9 @@ func (w *Watcher) initializeStoreWatcher() error {
 			schedulers.DeleteStoreMetrics(storeIDStr)
 			schedule.DeleteStoreMetrics(storeIDStr)
 			scatter.DeleteStoreMetrics(storeIDStr)
+			if fn := w.onStoreTombstoned.Load(); fn != nil {
+				(*fn)(store.GetId())
+			}
 		}
 
 		return nil
@@ -120,6 +131,9 @@ func (w *Watcher) initializeStoreWatcher() error {
 			schedulers.DeleteStoreMetrics(storeIDStr)
 			schedule.DeleteStoreMetrics(storeIDStr)
 			scatter.DeleteStoreMetrics(storeIDStr)
+			if fn := w.onStoreTombstoned.Load(); fn != nil {
+				(*fn)(storeID)
+			}
 			log.Info("delete store meta", zap.Uint64("store-id", storeID))
 		}
 		return nil
@@ -135,6 +149,22 @@ func (w *Watcher) initializeStoreWatcher() error {
 	)
 	w.storeWatcher.StartWatchLoop()
 	return w.storeWatcher.WaitLoad()
+}
+
+// SetOnStoreTombstoned sets the callback invoked (at least once) when a store
+// transitions to tombstone, for cleanup that only the parent Cluster can do
+// without an import cycle (removing rolling hot stats). NewWatcher's initial
+// load runs before the caller has a chance to install this callback, so a
+// store already tombstoned at startup would otherwise never get it invoked;
+// reconcile against whatever the watcher has already loaded here to close
+// that gap.
+func (w *Watcher) SetOnStoreTombstoned(fn func(storeID uint64)) {
+	w.onStoreTombstoned.Store(&fn)
+	for _, store := range w.basicCluster.GetStores() {
+		if store.IsRemoved() {
+			fn(store.GetID())
+		}
+	}
 }
 
 // Close closes the watcher.

--- a/pkg/mcs/scheduling/server/meta/watcher.go
+++ b/pkg/mcs/scheduling/server/meta/watcher.go
@@ -31,6 +31,7 @@ import (
 	"github.com/tikv/pd/pkg/schedule"
 	"github.com/tikv/pd/pkg/schedule/filter"
 	"github.com/tikv/pd/pkg/schedule/hbstream"
+	"github.com/tikv/pd/pkg/schedule/operator"
 	"github.com/tikv/pd/pkg/schedule/scatter"
 	"github.com/tikv/pd/pkg/schedule/schedulers"
 	"github.com/tikv/pd/pkg/statistics"
@@ -105,6 +106,7 @@ func (w *Watcher) initializeStoreWatcher() error {
 			schedulers.DeleteStoreMetrics(storeIDStr)
 			schedule.DeleteStoreMetrics(storeIDStr)
 			scatter.DeleteStoreMetrics(storeIDStr)
+			operator.DeleteStoreMetrics(storeIDStr)
 			if fn := w.onStoreTombstoned.Load(); fn != nil {
 				(*fn)(store.GetId())
 			}
@@ -131,6 +133,7 @@ func (w *Watcher) initializeStoreWatcher() error {
 			schedulers.DeleteStoreMetrics(storeIDStr)
 			schedule.DeleteStoreMetrics(storeIDStr)
 			scatter.DeleteStoreMetrics(storeIDStr)
+			operator.DeleteStoreMetrics(storeIDStr)
 			if fn := w.onStoreTombstoned.Load(); fn != nil {
 				(*fn)(storeID)
 			}

--- a/pkg/mcs/scheduling/server/server.go
+++ b/pkg/mcs/scheduling/server/server.go
@@ -497,6 +497,12 @@ func (s *Server) startCluster(context.Context) error {
 	if err != nil {
 		return err
 	}
+	// This package's own hotStat rolling stats can't be cleaned up from within
+	// the meta watcher's tombstone path without an import cycle, so the
+	// watcher invokes this callback instead.
+	s.metaWatcher.SetOnStoreTombstoned(func(storeID uint64) {
+		s.cluster.GetStoresStats().RemoveRollingStoreStats(storeID)
+	})
 	// Inject the cluster components into the config watcher after the scheduler controller is created.
 	s.configWatcher.SetSchedulersController(s.cluster.GetCoordinator().GetSchedulersController())
 	// Start the rule watcher after the cluster is created.

--- a/pkg/schedule/coordinator.go
+++ b/pkg/schedule/coordinator.go
@@ -508,7 +508,15 @@ func collectHotMetrics(cluster sche.ClusterInformer, stores []*core.StoreInfo, t
 		storeAddress := s.GetAddress()
 		storeID := s.GetID()
 		storeLabel := strconv.FormatUint(storeID, 10)
+		// HotPeerCache.gc() only removes a tombstoned store from status.AsLeader/
+		// AsPeer's source data on its own TTL-throttled schedule, not every tick,
+		// so a known-tombstoned store here can still have stale hot-peer data.
+		// Treat it as not hot regardless, so the delete branches below run
+		// instead of republishing hotSpotStatusGauge every tick until
+		// HotPeerCache.gc() eventually catches up.
+		removed := s.IsRemoved()
 		stat, hasHotLeader := status.AsLeader[storeID]
+		hasHotLeader = hasHotLeader && !removed
 		if hasHotLeader {
 			hotSpotStatusGauge.WithLabelValues(storeAddress, storeLabel, "total_"+kind+"_bytes_as_leader").Set(stat.TotalBytesRate)
 			hotSpotStatusGauge.WithLabelValues(storeAddress, storeLabel, "total_"+kind+"_keys_as_leader").Set(stat.TotalKeysRate)
@@ -522,6 +530,7 @@ func collectHotMetrics(cluster sche.ClusterInformer, stores []*core.StoreInfo, t
 		}
 
 		stat, hasHotPeer := status.AsPeer[storeID]
+		hasHotPeer = hasHotPeer && !removed
 		if hasHotPeer {
 			hotSpotStatusGauge.WithLabelValues(storeAddress, storeLabel, "total_"+kind+"_bytes_as_peer").Set(stat.TotalBytesRate)
 			hotSpotStatusGauge.WithLabelValues(storeAddress, storeLabel, "total_"+kind+"_keys_as_peer").Set(stat.TotalKeysRate)
@@ -547,7 +556,7 @@ func collectHotMetrics(cluster sche.ClusterInformer, stores []*core.StoreInfo, t
 		// iteration's own s was still live: once a snapshot correctly shows
 		// IsRemoved(), a tombstoned store sitting in GetStores() for up to 30
 		// days doesn't cost a scan on every tick.
-		if !s.IsRemoved() {
+		if !removed {
 			if store := cluster.GetStore(storeID); store == nil || store.IsRemoved() {
 				DeleteStoreMetrics(storeLabel)
 			}

--- a/pkg/schedule/coordinator.go
+++ b/pkg/schedule/coordinator.go
@@ -23,6 +23,8 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/log"
+	"go.uber.org/zap"
+
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/errs"
 	"github.com/tikv/pd/pkg/schedule/checker"
@@ -39,7 +41,6 @@ import (
 	"github.com/tikv/pd/pkg/statistics/utils"
 	"github.com/tikv/pd/pkg/utils/logutil"
 	"github.com/tikv/pd/pkg/utils/syncutil"
-	"go.uber.org/zap"
 )
 
 const (
@@ -537,6 +538,19 @@ func collectHotMetrics(cluster sche.ClusterInformer, stores []*core.StoreInfo, t
 			utils.ForeachRegionStats(func(rwTy utils.RWType, dim int, _ utils.RegionStatKind) {
 				schedulers.HotPendingSum.DeleteLabelValues(storeLabel, rwTy.String(), utils.DimToString(dim))
 			})
+		}
+
+		// stores is a snapshot taken before this loop; if s was buried or fully
+		// removed concurrently, the writes above can recreate a series
+		// DeleteStoreMetrics already deleted for it. DeleteStoreMetrics is a
+		// DeletePartialMatch full-vector scan, so only pay for it when this
+		// iteration's own s was still live: once a snapshot correctly shows
+		// IsRemoved(), a tombstoned store sitting in GetStores() for up to 30
+		// days doesn't cost a scan on every tick.
+		if !s.IsRemoved() {
+			if store := cluster.GetStore(storeID); store == nil || store.IsRemoved() {
+				DeleteStoreMetrics(storeLabel)
+			}
 		}
 	}
 }

--- a/pkg/schedule/filter/counter.go
+++ b/pkg/schedule/filter/counter.go
@@ -160,18 +160,22 @@ func (c *Counter) Flush(storeInformer core.StoreSetInformer) {
 						continue
 					}
 					count[targetID] = 0
-					// A tombstoned endpoint is rejected here on every scheduling cycle for
-					// as long as it stays known, so counting it would either leak (nothing
-					// ever calls Flush again to zero it) or fight with tombstone cleanup
-					// deleting the series between Flush calls. sourceID/targetID may be the
-					// zero placeholder for "no counterpart", which never matches a real
-					// store, so the lookup harmlessly misses.
+					// A tombstoned or already fully-removed endpoint is rejected here on
+					// every scheduling cycle for as long as it stays known, so counting it
+					// would either leak (nothing ever calls Flush again to zero it) or
+					// fight with tombstone cleanup deleting the series between Flush calls.
+					// sourceID/targetID may be the zero placeholder for "no counterpart",
+					// which is never a real store id and must not be looked up.
 					if storeInformer != nil {
-						if s := storeInformer.GetStore(sourceID); s != nil && s.IsRemoved() {
-							continue
+						if sourceID != 0 {
+							if s := storeInformer.GetStore(sourceID); s == nil || s.IsRemoved() {
+								continue
+							}
 						}
-						if s := storeInformer.GetStore(targetID); s != nil && s.IsRemoved() {
-							continue
+						if targetID != 0 {
+							if s := storeInformer.GetStore(targetID); s == nil || s.IsRemoved() {
+								continue
+							}
 						}
 					}
 					sourceIDStr := strconv.FormatUint(sourceID, 10)

--- a/pkg/schedule/filter/counter.go
+++ b/pkg/schedule/filter/counter.go
@@ -16,6 +16,8 @@ package filter
 
 import (
 	"strconv"
+
+	"github.com/tikv/pd/pkg/core"
 )
 
 type action int
@@ -141,21 +143,41 @@ func (c *Counter) inc(action action, filterType filterType, sourceID uint64, tar
 	c.counter[action][filterType][sourceID][targetID]++
 }
 
-// Flush flushes the counter to the metrics.
-func (c *Counter) Flush() {
+// Flush flushes the counter to the metrics. storeInformer is used to drop
+// counts for a store that was tombstoned after being counted but before this
+// flush: inc() only sees the store's state at selection time, so without this
+// re-check a store buried in between would have its just-deleted series
+// recreated here. It may be nil (e.g. in tests), in which case no re-check is
+// performed.
+func (c *Counter) Flush(storeInformer core.StoreSetInformer) {
 	for i, actions := range c.counter {
 		actionName := action(i).String()
 		for j, counters := range actions {
 			filterName := filterType(j).String()
 			for sourceID, count := range counters {
-				sourceIDStr := strconv.FormatUint(sourceID, 10)
 				for targetID, value := range count {
-					targetIDStr := strconv.FormatUint(targetID, 10)
-					if value > 0 {
-						filterCounter.WithLabelValues(actionName, c.scope, filterName, sourceIDStr, targetIDStr).
-							Add(float64(value))
-						counters[sourceID][targetID] = 0
+					if value <= 0 {
+						continue
 					}
+					count[targetID] = 0
+					// A tombstoned endpoint is rejected here on every scheduling cycle for
+					// as long as it stays known, so counting it would either leak (nothing
+					// ever calls Flush again to zero it) or fight with tombstone cleanup
+					// deleting the series between Flush calls. sourceID/targetID may be the
+					// zero placeholder for "no counterpart", which never matches a real
+					// store, so the lookup harmlessly misses.
+					if storeInformer != nil {
+						if s := storeInformer.GetStore(sourceID); s != nil && s.IsRemoved() {
+							continue
+						}
+						if s := storeInformer.GetStore(targetID); s != nil && s.IsRemoved() {
+							continue
+						}
+					}
+					sourceIDStr := strconv.FormatUint(sourceID, 10)
+					targetIDStr := strconv.FormatUint(targetID, 10)
+					filterCounter.WithLabelValues(actionName, c.scope, filterName, sourceIDStr, targetIDStr).
+						Add(float64(value))
 				}
 			}
 		}

--- a/pkg/schedule/filter/counter_test.go
+++ b/pkg/schedule/filter/counter_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/tikv/pd/pkg/schedule/types"
 )
 
@@ -45,7 +46,7 @@ func TestCounter(t *testing.T) {
 	counter.inc(target, storeStateTombstone, 1, 2)
 	re.Equal(1, counter.counter[source][storeStateTombstone][1][2])
 	re.Equal(1, counter.counter[target][storeStateTombstone][1][2])
-	counter.Flush()
+	counter.Flush(nil)
 	re.Zero(counter.counter[source][storeStateTombstone][1][2])
 	re.Zero(counter.counter[target][storeStateTombstone][1][2])
 }

--- a/pkg/schedule/filter/filters.go
+++ b/pkg/schedule/filter/filters.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/log"
+	"go.uber.org/zap"
+
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/core/constant"
 	"github.com/tikv/pd/pkg/core/storelimit"
@@ -27,7 +29,6 @@ import (
 	"github.com/tikv/pd/pkg/schedule/plan"
 	"github.com/tikv/pd/pkg/slice"
 	"github.com/tikv/pd/pkg/utils/typeutil"
-	"go.uber.org/zap"
 )
 
 // SelectSourceStores selects stores that be selected as source store from the list.
@@ -37,12 +38,19 @@ func SelectSourceStores(stores []*core.StoreInfo, filters []Filter, conf config.
 		return slice.AllOf(filters, func(i int) bool {
 			status := filters[i].Source(conf, s)
 			if !status.IsOK() {
-				if counter != nil {
-					counter.inc(source, filters[i].Type(), s.GetID(), 0)
-				} else {
-					sourceID := strconv.FormatUint(s.GetID(), 10)
-					// TODO: pre-allocate gauge metrics
-					filterCounter.WithLabelValues(source.String(), filters[i].Scope(), filters[i].Type().String(), sourceID, "").Inc()
+				// A tombstoned store is rejected here on every scheduling cycle for as
+				// long as it stays known, so counting it would either leak (nothing
+				// ever calls Counter.Flush again to zero it) or fight with tombstone
+				// cleanup deleting the series between Flush calls. It's not an
+				// actionable rejection reason for an operator either way.
+				if !s.IsRemoved() {
+					if counter != nil {
+						counter.inc(source, filters[i].Type(), s.GetID(), 0)
+					} else {
+						sourceID := strconv.FormatUint(s.GetID(), 10)
+						// TODO: pre-allocate gauge metrics
+						filterCounter.WithLabelValues(source.String(), filters[i].Scope(), filters[i].Type().String(), sourceID, "").Inc()
+					}
 				}
 				if collector != nil {
 					collector.Collect(plan.SetResource(s), plan.SetStatus(status))
@@ -62,16 +70,18 @@ func SelectUnavailableTargetStores(stores []*core.StoreInfo, filters []Filter, c
 		return slice.AnyOf(filters, func(i int) bool {
 			status := filters[i].Target(conf, s)
 			if !status.IsOK() {
-				cfilter, ok := filters[i].(comparingFilter)
-				sourceID := uint64(0)
-				if ok {
-					sourceID = cfilter.getSourceStoreID()
-				}
-				if counter != nil {
-					counter.inc(target, filters[i].Type(), sourceID, s.GetID())
-				} else {
-					filterCounter.WithLabelValues(target.String(), filters[i].Scope(), filters[i].Type().String(),
-						strconv.FormatUint(sourceID, 10), targetID).Inc()
+				if !s.IsRemoved() {
+					cfilter, ok := filters[i].(comparingFilter)
+					sourceID := uint64(0)
+					if ok {
+						sourceID = cfilter.getSourceStoreID()
+					}
+					if counter != nil {
+						counter.inc(target, filters[i].Type(), sourceID, s.GetID())
+					} else {
+						filterCounter.WithLabelValues(target.String(), filters[i].Scope(), filters[i].Type().String(),
+							strconv.FormatUint(sourceID, 10), targetID).Inc()
+					}
 				}
 
 				if collector != nil {
@@ -96,17 +106,19 @@ func SelectTargetStores(stores []*core.StoreInfo, filters []Filter, conf config.
 			filter := filters[i]
 			status := filter.Target(conf, s)
 			if !status.IsOK() {
-				cfilter, ok := filter.(comparingFilter)
-				sourceID := uint64(0)
-				if ok {
-					sourceID = cfilter.getSourceStoreID()
-				}
-				if counter != nil {
-					counter.inc(target, filter.Type(), sourceID, s.GetID())
-				} else {
-					targetIDStr := strconv.FormatUint(s.GetID(), 10)
-					sourceIDStr := strconv.FormatUint(sourceID, 10)
-					filterCounter.WithLabelValues(target.String(), filter.Scope(), filter.Type().String(), sourceIDStr, targetIDStr).Inc()
+				if !s.IsRemoved() {
+					cfilter, ok := filter.(comparingFilter)
+					sourceID := uint64(0)
+					if ok {
+						sourceID = cfilter.getSourceStoreID()
+					}
+					if counter != nil {
+						counter.inc(target, filter.Type(), sourceID, s.GetID())
+					} else {
+						targetIDStr := strconv.FormatUint(s.GetID(), 10)
+						sourceIDStr := strconv.FormatUint(sourceID, 10)
+						filterCounter.WithLabelValues(target.String(), filter.Scope(), filter.Type().String(), sourceIDStr, targetIDStr).Inc()
+					}
 				}
 				if collector != nil {
 					collector.Collect(plan.SetResource(s), plan.SetStatus(status))
@@ -151,7 +163,11 @@ func Target(conf config.SharedConfigProvider, store *core.StoreInfo, filters []F
 	for _, filter := range filters {
 		status := filter.Target(conf, store)
 		if !status.IsOK() {
-			if status != statusStoreRemoved {
+			// Check the store itself rather than this filter's own status: an
+			// earlier filter in the chain (e.g. an exclusion filter) can reject
+			// a tombstoned store for a reason other than statusStoreRemoved,
+			// which would otherwise still recreate the deleted series.
+			if !store.IsRemoved() {
 				cfilter, ok := filter.(comparingFilter)
 				targetID := storeID
 				sourceID := ""

--- a/pkg/schedule/filter/metrics.go
+++ b/pkg/schedule/filter/metrics.go
@@ -29,3 +29,14 @@ var (
 func init() {
 	prometheus.MustRegister(filterCounter)
 }
+
+// DeleteStoreMetrics deletes the filter metrics of a store.
+func DeleteStoreMetrics(storeID string) {
+	filterCounter.DeletePartialMatch(prometheus.Labels{"source": storeID})
+	filterCounter.DeletePartialMatch(prometheus.Labels{"target": storeID})
+}
+
+// ResetFilterMetrics resets the filter metrics.
+func ResetFilterMetrics() {
+	filterCounter.Reset()
+}

--- a/pkg/schedule/hbstream/heartbeat_streams.go
+++ b/pkg/schedule/hbstream/heartbeat_streams.go
@@ -25,12 +25,13 @@ import (
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/kvproto/pkg/schedulingpb"
 	"github.com/pingcap/log"
+	"go.uber.org/zap"
+
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/errs"
 	"github.com/tikv/pd/pkg/mcs/utils/constant"
 	"github.com/tikv/pd/pkg/utils/keypath"
 	"github.com/tikv/pd/pkg/utils/logutil"
-	"go.uber.org/zap"
 )
 
 // Operation is detailed scheduling step of a region.
@@ -136,9 +137,23 @@ func (s *HeartbeatStreams) run() {
 				delete(s.streams, storeID)
 				continue
 			}
+			if store.IsRemoved() {
+				delete(s.streams, storeID)
+				continue
+			}
 			storeAddress := store.GetAddress()
 			if stream, ok := s.streams[storeID]; ok {
-				if err := stream.Send(msg); err != nil {
+				err := stream.Send(msg)
+				// Send can block; re-fetch the store so bury/removal that
+				// happened while it was blocked doesn't recreate a series
+				// DeleteStoreMetrics already deleted for this store.
+				if store = s.storeInformer.GetStore(storeID); store == nil || store.IsRemoved() {
+					if err != nil {
+						delete(s.streams, storeID)
+					}
+					continue
+				}
+				if err != nil {
 					log.Warn("send heartbeat message fail",
 						zap.Uint64("region-id", msg.GetRegionId()), errs.ZapError(errs.ErrGRPCSend, err))
 					delete(s.streams, storeID)
@@ -160,9 +175,21 @@ func (s *HeartbeatStreams) run() {
 					delete(s.streams, storeID)
 					continue
 				}
+				if store.IsRemoved() {
+					delete(s.streams, storeID)
+					continue
+				}
 				storeAddress := store.GetAddress()
 				storeLabel := strconv.FormatUint(storeID, 10)
-				if err := stream.Send(keepAlive); err != nil {
+				err := stream.Send(keepAlive)
+				// Same re-fetch as the msg case above: Send can block across a bury.
+				if store = s.storeInformer.GetStore(storeID); store == nil || store.IsRemoved() {
+					if err != nil {
+						delete(s.streams, storeID)
+					}
+					continue
+				}
+				if err != nil {
 					log.Warn("send keepalive message fail, store maybe disconnected",
 						zap.Uint64("target-store-id", storeID),
 						errs.ZapError(err))

--- a/pkg/schedule/hbstream/metric.go
+++ b/pkg/schedule/hbstream/metric.go
@@ -30,3 +30,13 @@ var (
 func init() {
 	prometheus.MustRegister(heartbeatStreamCounter)
 }
+
+// DeleteStoreMetrics deletes the heartbeat stream metrics of a store.
+func DeleteStoreMetrics(storeID string) {
+	heartbeatStreamCounter.DeletePartialMatch(prometheus.Labels{"store": storeID})
+}
+
+// ResetHeartbeatStreamMetrics resets the heartbeat stream metrics.
+func ResetHeartbeatStreamMetrics() {
+	heartbeatStreamCounter.Reset()
+}

--- a/pkg/schedule/metrics.go
+++ b/pkg/schedule/metrics.go
@@ -29,3 +29,8 @@ var (
 func init() {
 	prometheus.MustRegister(hotSpotStatusGauge)
 }
+
+// DeleteStoreMetrics deletes the hotspot status metrics of a store.
+func DeleteStoreMetrics(storeID string) {
+	hotSpotStatusGauge.DeletePartialMatch(prometheus.Labels{"store": storeID})
+}

--- a/pkg/schedule/operator/metrics.go
+++ b/pkg/schedule/operator/metrics.go
@@ -16,6 +16,7 @@ package operator
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/tikv/pd/pkg/schedule/types"
 )
 
@@ -95,4 +96,14 @@ func init() {
 // IncOperatorLimitCounter increases the counter of operator meeting limit.
 func IncOperatorLimitCounter(typ types.CheckerSchedulerType, kind OpKind) {
 	operatorLimitCounter.WithLabelValues(typ.String(), kind.String()).Inc()
+}
+
+// DeleteStoreMetrics deletes the per-store operator metrics of a store.
+func DeleteStoreMetrics(storeID string) {
+	storeLimitCostCounter.DeletePartialMatch(prometheus.Labels{"store": storeID})
+}
+
+// ResetOperatorMetrics resets the operator metrics.
+func ResetOperatorMetrics() {
+	storeLimitCostCounter.Reset()
 }

--- a/pkg/schedule/operator/metrics_test.go
+++ b/pkg/schedule/operator/metrics_test.go
@@ -1,0 +1,44 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operator
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteStoreMetricsClearsStoreLimitCostCounter(t *testing.T) {
+	re := require.New(t)
+	defer storeLimitCostCounter.Reset()
+
+	storeLimitCostCounter.WithLabelValues("1", "add-peer").Add(1)
+	DeleteStoreMetrics("1")
+	// DeletePartialMatch returns how many series it found and removed, so a
+	// zero return here proves DeleteStoreMetrics already deleted it -- unlike
+	// checking WithLabelValues' value, which would recreate a fresh
+	// (zero-valued) series regardless of whether the old one was cleaned up.
+	re.Zero(storeLimitCostCounter.DeletePartialMatch(prometheus.Labels{"store": "1"}))
+}
+
+func TestResetOperatorMetricsClearsStoreLimitCostCounter(t *testing.T) {
+	re := require.New(t)
+	defer storeLimitCostCounter.Reset()
+
+	storeLimitCostCounter.WithLabelValues("1", "add-peer").Add(1)
+	ResetOperatorMetrics()
+	re.Zero(storeLimitCostCounter.DeletePartialMatch(prometheus.Labels{"store": "1"}))
+}

--- a/pkg/schedule/scatter/metrics.go
+++ b/pkg/schedule/scatter/metrics.go
@@ -38,3 +38,8 @@ func init() {
 	prometheus.MustRegister(scatterCounter)
 	prometheus.MustRegister(scatterDistributionCounter)
 }
+
+// DeleteStoreMetrics deletes the scatter distribution metrics of a store.
+func DeleteStoreMetrics(storeID string) {
+	scatterDistributionCounter.DeletePartialMatch(prometheus.Labels{"store": storeID})
+}

--- a/pkg/schedule/scatter/region_scatterer.go
+++ b/pkg/schedule/scatter/region_scatterer.go
@@ -26,6 +26,8 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/log"
+	"go.uber.org/zap"
+
 	"github.com/tikv/pd/pkg/cache"
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/core/constant"
@@ -36,7 +38,6 @@ import (
 	"github.com/tikv/pd/pkg/schedule/placement"
 	"github.com/tikv/pd/pkg/utils/syncutil"
 	"github.com/tikv/pd/pkg/utils/typeutil"
-	"go.uber.org/zap"
 )
 
 const regionScatterName = "region-scatter"
@@ -524,23 +525,33 @@ func (r *RegionScatterer) Put(peers map[uint64]*metapb.Peer, leaderStoreID uint6
 		}
 		if engineFilter.Target(r.cluster.GetSharedConfig(), store).IsOK() {
 			r.ordinaryEngine.selectedPeer.Put(storeID, group)
-			scatterDistributionCounter.WithLabelValues(
-				fmt.Sprintf("%v", storeID),
-				fmt.Sprintf("%v", false),
-				core.EngineTiKV).Inc()
+			// A force-buried store can still show up in a region's existing
+			// placement; skip the metric so DeleteStoreMetrics' one-shot
+			// cleanup at bury time isn't undone by a later scatter that keeps
+			// or falls back to that placement.
+			if !store.IsRemoved() {
+				scatterDistributionCounter.WithLabelValues(
+					fmt.Sprintf("%v", storeID),
+					fmt.Sprintf("%v", false),
+					core.EngineTiKV).Inc()
+			}
 		} else {
 			engine := store.GetLabelValue(core.EngineKey)
 			ctx, _ := r.specialEngines.Load(engine)
 			ctx.(engineContext).selectedPeer.Put(storeID, group)
-			scatterDistributionCounter.WithLabelValues(
-				fmt.Sprintf("%v", storeID),
-				fmt.Sprintf("%v", false),
-				engine).Inc()
+			if !store.IsRemoved() {
+				scatterDistributionCounter.WithLabelValues(
+					fmt.Sprintf("%v", storeID),
+					fmt.Sprintf("%v", false),
+					engine).Inc()
+			}
 		}
 	}
 	r.ordinaryEngine.selectedLeader.Put(leaderStoreID, group)
-	scatterDistributionCounter.WithLabelValues(
-		fmt.Sprintf("%v", leaderStoreID),
-		fmt.Sprintf("%v", true),
-		core.EngineTiKV).Inc()
+	if leaderStore := r.cluster.GetStore(leaderStoreID); leaderStore != nil && !leaderStore.IsRemoved() {
+		scatterDistributionCounter.WithLabelValues(
+			fmt.Sprintf("%v", leaderStoreID),
+			fmt.Sprintf("%v", true),
+			core.EngineTiKV).Inc()
+	}
 }

--- a/pkg/schedule/schedulers/balance_leader.go
+++ b/pkg/schedule/schedulers/balance_leader.go
@@ -24,6 +24,9 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/pingcap/log"
+	"github.com/unrolled/render"
+	"go.uber.org/zap"
+
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/core/constant"
 	"github.com/tikv/pd/pkg/errs"
@@ -34,8 +37,6 @@ import (
 	"github.com/tikv/pd/pkg/schedule/types"
 	"github.com/tikv/pd/pkg/utils/reflectutil"
 	"github.com/tikv/pd/pkg/utils/typeutil"
-	"github.com/unrolled/render"
-	"go.uber.org/zap"
 )
 
 const (
@@ -327,7 +328,7 @@ func (s *balanceLeaderScheduler) Schedule(cluster sche.SchedulerCluster, dryRun 
 	if dryRun {
 		collector = plan.NewCollector(basePlan)
 	}
-	defer s.filterCounter.Flush()
+	defer s.filterCounter.Flush(cluster)
 	batch := s.conf.getBatch()
 	balanceLeaderScheduleCounter.Inc()
 

--- a/pkg/schedule/schedulers/balance_region.go
+++ b/pkg/schedule/schedulers/balance_region.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/log"
+	"go.uber.org/zap"
+
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/core/constant"
 	sche "github.com/tikv/pd/pkg/schedule/core"
@@ -27,7 +29,6 @@ import (
 	"github.com/tikv/pd/pkg/schedule/operator"
 	"github.com/tikv/pd/pkg/schedule/plan"
 	"github.com/tikv/pd/pkg/schedule/types"
-	"go.uber.org/zap"
 )
 
 type balanceRegionSchedulerConfig struct {
@@ -93,7 +94,7 @@ func (s *balanceRegionScheduler) IsScheduleAllowed(cluster sche.SchedulerCluster
 // Schedule implements the Scheduler interface.
 func (s *balanceRegionScheduler) Schedule(cluster sche.SchedulerCluster, dryRun bool) ([]*operator.Operator, []plan.Plan) {
 	basePlan := plan.NewBalanceSchedulerPlan()
-	defer s.filterCounter.Flush()
+	defer s.filterCounter.Flush(cluster)
 	var collector *plan.Collector
 	if dryRun {
 		collector = plan.NewCollector(basePlan)

--- a/pkg/schedule/schedulers/hot_region.go
+++ b/pkg/schedule/schedulers/hot_region.go
@@ -27,6 +27,8 @@ import (
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/log"
 	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap"
+
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/core/constant"
 	"github.com/tikv/pd/pkg/errs"
@@ -41,7 +43,6 @@ import (
 	"github.com/tikv/pd/pkg/statistics/utils"
 	"github.com/tikv/pd/pkg/utils/keyutil"
 	"github.com/tikv/pd/pkg/utils/syncutil"
-	"go.uber.org/zap"
 )
 
 const (
@@ -111,7 +112,7 @@ func newBaseHotScheduler(
 // each store, only update read or write load detail
 func (s *baseHotScheduler) prepareForBalance(typ resourceType, cluster sche.SchedulerCluster) {
 	storeInfos := statistics.SummaryStoreInfos(cluster.GetStores())
-	s.summaryPendingInfluence(storeInfos)
+	s.summaryPendingInfluence(cluster, storeInfos)
 	storesLoads := cluster.GetStoresLoads()
 	isTraceRegionFlow := cluster.GetSchedulerConfig().IsTraceRegionFlow()
 
@@ -156,7 +157,7 @@ func (s *baseHotScheduler) updateHistoryLoadConfig(sampleDuration, sampleInterva
 // summaryPendingInfluence calculate the summary of pending Influence for each store
 // and clean the region from regionInfluence if they have ended operator.
 // It makes each dim rate or count become `weight` times to the origin value.
-func (s *baseHotScheduler) summaryPendingInfluence(storeInfos map[uint64]*statistics.StoreSummaryInfo) {
+func (s *baseHotScheduler) summaryPendingInfluence(cluster sche.SchedulerCluster, storeInfos map[uint64]*statistics.StoreSummaryInfo) {
 	for id, p := range s.regionPendings {
 		for _, from := range p.froms {
 			from := storeInfos[from]
@@ -179,6 +180,14 @@ func (s *baseHotScheduler) summaryPendingInfluence(storeInfos map[uint64]*statis
 	}
 	// for metrics
 	for storeID, info := range storeInfos {
+		// storeInfos is built from a snapshot taken at the top of
+		// prepareForBalance, so info.IsRemoved() can be stale by the time
+		// this loop runs; re-check the store fresh through cluster instead,
+		// otherwise a store buried after the snapshot was taken but before
+		// this write can still recreate HotPendingSum for it.
+		if store := cluster.GetStore(storeID); store == nil || store.IsRemoved() {
+			continue
+		}
 		storeLabel := strconv.FormatUint(storeID, 10)
 		if infl := info.PendingSum; infl != nil && len(infl.Loads) != 0 {
 			utils.ForeachRegionStats(func(rwTy utils.RWType, dim int, kind utils.RegionStatKind) {

--- a/pkg/schedule/schedulers/hot_region.go
+++ b/pkg/schedule/schedulers/hot_region.go
@@ -193,6 +193,14 @@ func (s *baseHotScheduler) summaryPendingInfluence(cluster sche.SchedulerCluster
 			utils.ForeachRegionStats(func(rwTy utils.RWType, dim int, kind utils.RegionStatKind) {
 				HotPendingSum.WithLabelValues(storeLabel, rwTy.String(), utils.DimToString(dim)).Set(infl.Loads[kind])
 			})
+			// The check above and this write are not atomic with DeleteStoreMetrics,
+			// so a bury landing in between can still let this write recreate the
+			// series after cleanup ran. Re-check right after writing to narrow that
+			// window; a store buried later still leaves a bounded residual until the
+			// next tick, which is an accepted, documented limitation.
+			if store := cluster.GetStore(storeID); store == nil || store.IsRemoved() {
+				HotPendingSum.DeletePartialMatch(prometheus.Labels{"store": storeLabel})
+			}
 		}
 	}
 }

--- a/pkg/schedule/schedulers/hot_region_test.go
+++ b/pkg/schedule/schedulers/hot_region_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/docker/go-units"
+	"github.com/prometheus/client_golang/prometheus"
 	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 
 	"github.com/pingcap/kvproto/pkg/metapb"
@@ -30,6 +31,7 @@ import (
 
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/mock/mockcluster"
+	sche "github.com/tikv/pd/pkg/schedule/core"
 	"github.com/tikv/pd/pkg/schedule/operator"
 	"github.com/tikv/pd/pkg/schedule/placement"
 	"github.com/tikv/pd/pkg/schedule/types"
@@ -3020,6 +3022,62 @@ func TestSummaryPendingInfluenceSkipsRemovedStoreMetric(t *testing.T) {
 	hb.summaryPendingInfluence(tc, storeInfos)
 
 	re.Equal(float64(42), promtestutil.ToFloat64(metric))
+}
+
+// buryAfterGetStoreCluster wraps a sche.SchedulerCluster and buries the
+// target store as a side effect of the first GetStore(target) call, but
+// still returns the pre-bury snapshot from that same call -- modeling a
+// GetStore that raced a concurrent bury completing between its read and its
+// caller using the result.
+type buryAfterGetStoreCluster struct {
+	sche.SchedulerCluster
+	tc     *mockcluster.Cluster
+	target uint64
+	buried bool
+}
+
+func (c *buryAfterGetStoreCluster) GetStore(id uint64) *core.StoreInfo {
+	store := c.SchedulerCluster.GetStore(id)
+	if id == c.target && !c.buried {
+		c.buried = true
+		c.tc.PutStore(store.Clone(core.SetStoreState(metapb.StoreState_Tombstone)))
+	}
+	return store
+}
+
+func TestSummaryPendingInfluenceCannotRepublishAfterBury(t *testing.T) {
+	re := require.New(t)
+	defer HotPendingSum.Reset()
+
+	cancel, _, tc, _ := prepareSchedulersTest()
+	defer cancel()
+	hb := newBaseHotScheduler(nil, 0, 0, initHotRegionScheduleConfig())
+	storeID := uint64(1)
+	tc.PutStore(core.NewStoreInfo(&metapb.Store{
+		Id:        storeID,
+		NodeState: metapb.NodeState_Serving,
+	}))
+
+	loads := make([]float64, utils.RegionStatCount)
+	loads[utils.RegionWriteBytes] = 1
+	storeInfos := map[uint64]*statistics.StoreSummaryInfo{
+		storeID: {
+			StoreInfo:  tc.GetStore(storeID),
+			PendingSum: &statistics.Influence{Loads: loads},
+		},
+	}
+
+	// Simulate DeleteStoreMetrics having already run for this store, then a
+	// bury landing exactly between summaryPendingInfluence's pre-write check
+	// and the write completing.
+	racingCluster := &buryAfterGetStoreCluster{SchedulerCluster: tc, tc: tc, target: storeID}
+	hb.summaryPendingInfluence(racingCluster, storeInfos)
+
+	// The write must have happened for this to be a meaningful check: assert
+	// via DeletePartialMatch's return value (a series count), rather than
+	// reading the already-obtained Gauge handle, since a deleted series still
+	// reports its last-set value through that handle.
+	re.Equal(0, HotPendingSum.DeletePartialMatch(prometheus.Labels{"store": "1"}))
 }
 
 func TestBucketFirstStat(t *testing.T) {

--- a/pkg/schedule/schedulers/hot_region_test.go
+++ b/pkg/schedule/schedulers/hot_region_test.go
@@ -22,9 +22,12 @@ import (
 	"time"
 
 	"github.com/docker/go-units"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/stretchr/testify/require"
+
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/mock/mockcluster"
 	"github.com/tikv/pd/pkg/schedule/operator"
@@ -180,7 +183,7 @@ func checkGCPendingOpInfos(re *require.Assertions, enablePlacementRules bool) {
 	}
 
 	storeInfos := statistics.SummaryStoreInfos(tc.GetStores())
-	hb.summaryPendingInfluence(storeInfos) // Calling this function will GC.
+	hb.summaryPendingInfluence(tc, storeInfos) // Calling this function will GC.
 
 	for i := range opInfluenceCreators {
 		for j, typ := range typs {
@@ -2089,7 +2092,7 @@ func TestInfluenceByRWType(t *testing.T) {
 	re.NotNil(op)
 
 	storeInfos := statistics.SummaryStoreInfos(tc.GetStores())
-	hb.(*hotScheduler).summaryPendingInfluence(storeInfos)
+	hb.(*hotScheduler).summaryPendingInfluence(tc, storeInfos)
 	re.True(nearlyAbout(storeInfos[1].PendingSum.Loads[utils.RegionWriteKeys], -0.5*units.MiB))
 	re.True(nearlyAbout(storeInfos[1].PendingSum.Loads[utils.RegionWriteBytes], -0.5*units.MiB))
 	re.True(nearlyAbout(storeInfos[4].PendingSum.Loads[utils.RegionWriteKeys], 0.5*units.MiB))
@@ -2114,7 +2117,7 @@ func TestInfluenceByRWType(t *testing.T) {
 	re.NotNil(op)
 
 	storeInfos = statistics.SummaryStoreInfos(tc.GetStores())
-	hb.(*hotScheduler).summaryPendingInfluence(storeInfos)
+	hb.(*hotScheduler).summaryPendingInfluence(tc, storeInfos)
 	// assert read/write influence is the sum of write peer and write leader
 	re.True(nearlyAbout(storeInfos[1].PendingSum.Loads[utils.RegionWriteKeys], -1.2*units.MiB))
 	re.True(nearlyAbout(storeInfos[1].PendingSum.Loads[utils.RegionWriteBytes], -1.2*units.MiB))
@@ -2980,6 +2983,43 @@ func TestEncodeConfig(t *testing.T) {
 	data, err := sche.EncodeConfig()
 	re.NoError(err)
 	re.NotEqual("null", string(data))
+}
+
+func TestSummaryPendingInfluenceSkipsRemovedStoreMetric(t *testing.T) {
+	re := require.New(t)
+	defer HotPendingSum.Reset()
+
+	cancel, _, tc, _ := prepareSchedulersTest()
+	defer cancel()
+	hb := newBaseHotScheduler(nil, 0, 0, initHotRegionScheduleConfig())
+	storeID := uint64(1)
+	removed := core.NewStoreInfo(&metapb.Store{
+		Id:        storeID,
+		NodeState: metapb.NodeState_Removed,
+	})
+	tc.PutStore(removed)
+	// storeInfos holds a stale snapshot still showing the store as serving,
+	// simulating one taken before the store was buried -- this only passes
+	// if the check re-reads the store fresh through cluster instead of
+	// trusting info.IsRemoved() on the snapshot.
+	stale := core.NewStoreInfo(&metapb.Store{
+		Id:        storeID,
+		NodeState: metapb.NodeState_Serving,
+	})
+	loads := make([]float64, utils.RegionStatCount)
+	loads[utils.RegionWriteBytes] = 1
+	storeInfos := map[uint64]*statistics.StoreSummaryInfo{
+		storeID: {
+			StoreInfo:  stale,
+			PendingSum: &statistics.Influence{Loads: loads},
+		},
+	}
+
+	metric := HotPendingSum.WithLabelValues("1", utils.Write.String(), utils.DimToString(utils.ByteDim))
+	metric.Set(42)
+	hb.summaryPendingInfluence(tc, storeInfos)
+
+	re.Equal(float64(42), promtestutil.ToFloat64(metric))
 }
 
 func TestBucketFirstStat(t *testing.T) {

--- a/pkg/schedule/schedulers/metrics.go
+++ b/pkg/schedule/schedulers/metrics.go
@@ -16,6 +16,7 @@ package schedulers
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/tikv/pd/pkg/schedule/types"
 )
 
@@ -163,6 +164,18 @@ func init() {
 	prometheus.MustRegister(storeSlowTrendActionStatusGauge)
 	prometheus.MustRegister(storeSlowTrendMiscGauge)
 	prometheus.MustRegister(HotPendingSum)
+}
+
+// DeleteStoreMetrics deletes the per-store scheduler metrics of a store.
+func DeleteStoreMetrics(storeID string) {
+	opInfluenceStatus.DeletePartialMatch(prometheus.Labels{"store": storeID})
+	balanceWitnessCounter.DeleteLabelValues("move-witness", storeID+"-out")
+	balanceWitnessCounter.DeleteLabelValues("move-witness", storeID+"-in")
+	hotSchedulerResultCounter.DeletePartialMatch(prometheus.Labels{"store": storeID})
+	balanceDirectionCounter.DeletePartialMatch(prometheus.Labels{"store": storeID})
+	hotDirectionCounter.DeletePartialMatch(prometheus.Labels{"store": storeID})
+	storeSlowTrendEvictedStatusGauge.DeletePartialMatch(prometheus.Labels{"store": storeID})
+	HotPendingSum.DeletePartialMatch(prometheus.Labels{"store": storeID})
 }
 
 func balanceLeaderCounterWithEvent(event string) prometheus.Counter {

--- a/pkg/schedule/schedulers/metrics.go
+++ b/pkg/schedule/schedulers/metrics.go
@@ -172,8 +172,13 @@ func DeleteStoreMetrics(storeID string) {
 	balanceWitnessCounter.DeleteLabelValues("move-witness", storeID+"-out")
 	balanceWitnessCounter.DeleteLabelValues("move-witness", storeID+"-in")
 	hotSchedulerResultCounter.DeletePartialMatch(prometheus.Labels{"store": storeID})
-	balanceDirectionCounter.DeletePartialMatch(prometheus.Labels{"store": storeID})
+	// balanceDirectionCounter and hotPendingStatus key on source/target rather
+	// than a single store label, so a store can appear on either side.
+	balanceDirectionCounter.DeletePartialMatch(prometheus.Labels{"source": storeID})
+	balanceDirectionCounter.DeletePartialMatch(prometheus.Labels{"target": storeID})
 	hotDirectionCounter.DeletePartialMatch(prometheus.Labels{"store": storeID})
+	hotPendingStatus.DeletePartialMatch(prometheus.Labels{"source": storeID})
+	hotPendingStatus.DeletePartialMatch(prometheus.Labels{"target": storeID})
 	storeSlowTrendEvictedStatusGauge.DeletePartialMatch(prometheus.Labels{"store": storeID})
 	HotPendingSum.DeletePartialMatch(prometheus.Labels{"store": storeID})
 }

--- a/pkg/schedule/schedulers/scheduler_controller.go
+++ b/pkg/schedule/schedulers/scheduler_controller.go
@@ -142,6 +142,7 @@ func ResetSchedulerMetrics() {
 	balanceWitnessCounter.Reset()
 	balanceDirectionCounter.Reset()
 	hotDirectionCounter.Reset()
+	hotPendingStatus.Reset()
 	storeSlowTrendEvictedStatusGauge.Reset()
 }
 

--- a/pkg/schedule/schedulers/scheduler_controller.go
+++ b/pkg/schedule/schedulers/scheduler_controller.go
@@ -23,6 +23,8 @@ import (
 	"time"
 
 	"github.com/pingcap/log"
+	"go.uber.org/zap"
+
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/errs"
 	sche "github.com/tikv/pd/pkg/schedule/core"
@@ -33,7 +35,6 @@ import (
 	"github.com/tikv/pd/pkg/storage/endpoint"
 	"github.com/tikv/pd/pkg/utils/logutil"
 	"github.com/tikv/pd/pkg/utils/syncutil"
-	"go.uber.org/zap"
 )
 
 const maxScheduleRetries = 10
@@ -136,6 +137,12 @@ func (c *Controller) CollectSchedulerMetrics() {
 func ResetSchedulerMetrics() {
 	schedulerStatusGauge.Reset()
 	ruleStatusGauge.Reset()
+	opInfluenceStatus.Reset()
+	hotSchedulerResultCounter.Reset()
+	balanceWitnessCounter.Reset()
+	balanceDirectionCounter.Reset()
+	hotDirectionCounter.Reset()
+	storeSlowTrendEvictedStatusGauge.Reset()
 }
 
 // AddSchedulerHandler adds the HTTP handler for a scheduler.

--- a/pkg/statistics/hot_cache.go
+++ b/pkg/statistics/hot_cache.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/smallnest/chanx"
+
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/statistics/utils"
 	"github.com/tikv/pd/pkg/utils/logutil"
@@ -157,9 +158,16 @@ func (w *HotCache) GetHotPeerStat(kind utils.RWType, regionID, storeID uint64) *
 func (w *HotCache) CollectMetrics() {
 	w.CheckWriteAsync(func(cache *HotPeerCache) {
 		cache.collectMetrics()
+		// gc() is otherwise only triggered from UpdateStat, so a store removed while
+		// the cluster is idle (or was the only store still receiving updates) would
+		// never have its hotCacheStatusGauge series cleaned up. Piggyback on this
+		// periodic, activity-independent tick instead; gc() already self-throttles
+		// via topNTTL, so calling it every tick is cheap.
+		cache.gc()
 	})
 	w.CheckReadAsync(func(cache *HotPeerCache) {
 		cache.collectMetrics()
+		cache.gc()
 	})
 }
 

--- a/pkg/statistics/hot_peer_cache.go
+++ b/pkg/statistics/hot_peer_cache.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/smallnest/chanx"
+
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/slice"
 	"github.com/tikv/pd/pkg/statistics/utils"
@@ -190,6 +191,15 @@ func (f *HotPeerCache) CheckPeerFlow(region *core.RegionInfo, peers []*metapb.Pe
 	stats := make([]*HotPeerStat, 0, len(peers))
 	for _, peer := range peers {
 		storeID := peer.GetStoreId()
+		// A tombstoned store can still show up as a peer here: the leader reporting
+		// this region may not have caught up with a raft config change removing it
+		// yet. Skip it so gc() cleaning up its entries at bury time doesn't get
+		// undone by the very next heartbeat from this region's (live) leader. A
+		// store the cluster doesn't know about yet is a different case (e.g. a
+		// target store for an in-flight add-peer) and isn't skipped here.
+		if store := f.cluster.GetStore(storeID); store != nil && store.IsRemoved() {
+			continue
+		}
 		oldItem := f.getOldHotPeerStat(regionID, storeID)
 
 		// check whether the peer is allowed to be inherited
@@ -556,18 +566,37 @@ func (f *HotPeerCache) gc() {
 		return
 	}
 	f.lastGCTime = time.Now()
-	// remove tombstone stores
+	// remove tombstone stores. GetStores() still returns a tombstoned store
+	// until it's fully removed, so treat IsRemoved() the same as absent here
+	// -- nothing writes region heartbeats for it anymore, so there's no
+	// reason to wait for full removal before cleaning it up.
 	stores := make(map[uint64]struct{})
-	for _, storeID := range f.cluster.GetStores() {
-		stores[storeID.GetID()] = struct{}{}
+	for _, store := range f.cluster.GetStores() {
+		if store.IsRemoved() {
+			continue
+		}
+		stores[store.GetID()] = struct{}{}
 	}
+	// calcHotThresholds can populate thresholdsOfStore for a store that never becomes
+	// hot enough to enter peersOfStore, so peersOfStore alone can miss it; check the
+	// union of both.
+	removed := make(map[uint64]struct{})
 	for storeID := range f.peersOfStore {
 		if _, ok := stores[storeID]; !ok {
-			delete(f.peersOfStore, storeID)
-			delete(f.regionsOfStore, storeID)
-			delete(f.thresholdsOfStore, storeID)
-			delete(f.metrics, storeID)
+			removed[storeID] = struct{}{}
 		}
+	}
+	for storeID := range f.thresholdsOfStore {
+		if _, ok := stores[storeID]; !ok {
+			removed[storeID] = struct{}{}
+		}
+	}
+	for storeID := range removed {
+		delete(f.peersOfStore, storeID)
+		delete(f.regionsOfStore, storeID)
+		delete(f.thresholdsOfStore, storeID)
+		delete(f.metrics, storeID)
+		hotCacheStatusGauge.DeletePartialMatch(prometheus.Labels{"store": storeTag(storeID), "type": f.kind.String()})
 	}
 	// remove expired items
 	for _, peers := range f.peersOfStore {

--- a/pkg/statistics/hot_peer_cache_test.go
+++ b/pkg/statistics/hot_peer_cache_test.go
@@ -23,9 +23,13 @@ import (
 	"time"
 
 	"github.com/docker/go-units"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/stretchr/testify/require"
+
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/mock/mockid"
 	"github.com/tikv/pd/pkg/movingaverage"
@@ -726,15 +730,27 @@ func TestRemoveExpireItems(t *testing.T) {
 	re.NotEmpty(cache.storesOfRegion[region2.GetID()])
 	time.Sleep(cache.topNTTL)
 	// case2: remove items when the store is not exist
-	re.NotNil(cache.peersOfStore[region1.GetLeader().GetStoreId()])
-	re.NotNil(cache.peersOfStore[region2.GetLeader().GetStoreId()])
+	store1ID := region1.GetLeader().GetStoreId()
+	store2ID := region2.GetLeader().GetStoreId()
+	re.NotNil(cache.peersOfStore[store1ID])
+	re.NotNil(cache.peersOfStore[store2ID])
+	// the hotcache status gauge should be populated for the removed stores before gc.
+	re.NotZero(testutil.ToFloat64(hotCacheStatusGauge.WithLabelValues("add_item", storeTag(store1ID), cache.kind.String())))
+	re.NotZero(testutil.ToFloat64(hotCacheStatusGauge.WithLabelValues("add_item", storeTag(store2ID), cache.kind.String())))
 	cluster.ResetStores()
 	re.Empty(cluster.GetStores())
 	region3 := buildRegion(cluster, utils.Write, 3, 10)
 	checkAndUpdate(re, cache, region3)
-	re.Nil(cache.peersOfStore[region1.GetLeader().GetStoreId()])
-	re.Nil(cache.peersOfStore[region2.GetLeader().GetStoreId()])
+	re.Nil(cache.peersOfStore[store1ID])
+	re.Nil(cache.peersOfStore[store2ID])
 	re.NotEmpty(cache.regionsOfStore[region3.GetLeader().GetStoreId()])
+	// gc should also delete the hotcache status gauge series of the removed stores, not
+	// just the in-memory map entries. DeletePartialMatch returns how many series it
+	// found and removed, so a zero return proves nothing is left -- unlike checking
+	// WithLabelValues' value, which would recreate a fresh (zero-valued) series on
+	// every call regardless of whether gc() actually deleted the old one.
+	re.Zero(hotCacheStatusGauge.DeletePartialMatch(prometheus.Labels{"store": storeTag(store1ID), "type": cache.kind.String()}))
+	re.Zero(hotCacheStatusGauge.DeletePartialMatch(prometheus.Labels{"store": storeTag(store2ID), "type": cache.kind.String()}))
 }
 
 func TestDifferentReportInterval(t *testing.T) {

--- a/pkg/statistics/store_collection.go
+++ b/pkg/statistics/store_collection.go
@@ -151,6 +151,15 @@ func (s *storeStatistics) observe(store *core.StoreInfo) {
 
 // ObserveHotStat records the hot region metrics for the store.
 func ObserveHotStat(store *core.StoreInfo, stats *StoresStats) {
+	// A store's RollingStoreStats can be recreated after bury by a StoreHeartbeat
+	// that was already in flight (HandleStoreHeartbeat only rejects a fully
+	// unknown store, not a tombstoned one). Without this check, that would make
+	// this function keep republishing storeStatusGauge every collection tick for
+	// as long as the entry exists, up to 30 days until final removal, instead of
+	// stopping once the store is known tombstoned like observe() already does.
+	if store.IsRemoved() {
+		return
+	}
 	// Store flows.
 	storeAddress := store.GetAddress()
 	id := strconv.FormatUint(store.GetID(), 10)
@@ -272,6 +281,11 @@ func (s *storeStatistics) collect() {
 // previous address.
 func ResetStoreStatistics(id string) {
 	storeStatusGauge.DeletePartialMatch(prometheus.Labels{"store": id})
+	// placementStatusGauge's "name" label is an arbitrary, unbounded label-rule
+	// name (unlike clusterStatusGauge's small, fixed engine set below), so an
+	// exact DeleteLabelValues per combination isn't feasible here either --
+	// same tradeoff as storeStatusGauge above.
+	placementStatusGauge.DeletePartialMatch(prometheus.Labels{"store": id})
 	// mcs never cleaned StoreLimitGauge on its own: unlike the classic path's
 	// RemoveStoreLimit, the mcs scheduling service has no store-limit config
 	// of its own to persist a removal for. Deleting it here, alongside
@@ -309,6 +323,7 @@ func Reset() {
 	storeStatusGauge.Reset()
 	clusterStatusGauge.Reset()
 	placementStatusGauge.Reset()
+	StoreLimitGauge.Reset()
 	ResetRegionStatsMetrics()
 	ResetLabelStatsMetrics()
 	ResetHotCacheStatusMetrics()

--- a/pkg/statistics/store_collection.go
+++ b/pkg/statistics/store_collection.go
@@ -19,6 +19,8 @@ import (
 	"strconv"
 
 	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/core/constant"
 	"github.com/tikv/pd/pkg/core/storelimit"
@@ -264,35 +266,19 @@ func (s *storeStatistics) collect() {
 }
 
 // ResetStoreStatistics resets the metrics of store.
-func ResetStoreStatistics(storeAddress string, id string) {
-	metrics := []string{
-		"region_score",
-		"leader_score",
-		"region_size",
-		"region_count",
-		"leader_size",
-		"leader_count",
-		"witness_count",
-		"learner_count",
-		"store_available",
-		"store_used",
-		"store_capacity",
-		"store_write_rate_bytes",
-		"store_read_rate_bytes",
-		"store_write_rate_keys",
-		"store_read_rate_keys",
-		"store_write_query_rate",
-		"store_read_query_rate",
-		"store_regions_write_rate_bytes",
-		"store_regions_write_rate_keys",
-		"store_slow_trend_cause_value",
-		"store_slow_trend_cause_rate",
-		"store_slow_trend_result_value",
-		"store_slow_trend_result_rate",
-	}
-	for _, m := range metrics {
-		storeStatusGauge.DeleteLabelValues(storeAddress, id, m)
-	}
+// Matches on the store label alone, not address: PD allows an existing store ID to
+// change address (e.g. after a TiKV restart with a new IP), so requiring the current
+// address to match as well would permanently leak any series recorded under a
+// previous address.
+func ResetStoreStatistics(id string) {
+	storeStatusGauge.DeletePartialMatch(prometheus.Labels{"store": id})
+	// mcs never cleaned StoreLimitGauge on its own: unlike the classic path's
+	// RemoveStoreLimit, the mcs scheduling service has no store-limit config
+	// of its own to persist a removal for. Deleting it here, alongside
+	// everything else this function already covers, closes that gap for
+	// both classic (redundant with RemoveStoreLimit, harmless) and mcs.
+	StoreLimitGauge.DeleteLabelValues(id, "add-peer")
+	StoreLimitGauge.DeleteLabelValues(id, "remove-peer")
 }
 
 type storeStatisticsMap struct {

--- a/pkg/statistics/store_collection_test.go
+++ b/pkg/statistics/store_collection_test.go
@@ -20,9 +20,13 @@ import (
 	"time"
 
 	"github.com/docker/go-units"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/stretchr/testify/require"
+
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/core/constant"
 	"github.com/tikv/pd/pkg/mock/mockconfig"
@@ -93,6 +97,22 @@ func TestStoreStatistics(t *testing.T) {
 	re.Equal([]uint64{1, 3, 5, 7}, stats.LabelCounter["host:h1"])
 	re.Len(stats.LabelCounter["host:h2"], 4)
 	re.Len(stats.LabelCounter["zone:unknown"], 2)
+}
+
+func TestResetStoreStatisticsClearsPlacementStatusGauge(t *testing.T) {
+	re := require.New(t)
+	defer placementStatusGauge.Reset()
+
+	metric := placementStatusGauge.WithLabelValues("label-type", "label-name", "1")
+	metric.Set(1)
+	re.NotZero(testutil.ToFloat64(metric))
+
+	ResetStoreStatistics("1")
+	// DeletePartialMatch returns how many series it found and removed, so a
+	// zero return here proves ResetStoreStatistics already deleted it --
+	// unlike checking WithLabelValues' value, which would recreate a fresh
+	// (zero-valued) series regardless of whether the old one was cleaned up.
+	re.Zero(placementStatusGauge.DeletePartialMatch(prometheus.Labels{"store": "1"}))
 }
 
 func TestSummaryStoreInfos(t *testing.T) {

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -2475,6 +2475,18 @@ func (c *RaftCluster) SetExternalTS(timestamp uint64) error {
 
 // SetStoreLimit sets a store limit for a given type and rate.
 func (c *RaftCluster) SetStoreLimit(storeID uint64, typ storelimit.Type, ratePerMin float64) error {
+	// A tombstoned store's config entry is only ever cleared once, at bury time
+	// (RemoveStoreLimit); nothing sweeps it again afterward. Without this check,
+	// setting a limit for an already-tombstoned store re-adds it, and
+	// StoreLimitGauge stays republished for it until final removal.
+	//
+	// GetStore returning nil is deliberately NOT treated the same as removed
+	// here: callers legitimately set a store's limit before the store itself
+	// is registered (see testCluster.addRegionStore), so nil just means
+	// "not created yet," not "already gone."
+	if store := c.GetStore(storeID); store != nil && store.IsRemoved() {
+		return errs.ErrStoreRemoved.FastGenByArgs(storeID)
+	}
 	err := c.opt.UpdateScheduleConfig(c.storage, func(_ *sc.ScheduleConfig, cfg *sc.ScheduleConfig) (bool, error) {
 		slc, ok := cfg.StoreLimit[storeID]
 		if !ok {

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -2103,7 +2103,6 @@ func (c *RaftCluster) RemoveTombStoneRecords() error {
 					errs.ZapError(err))
 				return err
 			}
-			c.RemoveStoreLimit(store.GetID())
 			log.Info("delete store succeeded",
 				zap.Stringer("store", store.GetMeta()))
 		}
@@ -2136,6 +2135,12 @@ func (c *RaftCluster) deleteStore(store *core.StoreInfo) error {
 	// leaving a series this cleanup just deleted with no later event able to
 	// find and remove it again.
 	c.DeleteStore(store)
+	// The auto-GC path (checkStores' NodeState_Removed branch) only ever calls
+	// deleteStore, never RemoveTombStoneRecords, so the store-limit config entry
+	// needs to be cleared here rather than by the manual remove-tombstone caller
+	// alone -- otherwise a store reclaimed purely by the 30-day auto-GC timer
+	// never gets this cleanup at all.
+	c.RemoveStoreLimit(store.GetID())
 	storeIDStr := strconv.FormatUint(store.GetID(), 10)
 	statistics.ResetStoreStatistics(storeIDStr)
 	filter.DeleteStoreMetrics(storeIDStr)

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -2058,6 +2058,18 @@ func (c *RaftCluster) updateProgress(storeID uint64, storeAddress, action string
 	storesProgressGauge.WithLabelValues(storeAddress, storeLabel, action).Set(progress)
 	storesSpeedGauge.WithLabelValues(storeAddress, storeLabel, action).Set(currentSpeed)
 	storesETAGauge.WithLabelValues(storeAddress, storeLabel, action).Set(leftSeconds)
+	// The AddProgress/UpdateProgress calls above and this write are not atomic
+	// with BuryStore's resetProgress, so a bury landing in between can still
+	// let this write recreate the three gauges after resetProgress already
+	// cleaned them up -- and deleteStore never calls resetProgress again, so
+	// nothing else would remove them afterward. Re-check right after writing
+	// and delete the just-written series if the store turned out removed,
+	// narrowing that window.
+	if store := c.GetStore(storeID); store == nil || store.IsRemoved() {
+		storesProgressGauge.DeleteLabelValues(storeAddress, storeLabel, action)
+		storesSpeedGauge.DeleteLabelValues(storeAddress, storeLabel, action)
+		storesETAGauge.DeleteLabelValues(storeAddress, storeLabel, action)
+	}
 }
 
 func (c *RaftCluster) resetProgress(storeID uint64, storeAddress string) {

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/coreos/go-semver/semver"
@@ -34,6 +35,9 @@ import (
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/log"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.uber.org/zap"
+
 	"github.com/tikv/pd/pkg/cluster"
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/core/storelimit"
@@ -49,10 +53,14 @@ import (
 	"github.com/tikv/pd/pkg/progress"
 	"github.com/tikv/pd/pkg/ratelimit"
 	"github.com/tikv/pd/pkg/replication"
+	"github.com/tikv/pd/pkg/schedule"
 	sc "github.com/tikv/pd/pkg/schedule/config"
+	"github.com/tikv/pd/pkg/schedule/filter"
 	"github.com/tikv/pd/pkg/schedule/hbstream"
 	"github.com/tikv/pd/pkg/schedule/labeler"
 	"github.com/tikv/pd/pkg/schedule/placement"
+	"github.com/tikv/pd/pkg/schedule/scatter"
+	"github.com/tikv/pd/pkg/schedule/schedulers"
 	"github.com/tikv/pd/pkg/slice"
 	"github.com/tikv/pd/pkg/statistics"
 	"github.com/tikv/pd/pkg/statistics/utils"
@@ -68,8 +76,6 @@ import (
 	"github.com/tikv/pd/pkg/utils/typeutil"
 	"github.com/tikv/pd/pkg/versioninfo"
 	"github.com/tikv/pd/server/config"
-	clientv3 "go.etcd.io/etcd/client/v3"
-	"go.uber.org/zap"
 )
 
 var (
@@ -189,6 +195,19 @@ type RaftCluster struct {
 	miscRunner ratelimit.Runner
 	// logRunner is used to process the log asynchronously.
 	logRunner ratelimit.Runner
+
+	// onStoreBuried is an optional callback invoked (at least once) with a store's
+	// ID right after it's buried, for cleanup that only the owning package can do
+	// without an import cycle -- e.g. the server package's own heartbeat/bucket
+	// metrics, which server/cluster cannot import directly. Set via
+	// SetOnStoreBuried; read through an atomic pointer since BuryStoreLocked can run
+	// before the owner has had a chance to install it.
+	onStoreBuried atomic.Pointer[func(storeID string)]
+}
+
+// SetOnStoreBuried sets the callback invoked when a store is buried.
+func (c *RaftCluster) SetOnStoreBuried(fn func(storeID string)) {
+	c.onStoreBuried.Store(&fn)
 }
 
 // Status saves some state information.
@@ -1141,12 +1160,18 @@ func (c *RaftCluster) HandleStoreHeartbeat(heartbeat *pdpb.StoreHeartbeatRequest
 	return nil
 }
 
-// processReportBuckets update the bucket information.
-func (c *RaftCluster) processReportBuckets(buckets *metapb.Buckets) error {
+// processReportBuckets updates the bucket information. The first return value
+// reports whether the report was actually applied, so callers don't enqueue
+// hot-bucket work for a report that was ignored because its leader is
+// tombstoned.
+func (c *RaftCluster) processReportBuckets(buckets *metapb.Buckets) (bool, error) {
 	region := c.GetRegion(buckets.GetRegionId())
 	if region == nil {
 		regionCacheMissCounter.Inc()
-		return errors.Errorf("region %v not found", buckets.GetRegionId())
+		return false, errors.Errorf("region %v not found", buckets.GetRegionId())
+	}
+	if store := c.GetStore(region.GetLeader().GetStoreId()); store != nil && store.IsRemoved() {
+		return false, nil
 	}
 	// use CAS to update the bucket information.
 	// the two request(A:3,B:2) get the same region and need to update the buckets.
@@ -1157,17 +1182,17 @@ func (c *RaftCluster) processReportBuckets(buckets *metapb.Buckets) error {
 		// region should not update if the version of the buckets is less than the old one.
 		if old != nil && buckets.GetVersion() <= old.GetVersion() {
 			versionNotMatchCounter.Inc()
-			return nil
+			return false, nil
 		}
 		failpoint.Inject("concurrentBucketHeartbeat", func() {
 			time.Sleep(500 * time.Millisecond)
 		})
 		if ok := region.UpdateBuckets(buckets, old); ok {
-			return nil
+			return true, nil
 		}
 	}
 	updateFailedCounter.Inc()
-	return nil
+	return false, nil
 }
 
 var regionGuide = core.GenerateRegionGuideFunc(true)
@@ -1599,9 +1624,15 @@ func (c *RaftCluster) BuryStore(storeID uint64, forceBury bool) error {
 		addr := store.GetAddress()
 		c.resetProgress(storeID, addr)
 		storeIDStr := strconv.FormatUint(storeID, 10)
-		statistics.ResetStoreStatistics(addr, storeIDStr)
+		statistics.ResetStoreStatistics(storeIDStr)
+		filter.DeleteStoreMetrics(storeIDStr)
+		hbstream.DeleteStoreMetrics(storeIDStr)
+		schedule.DeleteStoreMetrics(storeIDStr)
 		if !c.IsServiceIndependent(constant.SchedulingServiceName) {
 			c.removeStoreStatistics(storeID)
+		}
+		if fn := c.onStoreBuried.Load(); fn != nil {
+			(*fn)(storeIDStr)
 		}
 	}
 	return err
@@ -2095,7 +2126,24 @@ func (c *RaftCluster) deleteStore(store *core.StoreInfo) error {
 			return err
 		}
 	}
+	// Remove the store before the metric cleanup below, not after: a metrics
+	// collection tick observing this store concurrently re-checks GetStore
+	// right after it writes and undoes its own write if the store is already
+	// gone. If DeleteStore ran last, that re-check could still see the
+	// (already fully cleaned) tombstone entry and skip its own cleanup,
+	// leaving a series this cleanup just deleted with no later event able to
+	// find and remove it again.
 	c.DeleteStore(store)
+	storeIDStr := strconv.FormatUint(store.GetID(), 10)
+	statistics.ResetStoreStatistics(storeIDStr)
+	filter.DeleteStoreMetrics(storeIDStr)
+	hbstream.DeleteStoreMetrics(storeIDStr)
+	schedule.DeleteStoreMetrics(storeIDStr)
+	schedulers.DeleteStoreMetrics(storeIDStr)
+	scatter.DeleteStoreMetrics(storeIDStr)
+	if fn := c.onStoreBuried.Load(); fn != nil {
+		(*fn)(storeIDStr)
+	}
 	return nil
 }
 

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -58,6 +58,7 @@ import (
 	"github.com/tikv/pd/pkg/schedule/filter"
 	"github.com/tikv/pd/pkg/schedule/hbstream"
 	"github.com/tikv/pd/pkg/schedule/labeler"
+	"github.com/tikv/pd/pkg/schedule/operator"
 	"github.com/tikv/pd/pkg/schedule/placement"
 	"github.com/tikv/pd/pkg/schedule/scatter"
 	"github.com/tikv/pd/pkg/schedule/schedulers"
@@ -1628,6 +1629,7 @@ func (c *RaftCluster) BuryStore(storeID uint64, forceBury bool) error {
 		filter.DeleteStoreMetrics(storeIDStr)
 		hbstream.DeleteStoreMetrics(storeIDStr)
 		schedule.DeleteStoreMetrics(storeIDStr)
+		operator.DeleteStoreMetrics(storeIDStr)
 		if !c.IsServiceIndependent(constant.SchedulingServiceName) {
 			c.removeStoreStatistics(storeID)
 		}
@@ -2141,6 +2143,7 @@ func (c *RaftCluster) deleteStore(store *core.StoreInfo) error {
 	schedule.DeleteStoreMetrics(storeIDStr)
 	schedulers.DeleteStoreMetrics(storeIDStr)
 	scatter.DeleteStoreMetrics(storeIDStr)
+	operator.DeleteStoreMetrics(storeIDStr)
 	if fn := c.onStoreBuried.Load(); fn != nil {
 		(*fn)(storeIDStr)
 	}

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/log"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/tikv/pd/pkg/cluster"
@@ -482,6 +483,48 @@ func TestUpStore(t *testing.T) {
 	// store 4 not exist
 	err = cluster.UpStore(10)
 	re.True(errors.ErrorEqual(err, errs.ErrStoreNotFound.FastGenByArgs(4)))
+}
+
+// TestAutoGCTombstoneStoreCleansUpStaleStoreLimit covers the auto-GC path
+// (checkStores' NodeState_Removed branch, via deleteStore) clearing a store
+// limit entry that survived bury. BuryStore already clears the store limit
+// at bury time, but an in-flight SetStoreLimit that read IsRemoved()==false
+// just before bury and wrote just after can race back in and re-add it;
+// deleteStore -- not just BuryStore -- has to clean it up too, since it is
+// also reached by the 30-day auto-GC timer with no manual
+// RemoveTombStoneRecords call involved.
+func TestAutoGCTombstoneStoreCleansUpStaleStoreLimit(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, opt, err := newTestScheduleConfig()
+	re.NoError(err)
+	cluster := newTestRaftCluster(ctx, mockid.NewIDAllocator(), opt, storage.NewStorageWithMemoryBackend())
+	cluster.coordinator = schedule.NewCoordinator(ctx, cluster, nil)
+
+	store := newTestStores(1, "5.0.0")[0]
+	re.NoError(cluster.PutMetaStore(store.GetMeta()))
+	// Back-date the heartbeat so the store is already past gcTombstoneInterval
+	// once tombstoned, letting the second checkStores() call below auto-GC it.
+	re.NoError(cluster.setStore(cluster.GetStore(1).Clone(core.SetLastHeartbeatTS(time.Now().Add(-31 * 24 * time.Hour)))))
+
+	re.NoError(cluster.RemoveStore(1, true))
+	cluster.checkStores() // buries store 1; also clears its store limit.
+
+	// Simulate the race: re-add the persisted entry and gauge series
+	// directly, bypassing RaftCluster.SetStoreLimit's IsRemoved guard, the
+	// way a request that read IsRemoved()==false just before bury and wrote
+	// just after would.
+	cluster.opt.SetStoreLimit(1, storelimit.AddPeer, 60)
+	statistics.StoreLimitGauge.WithLabelValues("1", "add-peer").Set(60)
+
+	cluster.checkStores() // auto-GC: DownTime() > gcTombstoneInterval.
+
+	re.NotContains(cluster.opt.GetStoresLimit(), uint64(1))
+	// DeletePartialMatch returns how many series it found and removed, so a
+	// zero return here proves the auto-GC path already deleted it.
+	re.Zero(statistics.StoreLimitGauge.DeletePartialMatch(prometheus.Labels{"store": "1"}))
 }
 
 func TestRemovingProcess(t *testing.T) {

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/log"
 	"github.com/stretchr/testify/require"
+
 	"github.com/tikv/pd/pkg/cluster"
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/core/constant"
@@ -682,7 +683,8 @@ func TestBucketHeartbeat(t *testing.T) {
 		Version:  1,
 		Keys:     [][]byte{{'1'}, {'2'}},
 	}
-	re.Error(cluster.processReportBuckets(buckets))
+	_, err = cluster.processReportBuckets(buckets)
+	re.Error(err)
 
 	// case2: bucket can be processed after the region update.
 	stores := newTestStores(3, "2.0.0")
@@ -695,18 +697,21 @@ func TestBucketHeartbeat(t *testing.T) {
 	re.NoError(cluster.processRegionHeartbeat(core.ContextTODO(), regions[0]))
 	re.NoError(cluster.processRegionHeartbeat(core.ContextTODO(), regions[1]))
 	re.Nil(cluster.GetRegion(uint64(1)).GetBuckets())
-	re.NoError(cluster.processReportBuckets(buckets))
+	_, err = cluster.processReportBuckets(buckets)
+	re.NoError(err)
 	re.Equal(buckets, cluster.GetRegion(uint64(1)).GetBuckets())
 
 	// case3: the bucket version is same.
-	re.NoError(cluster.processReportBuckets(buckets))
+	_, err = cluster.processReportBuckets(buckets)
+	re.NoError(err)
 	// case4: the bucket version is changed.
 	newBuckets := &metapb.Buckets{
 		RegionId: 1,
 		Version:  3,
 		Keys:     [][]byte{{'1'}, {'2'}},
 	}
-	re.NoError(cluster.processReportBuckets(newBuckets))
+	_, err = cluster.processReportBuckets(newBuckets)
+	re.NoError(err)
 	re.Equal(newBuckets, cluster.GetRegion(uint64(1)).GetBuckets())
 
 	// case5: region update should inherit buckets.
@@ -1071,11 +1076,13 @@ func TestConcurrentReportBucket(t *testing.T) {
 	re.NoError(failpoint.Enable("github.com/tikv/pd/server/cluster/concurrentBucketHeartbeat", "return(true)"))
 	go func() {
 		defer wg.Done()
-		cluster.processReportBuckets(bucket1)
+		_, err := cluster.processReportBuckets(bucket1)
+		re.NoError(err)
 	}()
 	time.Sleep(100 * time.Millisecond)
 	re.NoError(failpoint.Disable("github.com/tikv/pd/server/cluster/concurrentBucketHeartbeat"))
-	re.NoError(cluster.processReportBuckets(bucket2))
+	_, err = cluster.processReportBuckets(bucket2)
+	re.NoError(err)
 	wg.Wait()
 	re.Equal(bucket1, cluster.GetRegion(1).GetBuckets())
 }

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -527,6 +527,52 @@ func TestAutoGCTombstoneStoreCleansUpStaleStoreLimit(t *testing.T) {
 	re.Zero(statistics.StoreLimitGauge.DeletePartialMatch(prometheus.Labels{"store": "1"}))
 }
 
+// TestUpdateProgressCannotRepublishAfterBury covers updateProgress writing
+// the three progress gauges for a store that is already buried. deleteStore
+// never calls resetProgress again, so without a post-write recheck such a
+// write would leave the series stranded until the next full metrics reset.
+//
+// AddProgress's "already existed" gate means a single updateProgress call
+// right after bury can't reach the gauge writes by itself: resetProgress
+// removed the progress-manager entry, so that call just recreates it and
+// returns early. It takes a second call, with the entry now present, to
+// reach the writes -- modeling two updateProgress calls (e.g. from a stale
+// concurrent checkStores tick, or the entry being independently recreated
+// by another caller) landing back to back after the store was buried.
+func TestUpdateProgressCannotRepublishAfterBury(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, opt, err := newTestScheduleConfig()
+	re.NoError(err)
+	cluster := newTestRaftCluster(ctx, mockid.NewIDAllocator(), opt, storage.NewStorageWithMemoryBackend())
+	cluster.coordinator = schedule.NewCoordinator(ctx, cluster, nil)
+	cluster.progressManager = progress.NewManager()
+
+	store := newTestStores(1, "5.0.0")[0]
+	re.NoError(cluster.PutMetaStore(store.GetMeta()))
+
+	re.NoError(cluster.RemoveStore(1, true))
+	cluster.checkStores() // buries store 1.
+
+	// First post-bury call: no progress entry exists yet, so AddProgress
+	// creates one and returns exist=false, and updateProgress returns before
+	// writing any gauge.
+	cluster.updateProgress(1, store.GetAddress(), removingAction, 10, 20, false /* dec */)
+	// Second post-bury call: the entry now exists, so this write proceeds
+	// unconditionally and reaches the gauge writes for the already-removed
+	// store.
+	cluster.updateProgress(1, store.GetAddress(), removingAction, 10, 20, false /* dec */)
+
+	// DeletePartialMatch returns how many series it found and removed, so a
+	// zero return here proves the write's post-write recheck already deleted
+	// it, rather than the write never having happened at all.
+	re.Zero(storesProgressGauge.DeletePartialMatch(prometheus.Labels{"store": "1"}))
+	re.Zero(storesSpeedGauge.DeletePartialMatch(prometheus.Labels{"store": "1"}))
+	re.Zero(storesETAGauge.DeletePartialMatch(prometheus.Labels{"store": "1"}))
+}
+
 func TestRemovingProcess(t *testing.T) {
 	re := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/server/cluster/cluster_worker.go
+++ b/server/cluster/cluster_worker.go
@@ -21,6 +21,8 @@ import (
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/log"
+	"go.uber.org/zap"
+
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/errs"
 	"github.com/tikv/pd/pkg/mcs/utils/constant"
@@ -30,7 +32,6 @@ import (
 	"github.com/tikv/pd/pkg/utils/logutil"
 	"github.com/tikv/pd/pkg/utils/typeutil"
 	"github.com/tikv/pd/pkg/versioninfo"
-	"go.uber.org/zap"
 )
 
 // HandleRegionHeartbeat processes RegionInfo reports from client.
@@ -254,10 +255,11 @@ func (*RaftCluster) HandleBatchReportSplit(request *pdpb.ReportBatchSplitRequest
 
 // HandleReportBuckets processes buckets reports from client
 func (c *RaftCluster) HandleReportBuckets(b *metapb.Buckets) error {
-	if err := c.processReportBuckets(b); err != nil {
+	applied, err := c.processReportBuckets(b)
+	if err != nil {
 		return err
 	}
-	if !c.IsServiceIndependent(constant.SchedulingServiceName) {
+	if applied && !c.IsServiceIndependent(constant.SchedulingServiceName) {
 		c.hotStat.CheckAsync(buckets.NewCheckPeerTask(b))
 	}
 	return nil

--- a/server/cluster/scheduling_controller.go
+++ b/server/cluster/scheduling_controller.go
@@ -196,13 +196,13 @@ func (sc *schedulingController) collectSchedulingMetrics() {
 		// right after the write and redoing the cleanup closes that race
 		// without needing synchronization with the bury/removal path.
 		current := sc.GetStore(s.GetID())
-		// ResetStoreStatistics covers storeStatusGauge/storeStats, which
-		// observe() itself stops writing as soon as it sees a tombstoned
-		// store -- so, unlike the fields above, there's no legitimate write to
-		// preserve here once the store is IsRemoved(), not just once it's
-		// gone entirely. But storeStatusGauge's cleanup is a DeletePartialMatch
-		// full-vector scan, so only pay for it when this iteration's own s was
-		// still live (observe(s) could then have written using stale data);
+		// ResetStoreStatistics covers storeStatusGauge, which observe()
+		// itself stops writing as soon as it sees a tombstoned store, so
+		// there's no legitimate write to preserve here once the store is
+		// IsRemoved(), not just once it's gone entirely. But its cleanup is a
+		// DeletePartialMatch full-vector scan, so only pay for it when this
+		// iteration's own s was still live (observe(s) could then have written
+		// using stale data);
 		// once a snapshot correctly shows IsRemoved(), observe() already
 		// skipped writing these fields and there's nothing to undo, so a
 		// tombstoned store sitting in GetStores() for up to 30 days doesn't

--- a/server/cluster/scheduling_controller.go
+++ b/server/cluster/scheduling_controller.go
@@ -17,16 +17,19 @@ package cluster
 import (
 	"context"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/log"
+
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/schedule"
 	"github.com/tikv/pd/pkg/schedule/checker"
 	sc "github.com/tikv/pd/pkg/schedule/config"
 	sche "github.com/tikv/pd/pkg/schedule/core"
+	"github.com/tikv/pd/pkg/schedule/filter"
 	"github.com/tikv/pd/pkg/schedule/hbstream"
 	"github.com/tikv/pd/pkg/schedule/operator"
 	"github.com/tikv/pd/pkg/schedule/placement"
@@ -130,8 +133,10 @@ func (sc *schedulingController) runStatsBackgroundJobs() {
 	defer ticker.Stop()
 
 	for _, store := range sc.GetStores() {
-		storeID := store.GetID()
-		sc.hotStat.GetOrCreateRollingStoreStats(storeID)
+		if store.IsRemoved() {
+			continue
+		}
+		sc.hotStat.GetOrCreateRollingStoreStats(store.GetID())
 	}
 	for {
 		select {
@@ -175,6 +180,8 @@ func resetSchedulingMetrics() {
 	statistics.ResetLabelStatsMetrics()
 	// reset hot cache metrics
 	statistics.ResetHotCacheStatusMetrics()
+	filter.ResetFilterMetrics()
+	hbstream.ResetHeartbeatStreamMetrics()
 }
 
 func (sc *schedulingController) collectSchedulingMetrics() {
@@ -183,8 +190,43 @@ func (sc *schedulingController) collectSchedulingMetrics() {
 	for _, s := range stores {
 		statsMap.Observe(s)
 		statistics.ObserveHotStat(s, sc.hotStat.StoresStats)
+		// Observe/ObserveHotStat write from this snapshot unconditionally, so a
+		// concurrent bury or final removal of s between GetStores() above and
+		// this write can have its own metric cleanup undone by it. Re-checking
+		// right after the write and redoing the cleanup closes that race
+		// without needing synchronization with the bury/removal path.
+		current := sc.GetStore(s.GetID())
+		// ResetStoreStatistics covers storeStatusGauge/storeStats, which
+		// observe() itself stops writing as soon as it sees a tombstoned
+		// store -- so, unlike the fields above, there's no legitimate write to
+		// preserve here once the store is IsRemoved(), not just once it's
+		// gone entirely. But storeStatusGauge's cleanup is a DeletePartialMatch
+		// full-vector scan, so only pay for it when this iteration's own s was
+		// still live (observe(s) could then have written using stale data);
+		// once a snapshot correctly shows IsRemoved(), observe() already
+		// skipped writing these fields and there's nothing to undo, so a
+		// tombstoned store sitting in GetStores() for up to 30 days doesn't
+		// cost a scan on every 10s tick.
+		if !s.IsRemoved() && (current == nil || current.IsRemoved()) {
+			statistics.ResetStoreStatistics(strconv.FormatUint(s.GetID(), 10))
+		}
 	}
 	statsMap.Collect()
+	// statsMap.Collect() writes statistics.StoreLimitGauge from its own
+	// GetStoresLimit() snapshot, taken independently of stores above and with
+	// no cluster reference of its own to re-check against. Reuse the stores
+	// snapshot already captured here to catch and undo it. Like
+	// ResetStoreStatistics above, a store limit has no legitimate reason to
+	// still be configured once the store is tombstoned (RemoveStoreLimit
+	// already clears it at bury time), so this also checks IsRemoved(), not
+	// just full removal.
+	for _, s := range stores {
+		if store := sc.GetStore(s.GetID()); store == nil || store.IsRemoved() {
+			id := strconv.FormatUint(s.GetID(), 10)
+			statistics.StoreLimitGauge.DeleteLabelValues(id, "add-peer")
+			statistics.StoreLimitGauge.DeleteLabelValues(id, "remove-peer")
+		}
+	}
 	sc.coordinator.GetSchedulersController().CollectSchedulerMetrics()
 	sc.coordinator.CollectHotSpotMetrics()
 	if sc.regionStats == nil {
@@ -201,6 +243,9 @@ func (sc *schedulingController) collectSchedulingMetrics() {
 func (sc *schedulingController) removeStoreStatistics(storeID uint64) {
 	sc.hotStat.RemoveRollingStoreStats(storeID)
 	sc.slowStat.RemoveSlowStoreStatus(storeID)
+	storeIDStr := strconv.FormatUint(storeID, 10)
+	schedulers.DeleteStoreMetrics(storeIDStr)
+	scatter.DeleteStoreMetrics(storeIDStr)
 }
 
 func (sc *schedulingController) updateStoreStatistics(storeID uint64, isSlow bool) {

--- a/server/cluster/scheduling_controller.go
+++ b/server/cluster/scheduling_controller.go
@@ -182,6 +182,7 @@ func resetSchedulingMetrics() {
 	statistics.ResetHotCacheStatusMetrics()
 	filter.ResetFilterMetrics()
 	hbstream.ResetHeartbeatStreamMetrics()
+	operator.ResetOperatorMetrics()
 }
 
 func (sc *schedulingController) collectSchedulingMetrics() {

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -35,6 +35,13 @@ import (
 	"github.com/pingcap/kvproto/pkg/schedulingpb"
 	"github.com/pingcap/kvproto/pkg/tsopb"
 	"github.com/pingcap/log"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.uber.org/multierr"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/errs"
 	"github.com/tikv/pd/pkg/mcs/utils/constant"
@@ -48,12 +55,6 @@ import (
 	"github.com/tikv/pd/pkg/utils/tsoutil"
 	"github.com/tikv/pd/pkg/versioninfo"
 	"github.com/tikv/pd/server/cluster"
-	clientv3 "go.etcd.io/etcd/client/v3"
-	"go.uber.org/multierr"
-	"go.uber.org/zap"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 const (
@@ -1210,6 +1211,8 @@ func (s *GrpcServer) ReportBuckets(stream pdpb.PD_ReportBucketsServer) error {
 			// As TiKV report buckets just after the region heartbeat, for new created region, PD may receive buckets report before the first region heartbeat is handled.
 			// So we should not return error here.
 			log.Warn("the store of the bucket in region is not found ", zap.Uint64("region-id", buckets.GetRegionId()))
+		} else if store.IsRemoved() {
+			continue
 		} else {
 			storeLabel = strconv.FormatUint(store.GetID(), 10)
 			storeAddress = store.GetAddress()
@@ -1317,6 +1320,10 @@ func (s *GrpcServer) RegionHeartbeat(stream pdpb.PD_RegionHeartbeatServer) error
 		store := rc.GetStore(storeID)
 		if store == nil {
 			return errors.Errorf("invalid store ID %d, not found", storeID)
+		}
+		if store.IsRemoved() {
+			log.Debug("skip region heartbeat from tombstone store", zap.Uint64("store-id", storeID))
+			continue
 		}
 		storeAddress := store.GetAddress()
 

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -190,3 +190,19 @@ func init() {
 	prometheus.MustRegister(forwardFailCounter)
 	prometheus.MustRegister(forwardTsoDuration)
 }
+
+// DeleteStoreMetrics deletes the per-store heartbeat/bucket-report metrics of a store.
+// Matches on the store label alone, not address: PD allows an existing store ID to
+// change address (e.g. after a TiKV restart with a new IP), so requiring the current
+// address to match as well would permanently leak any series recorded under a
+// previous address.
+func DeleteStoreMetrics(id string) {
+	labels := prometheus.Labels{"store": id}
+	regionHeartbeatCounter.DeletePartialMatch(labels)
+	regionHeartbeatLatency.DeletePartialMatch(labels)
+	regionHeartbeatHandleDuration.DeletePartialMatch(labels)
+	storeHeartbeatHandleDuration.DeletePartialMatch(labels)
+	bucketReportCounter.DeletePartialMatch(labels)
+	bucketReportLatency.DeletePartialMatch(labels)
+	bucketReportInterval.DeletePartialMatch(labels)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -42,6 +42,13 @@ import (
 	"github.com/pingcap/kvproto/pkg/tsopb"
 	"github.com/pingcap/log"
 	"github.com/pingcap/sysutil"
+	"go.etcd.io/etcd/api/v3/mvccpb"
+	etcdtypes "go.etcd.io/etcd/client/pkg/v3/types"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/server/v3/embed"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+
 	"github.com/tikv/pd/pkg/audit"
 	bs "github.com/tikv/pd/pkg/basicserver"
 	"github.com/tikv/pd/pkg/cgroup"
@@ -81,12 +88,6 @@ import (
 	"github.com/tikv/pd/pkg/versioninfo"
 	"github.com/tikv/pd/server/cluster"
 	"github.com/tikv/pd/server/config"
-	"go.etcd.io/etcd/api/v3/mvccpb"
-	etcdtypes "go.etcd.io/etcd/client/pkg/v3/types"
-	clientv3 "go.etcd.io/etcd/client/v3"
-	"go.etcd.io/etcd/server/v3/embed"
-	"go.uber.org/zap"
-	"google.golang.org/grpc"
 )
 
 const (
@@ -492,6 +493,10 @@ func (s *Server) startServer(ctx context.Context) error {
 	s.gcSafePointManager = gc.NewSafePointManager(s.storage, s.cfg.PDServerCfg)
 	s.basicCluster = core.NewBasicCluster()
 	s.cluster = cluster.NewRaftCluster(ctx, s.GetMember(), s.GetBasicCluster(), s.GetStorage(), syncer.NewRegionSyncer(s), s.client, s.httpClient, s.tsoAllocatorManager)
+	// This package's own heartbeat/bucket-report metrics can't be cleaned up from
+	// within RaftCluster's bury path without an import cycle, so RaftCluster invokes
+	// this callback instead.
+	s.cluster.SetOnStoreBuried(DeleteStoreMetrics)
 	keyspaceIDAllocator := id.NewAllocator(&id.AllocatorParams{
 		Client:    s.client,
 		RootPath:  s.rootPath,

--- a/tests/integrations/client/client_test.go
+++ b/tests/integrations/client/client_test.go
@@ -1507,6 +1507,7 @@ func (suite *clientTestSuite) TestGetStore() {
 	// Get an up store should be OK.
 	n, err := suite.client.GetStore(context.Background(), store.GetId())
 	re.NoError(err)
+	store.LastHeartbeat = n.LastHeartbeat
 	re.Equal(store, n)
 
 	actualStores, err := suite.client.GetAllStores(context.Background())

--- a/tests/integrations/client/client_test.go
+++ b/tests/integrations/client/client_test.go
@@ -39,6 +39,9 @@ import (
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.uber.org/goleak"
+
 	pd "github.com/tikv/pd/client"
 	clierrs "github.com/tikv/pd/client/errs"
 	"github.com/tikv/pd/client/retry"
@@ -57,8 +60,6 @@ import (
 	"github.com/tikv/pd/server/config"
 	"github.com/tikv/pd/tests"
 	"github.com/tikv/pd/tests/integrations/mcs"
-	clientv3 "go.etcd.io/etcd/client/v3"
-	"go.uber.org/goleak"
 )
 
 const (
@@ -1497,7 +1498,11 @@ func (suite *clientTestSuite) TestGetStore() {
 	re := suite.Require()
 	cluster := suite.srv.GetRaftCluster()
 	re.NotNil(cluster)
-	store := stores[0]
+	// Use stores[3]: this test destructively transitions it through
+	// offline -> tombstone, and stores[0..2] are the ones other tests in
+	// this suite heartbeat regions through (peers[0..2]) and expect to
+	// stay live for the rest of the suite.
+	store := stores[3]
 
 	// Get an up store should be OK.
 	n, err := suite.client.GetStore(context.Background(), store.GetId())

--- a/tests/server/cluster/cluster_test.go
+++ b/tests/server/cluster/cluster_test.go
@@ -32,6 +32,9 @@ import (
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/kvproto/pkg/replication_modepb"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/core/storelimit"
 	"github.com/tikv/pd/pkg/dashboard"
@@ -55,8 +58,6 @@ import (
 	"github.com/tikv/pd/server/config"
 	"github.com/tikv/pd/tests"
 	"github.com/tikv/pd/tests/server/api"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 const (
@@ -474,8 +475,20 @@ func testStateAndLimit(re *require.Assertions, clusterID uint64, rc *cluster.Raf
 	// prepare
 	storeID := store.GetId()
 	oc := rc.GetOperatorController()
-	rc.SetStoreLimit(storeID, storelimit.AddPeer, 60)
-	rc.SetStoreLimit(storeID, storelimit.RemovePeer, 60)
+	// The store can be left tombstoned by a previous call to this helper (the
+	// tombstone beforeState block runs it twice on the same store). Production
+	// never un-tombstones a store, so don't fake that transition here either --
+	// these SetStoreLimit calls only exist to seed a limit before resetStoreState
+	// below establishes the state this specific case actually wants to test, and
+	// resetStoreState's own Tombstone branch clears any limit anyway, so seeding
+	// one is pointless (and rejected by SetStoreLimit) once the store is already
+	// tombstoned.
+	if store := rc.GetStore(storeID); store == nil || !store.IsRemoved() {
+		err := rc.SetStoreLimit(storeID, storelimit.AddPeer, 60)
+		re.NoError(err)
+		err = rc.SetStoreLimit(storeID, storelimit.RemovePeer, 60)
+		re.NoError(err)
+	}
 	op := operator.NewTestOperator(2, &metapb.RegionEpoch{}, operator.OpRegion, operator.AddPeer{ToStore: storeID, PeerID: 3})
 	oc.AddOperator(op)
 	op = operator.NewTestOperator(2, &metapb.RegionEpoch{}, operator.OpRegion, operator.RemovePeer{FromStore: storeID})


### PR DESCRIPTION
This is a manual cherry-pick of #11127, and also carries the subset of the still-open #11166 (a direct follow-up to #11127 on the same area) that applies to this release branch — see "Also includes part of #11166" below.

close tikv/pd#11126

### What problem does this PR solve?

Several per-store Prometheus metrics were never cleaned up on store removal, leaking stale time series until the next PD leader election forced a full `Reset()`.

### What is changed and how does it work?

Ports #11127's event-driven per-store metric cleanup: a one-shot sweep at bury time (`RaftCluster.BuryStoreLocked` and the mcs meta watcher's tombstone handler) and again at final removal (`deleteStore` / the watcher's remove-tombstone handler), plus write-side `IsRemoved()` guards in `RegionHeartbeat`, `StoreHeartbeat`, region-buckets handling, `HotPeerCache.CheckPeerFlow`, the filter package's `Select*Stores` helpers, and `RegionScatterer` so a late heartbeat or scatter decision for an already-buried store can't recreate a series that was just deleted.

### Cherry-pick notes

`release-8.5-20260130-v8.5.3` predates several subsystems #11127's diff otherwise touches, so those parts were left out rather than force-fit, and only the applicable metric-cleanup logic was ported:

- The router microservice (`pkg/mcs/router`) and the balance-range scheduler (`pkg/schedule/schedulers/balance_range.go`) don't exist on this branch.
- The mcs scheduling server has no per-request heartbeat/bucket-report metrics yet (no `pkg/mcs/scheduling/server/metrics.go`, no `storeHeartbeatCounter`/`regionHeartbeatCounter`/`regionBucketsCounter`), so the corresponding `DeleteStoreMetrics`/`ResetStoreMetrics` wiring and the new `RegionBuckets` gRPC handler were dropped; only the `IsRemoved()` early-return guards were kept for `RegionHeartbeat`/`StoreHeartbeat`.
- The CAS-based report/committed buckets split (`RegionInfo.CompareAndSetReportBuckets`/`GetReportBuckets`) isn't on this branch either; `processReportBuckets` keeps its existing version-check + `UpdateBuckets` retry loop and only gained the `(bool, error)` return plus the tombstoned-leader skip. `TestBucketCompatibility`/`TestStaleBucketMeta`, which depend on that split, were not backported.
- `statistics.DeleteClusterStatusMetrics` and the per-store, engine-labeled `clusterStatusGauge` it targets don't exist here; `clusterStatusGauge` on this branch is a cluster-wide aggregate with no store label, so `ResetStoreStatistics` only had its signature narrowed to a bare store ID and gained the `StoreLimitGauge` cleanup.
- `pkg/schedule/filter`'s `Counter` already tracks `(source, target)` pairs under a single `filterCounter` metric on this branch (predates the upstream split into `filterSourceCounter`/`filterTargetCounter`), so the `IsRemoved()` skip was grafted onto the existing pair-keyed `Flush` instead of adopting the split metrics.
- `RegionScatterer.applyScatterStateDelta` belongs to a newer runtime-resource-management refactor not on this branch; `RegionScatterer.Put` kept its existing `sync.Map`-based `specialEngines`/`fmt.Sprintf`-labeled style. The `onStoreBuried`/`onStoreTombstoned` cross-package callback wiring (`RaftCluster.SetOnStoreBuried`, `meta.Watcher.SetOnStoreTombstoned`) was reinstated during review, once the MCS rolling-stats cleanup (below) needed a caller-side hook to invoke it from.
- `storeTriggerNetworkSlowEvict` doesn't exist on this branch, so its cleanup call was dropped from `BuryStoreLocked`/`deleteStore`.

### Also includes part of #11166

#11166 (still open on master) closes several residual tombstone-metric leaks left after #11127, on the same classes of gauges/counters this PR already touches. This PR carries the subset that is a pure Prometheus-metric-leak fix and applies cleanly to this branch's code shape:

- `ObserveHotStat`/`ResetStoreStatistics`/`Reset()`: stop `storeStatusGauge` from being republished by an in-flight `StoreHeartbeat` after bury, clean up `placementStatusGauge`, reset `StoreLimitGauge` on a full leader-election reset.
- `collectHotMetrics`: gate `hasHotLeader`/`hasHotPeer` on a single `IsRemoved()` read so a tombstoned store's stale `HotPeerCache` data can't republish `hotSpotStatusGauge` between `HotPeerCache.gc()` ticks.
- `SetStoreLimit`: reject setting a limit on an already-tombstoned store, and `deleteStore` now also calls `RemoveStoreLimit` (not just `BuryStore`/the manual `RemoveTombStoneRecords` path), so the 30-day auto-GC path gets the same store-limit cleanup as manual removal.
- `summaryPendingInfluence`: re-check each store fresh through the cluster instead of trusting the possibly-stale `StoreSummaryInfo` snapshot before writing `HotPendingSum`.
- `storeLimitCostCounter` (`pd_schedule_store_limit_cost`): release-only — master removed it in #9535, so #11127's diff could never expose this gap. Added `operator.DeleteStoreMetrics`/`ResetOperatorMetrics` and wired them into both classic and MCS tombstone/final-removal hooks and reset paths.

Left out (not applicable to this branch): #11166's `evict_slow_store.go`/`adjustNetworkSlowStore` guards (network-slow-store eviction doesn't exist here) and its memory-leak-only fixes (region rule fit cache, `storesOfRegion` reverse index, `StoreHistoryLoads` GC), which are a separate concern from metric leakage and are not carried by this PR.

### Check List

Tests

- Unit test

### Release note

```release-note
Fix per-store Prometheus metrics (hotcache, scheduler, filter, heartbeat-stream, scatter, operator, and heartbeat/bucket-report metrics) not being removed after a store is tombstoned, which previously left stale time series in `/metrics` until the next PD leader election. Cleanup is best-effort: a rare race between an in-flight scheduling round and a store's removal can still leave a stale series until the next leader election.
```

