### PR TITLE
client/router: handle zero region ID

### DIFF
--- a/client/clients/router/client.go
+++ b/client/clients/router/client.go
@@ -290,7 +290,7 @@ func requestFinisher(resp *pdpb.QueryRegionResponse) batch.FinisherFunc[*Request
 		} else if req.prevKey != nil {
 			id = resp.PrevKeyIdMap[prevKeyIdx]
 			prevKeyIdx++
-		} else if req.id != 0 {
+		} else {
 			id = req.id
 		}
 		if regionResp, ok := resp.RegionsById[id]; ok {
@@ -728,6 +728,33 @@ func (c *Cli) sendToMs(ctx context.Context) (processFn, string) {
 type recvFn func() (*pdpb.QueryRegionResponse, error)
 type sendFn func(*pdpb.QueryRegionRequest) error
 
+// buildQueryRegionRequest converts the collected requests into one QueryRegion
+// request. A request with neither key nor prevKey is an ID query, so the entire
+// uint64 ID range, including zero, is preserved.
+func buildQueryRegionRequest(clusterID uint64, requests []*Request) *pdpb.QueryRegionRequest {
+	queryReq := &pdpb.QueryRegionRequest{
+		Header: &pdpb.RequestHeader{
+			ClusterId: clusterID,
+		},
+		Keys:     make([][]byte, 0, len(requests)),
+		PrevKeys: make([][]byte, 0, len(requests)),
+		Ids:      make([]uint64, 0, len(requests)),
+	}
+	for _, req := range requests {
+		if !queryReq.NeedBuckets && req.options.NeedBuckets {
+			queryReq.NeedBuckets = true
+		}
+		if req.key != nil {
+			queryReq.Keys = append(queryReq.Keys, req.key)
+		} else if req.prevKey != nil {
+			queryReq.PrevKeys = append(queryReq.PrevKeys, req.prevKey)
+		} else {
+			queryReq.Ids = append(queryReq.Ids, req.id)
+		}
+	}
+	return queryReq
+}
+
 func (c *Cli) processRequestsInner(send sendFn, recv recvFn) error {
 	var (
 		requests = c.batchController.GetCollectedRequests()
@@ -750,28 +777,7 @@ func (c *Cli) processRequestsInner(send sendFn, recv recvFn) error {
 		traceRegion.End()
 	}()
 
-	queryReq := &pdpb.QueryRegionRequest{
-		Header: &pdpb.RequestHeader{
-			ClusterId: c.svcDiscovery.GetClusterID(),
-		},
-		Keys:     make([][]byte, 0, len(requests)),
-		PrevKeys: make([][]byte, 0, len(requests)),
-		Ids:      make([]uint64, 0, len(requests)),
-	}
-	for _, req := range requests {
-		if !queryReq.NeedBuckets && req.options.NeedBuckets {
-			queryReq.NeedBuckets = true
-		}
-		if req.key != nil {
-			queryReq.Keys = append(queryReq.Keys, req.key)
-		} else if req.prevKey != nil {
-			queryReq.PrevKeys = append(queryReq.PrevKeys, req.prevKey)
-		} else if req.id != 0 {
-			queryReq.Ids = append(queryReq.Ids, req.id)
-		} else {
-			panic("invalid region query request received")
-		}
-	}
+	queryReq := buildQueryRegionRequest(c.svcDiscovery.GetClusterID(), requests)
 	start := time.Now()
 	err := send(queryReq)
 	if err != nil {

--- a/client/clients/router/client_test.go
+++ b/client/clients/router/client_test.go
@@ -16,6 +16,7 @@ package router
 
 import (
 	"context"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -42,7 +43,7 @@ func newMockRegionResponse(id uint64) *pdpb.RegionResponse {
 
 // newTestRequest builds a *Request directly for finisher tests, mirroring the
 // invariants that the production newRequest guarantees: a non-nil options and a
-// buffered done channel. Callers set key/prevKey/id afterwards.
+// buffered done channel. Callers set key, prevKey, or id afterwards.
 func newTestRequest(ctx context.Context, opts ...opt.GetRegionOption) *Request {
 	req := &Request{
 		requestCtx: ctx,
@@ -147,4 +148,45 @@ func TestRequestFinisherClearsUnrequestedBuckets(t *testing.T) {
 	re.NotNil(reqWithBuckets.region.Buckets)
 	// The request that did not ask for buckets must not receive them.
 	re.Nil(reqWithoutBuckets.region.Buckets)
+}
+
+func TestRequestFinisherWithZeroRegionID(t *testing.T) {
+	re := require.New(t)
+	req := newTestRequest(context.Background())
+
+	finisher := requestFinisher(&pdpb.QueryRegionResponse{})
+	finisher(0, req, nil)
+
+	re.NoError(<-req.done)
+	re.Nil(req.region)
+}
+
+func TestBuildQueryRegionRequest(t *testing.T) {
+	re := require.New(t)
+	ctx := context.Background()
+	keyReq := newTestRequest(ctx)
+	keyReq.key = []byte{}
+	prevKeyReq := newTestRequest(ctx, opt.WithBuckets())
+	prevKeyReq.prevKey = []byte{}
+	zeroIDReq := newTestRequest(ctx)
+	zeroIDReq.id = 0
+	maxIDReq := newTestRequest(ctx)
+	maxIDReq.id = math.MaxUint64
+
+	queryReq := buildQueryRegionRequest(42, []*Request{
+		keyReq,
+		prevKeyReq,
+		zeroIDReq,
+		maxIDReq,
+	})
+
+	re.Equal(uint64(42), queryReq.GetHeader().GetClusterId())
+	re.Len(queryReq.GetKeys(), 1)
+	re.NotNil(queryReq.GetKeys()[0])
+	re.Empty(queryReq.GetKeys()[0])
+	re.Len(queryReq.GetPrevKeys(), 1)
+	re.NotNil(queryReq.GetPrevKeys()[0])
+	re.Empty(queryReq.GetPrevKeys()[0])
+	re.Equal([]uint64{0, math.MaxUint64}, queryReq.GetIds())
+	re.True(queryReq.GetNeedBuckets())
 }

--- a/client/clients/router/request.go
+++ b/client/clients/router/request.go
@@ -31,11 +31,14 @@ type Request struct {
 	requestCtx context.Context
 	clientCtx  context.Context
 
-	// Key field represents this is a `GetRegion` request.
+	// The query kind is encoded without a separate discriminator. GetRegion and
+	// GetPrevRegion always set a non-nil (possibly empty) key field; otherwise,
+	// id is used by GetRegionByID, including Region ID 0.
+	// key is non-nil for GetRegion requests.
 	key []byte
-	// PrevKey field represents this is a `GetPrevRegion` request.
+	// prevKey is non-nil for GetPrevRegion requests.
 	prevKey []byte
-	// ID field represents this is a `GetRegionByID` request.
+	// id is the requested Region ID when both key and prevKey are nil.
 	id uint64
 
 	options *opt.GetRegionOp

--- a/tests/integrations/client/router_client_test.go
+++ b/tests/integrations/client/router_client_test.go
@@ -127,6 +127,10 @@ func (suite *routerClientSuite) TestGetRegion() {
 			reflect.DeepEqual(peers[0], r.Leader) &&
 			r.Buckets == nil
 	})
+	r, err := suite.client.GetRegion(context.Background(), nil)
+	re.NoError(err)
+	re.NotNil(r)
+	re.Equal(regionID, r.Meta.GetId())
 	breq := &pdpb.ReportBucketsRequest{
 		Header: newHeader(),
 		Buckets: &metapb.Buckets{
@@ -243,6 +247,10 @@ func (suite *routerClientSuite) TestGetRegionByID() {
 		return reflect.DeepEqual(region, r.Meta) &&
 			reflect.DeepEqual(peers[0], r.Leader)
 	})
+
+	r, err := suite.client.GetRegionByID(context.Background(), 0)
+	re.NoError(err)
+	re.Nil(r)
 
 	// test WithCallerComponent
 	testutil.Eventually(re, func() bool {

--- a/tests/integrations/mcs/router/server_test.go
+++ b/tests/integrations/mcs/router/server_test.go
@@ -247,6 +247,9 @@ func (suite *serverTestSuite) checkRegionAPI(cli pd.Client) {
 		re.Equal(regionID, r1.Meta.Id)
 		return true
 	})
+	r0, err := cli.GetRegionByID(suite.ctx, 0, allowEnableRouterServiceOpt)
+	re.NoError(err)
+	re.Nil(r0)
 
 	// get region by key
 	r2, err := cli.GetRegion(suite.ctx, r1.Meta.GetStartKey(), allowEnableRouterServiceOpt)


### PR DESCRIPTION
### What problem does this PR solve?

When QueryRegion is enabled, the router client uses `id != 0` to identify ID lookups, so `GetRegionByID(0)` is treated as an invalid request and triggers a panic. The unary request path accepts Region ID 0 and returns no matching region without an error.

Issue Number: ref #11180

### What is changed and how does it work?

```commit-message
Use the existing request selector fields as a total encoding: key != nil selects GetRegion, prevKey != nil selects GetPrevRegion, and the remaining state selects GetRegionByID over the full uint64 range. GetRegion and GetPrevRegion already normalize nil keys to non-nil empty slices, so Region ID 0 can be sent through QueryRegion without extra per-request state or allocations.

Extract QueryRegion request construction into a pure helper so the selector contract is centralized and directly testable.
```

### Check List

Tests

- Unit test
- Integration test

### Release note

```release-note
Fix a panic when GetRegionByID is called with Region ID 0 while QueryRegion is enabled.
```
