### PR TITLE
tests: prevent RunServer goroutine leaks

### DIFF
--- a/tests/cluster.go
+++ b/tests/cluster.go
@@ -678,7 +678,9 @@ func restartTestCluster(
 
 // RunServer starts to run TestServer.
 func RunServer(server *TestServer) <-chan error {
-	resC := make(chan error)
+	// Buffer the one-shot result so the goroutine can exit even if the caller
+	// returns early after another concurrently started server fails.
+	resC := make(chan error, 1)
 	go func() { resC <- server.Run() }()
 	return resC
 }

--- a/tests/cluster_test.go
+++ b/tests/cluster_test.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
@@ -56,6 +57,16 @@ func TestClassifyInitialServersError(t *testing.T) {
 	re.Equal(startServersRetryRecreate, classifyInitialServersError(errors.New("Etcd cluster ID mismatch")))
 	re.Equal(startServersNoRetry, classifyInitialServersError(errors.New("some other error")))
 	re.Equal(startServersNoRetry, classifyInitialServersError(nil))
+}
+
+func TestRunServerDoesNotBlockWithoutReceiver(t *testing.T) {
+	t.Parallel()
+
+	result := RunServer(&TestServer{state: Destroy})
+	require.Eventually(t, func() bool {
+		return len(result) == 1
+	}, time.Second, 10*time.Millisecond)
+	require.Error(t, <-result)
 }
 
 func TestRegenerateInitialServerURLsKeepsInitialClusterConsistent(t *testing.T) {

--- a/tests/integrations/tso/consistency_test.go
+++ b/tests/integrations/tso/consistency_test.go
@@ -190,6 +190,11 @@ func (suite *tsoConsistencyTestSuite) TestFallbackTSOConsistency() {
 	suite.SetupSuite()
 	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/tso/fallBackSync"))
 	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/tso/fallBackUpdate"))
+	defer func() {
+		// Do not let the simulated future TSO affect the following test.
+		suite.TearDownSuite()
+		suite.SetupSuite()
+	}()
 
 	ctx, cancel := context.WithCancel(suite.ctx)
 	defer cancel()


### PR DESCRIPTION
### What problem does this PR solve?

`RunServers` returns immediately after receiving the first server startup
error. When other concurrent startup attempts finish, their `RunServer`
goroutines can remain blocked while sending results through unbuffered
channels. A later retry may succeed, but goleak still fails the test package.

Issue Number: Close #11183

### What is changed and how does it work?

```commit-message
Buffer the one-shot server startup result so its goroutine can exit when the
caller returns after another concurrent startup fails. Add a regression test
that verifies the result can be published without an immediate receiver.
```

### Check List

Tests

- Unit test

### Release note

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server startup handling so background operations can complete without blocking when the caller exits early.
  * Ensured startup errors are reliably returned through the result channel.
  * Improved test isolation after fallback time synchronization scenarios.

* **Tests**
  * Added coverage verifying that server startup reports errors promptly, even when no receiver is immediately waiting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->