### PR TITLE
ratelimit: reduce concurrent runner memory retention

### DIFF
--- a/pkg/ratelimit/runner.go
+++ b/pkg/ratelimit/runner.go
@@ -42,7 +42,7 @@ const (
 	initialCapacity = 10000
 	// maxPendingTaskNum bounds the closures and their captured objects retained
 	// by a runner that cannot keep up with incoming work.
-	maxPendingTaskNum = 100000
+	maxPendingTaskNum = 20000000
 )
 
 // Runner is the interface for running tasks.
@@ -237,7 +237,6 @@ func (cr *ConcurrentRunner) Stop() {
 
 // RunTask runs the task asynchronously.
 func (cr *ConcurrentRunner) RunTask(id uint64, name string, f func(context.Context), opts ...TaskOption) error {
-	cr.processPendingTasks()
 	cr.pendingMu.Lock()
 	defer func() {
 		cr.pendingMu.Unlock()

--- a/pkg/ratelimit/runner.go
+++ b/pkg/ratelimit/runner.go
@@ -39,8 +39,10 @@ const (
 )
 
 const (
-	initialCapacity   = 10000
-	maxPendingTaskNum = 20000000
+	initialCapacity = 10000
+	// maxPendingTaskNum bounds the closures and their captured objects retained
+	// by a runner that cannot keep up with incoming work.
+	maxPendingTaskNum = 100000
 )
 
 // Runner is the interface for running tasks.
@@ -72,11 +74,13 @@ type ConcurrentRunner struct {
 	name               string
 	limiter            *ConcurrencyLimiter
 	maxPendingDuration time.Duration
+	maxPendingTaskNum  int
 	taskChan           chan *Task
 	pendingMu          sync.Mutex
 	wg                 sync.WaitGroup
 	pendingTaskCount   map[string]int
 	pendingTasks       []*Task
+	pendingHead        int
 	existTasks         map[taskID]*Task
 	maxWaitingDuration prometheus.Gauge
 }
@@ -87,6 +91,7 @@ func NewConcurrentRunner(name string, limiter *ConcurrencyLimiter, maxPendingDur
 		name:               name,
 		limiter:            limiter,
 		maxPendingDuration: maxPendingDuration,
+		maxPendingTaskNum:  maxPendingTaskNum,
 		taskChan:           make(chan *Task, 1),
 		pendingTasks:       make([]*Task, 0, initialCapacity),
 		pendingTaskCount:   make(map[string]int),
@@ -126,15 +131,15 @@ func (cr *ConcurrentRunner) Start(ctx context.Context) {
 				}
 			case <-cr.ctx.Done():
 				cr.pendingMu.Lock()
-				cr.pendingTasks = make([]*Task, 0, initialCapacity)
+				cr.resetPendingTasks(0)
 				cr.pendingMu.Unlock()
 				log.Info("stopping async task runner", zap.String("name", cr.name))
 				return
 			case <-ticker.C:
 				maxDuration := time.Duration(0)
 				cr.pendingMu.Lock()
-				if len(cr.pendingTasks) > 0 {
-					maxDuration = time.Since(cr.pendingTasks[0].submittedAt)
+				if cr.pendingTaskNum() > 0 {
+					maxDuration = time.Since(cr.pendingTasks[cr.pendingHead].submittedAt)
 				}
 				for taskName, cnt := range cr.pendingTaskCount {
 					runnerPendingTasks.WithLabelValues(cr.name, taskName).Set(float64(cnt))
@@ -165,17 +170,62 @@ func (cr *ConcurrentRunner) run(ctx context.Context, task *Task, token *TaskToke
 func (cr *ConcurrentRunner) processPendingTasks() {
 	cr.pendingMu.Lock()
 	defer cr.pendingMu.Unlock()
-	if len(cr.pendingTasks) > 0 {
-		task := cr.pendingTasks[0]
+	if cr.pendingTaskNum() > 0 {
+		task := cr.pendingTasks[cr.pendingHead]
 		select {
 		case cr.taskChan <- task:
-			cr.pendingTasks[0] = nil // avoid memory leak
-			cr.pendingTasks = cr.pendingTasks[1:]
+			cr.pendingTasks[cr.pendingHead] = nil
+			cr.pendingHead++
 			cr.pendingTaskCount[task.name]--
 			delete(cr.existTasks, taskID{id: task.id, name: task.name})
+			cr.compactPendingTasks()
 		default:
 		}
 		return
+	}
+}
+
+func (cr *ConcurrentRunner) pendingTaskNum() int {
+	return len(cr.pendingTasks) - cr.pendingHead
+}
+
+// compactPendingTasks releases the consumed prefix and the high-water capacity
+// of the task index after a burst. It must be called with pendingMu held.
+func (cr *ConcurrentRunner) compactPendingTasks() {
+	pendingTaskNum := cr.pendingTaskNum()
+	if pendingTaskNum == 0 {
+		if cr.pendingHead >= initialCapacity {
+			cr.resetPendingTasks(initialCapacity)
+		} else {
+			cr.pendingTasks = cr.pendingTasks[:0]
+			cr.pendingHead = 0
+		}
+		return
+	}
+	if cr.pendingHead < initialCapacity || cr.pendingHead < pendingTaskNum {
+		return
+	}
+
+	capacity := max(initialCapacity, pendingTaskNum*2)
+	pendingTasks := make([]*Task, pendingTaskNum, capacity)
+	copy(pendingTasks, cr.pendingTasks[cr.pendingHead:])
+	cr.pendingTasks = pendingTasks
+	cr.pendingHead = 0
+	cr.existTasks = make(map[taskID]*Task, pendingTaskNum)
+	for _, task := range cr.pendingTasks {
+		cr.existTasks[taskID{id: task.id, name: task.name}] = task
+	}
+}
+
+// resetPendingTasks releases all pending task storage. It must be called with
+// pendingMu held. capacity is kept small during normal operation and zero when
+// the runner stops.
+func (cr *ConcurrentRunner) resetPendingTasks(capacity int) {
+	cr.pendingTasks = make([]*Task, 0, capacity)
+	cr.pendingHead = 0
+	cr.existTasks = make(map[taskID]*Task)
+	for taskName := range cr.pendingTaskCount {
+		cr.pendingTaskCount[taskName] = 0
 	}
 }
 
@@ -187,6 +237,23 @@ func (cr *ConcurrentRunner) Stop() {
 
 // RunTask runs the task asynchronously.
 func (cr *ConcurrentRunner) RunTask(id uint64, name string, f func(context.Context), opts ...TaskOption) error {
+	cr.processPendingTasks()
+	cr.pendingMu.Lock()
+	defer func() {
+		cr.pendingMu.Unlock()
+		cr.processPendingTasks()
+	}()
+
+	pendingTaskNum := cr.pendingTaskNum()
+	tid := taskID{id: id, name: name}
+	if pendingTaskNum > 0 {
+		// Here we use a map to find the task with the same ID.
+		// Then replace the old task with the new one.
+		if t, ok := cr.existTasks[tid]; ok {
+			t.f = f
+			return nil
+		}
+	}
 	task := &Task{
 		id:          id,
 		name:        name,
@@ -196,38 +263,22 @@ func (cr *ConcurrentRunner) RunTask(id uint64, name string, f func(context.Conte
 	for _, opt := range opts {
 		opt(task)
 	}
-	cr.processPendingTasks()
-	cr.pendingMu.Lock()
-	defer func() {
-		cr.pendingMu.Unlock()
-		cr.processPendingTasks()
-	}()
-
-	pendingTaskNum := len(cr.pendingTasks)
-	tid := taskID{task.id, task.name}
 	if pendingTaskNum > 0 {
-		// Here we use a map to find the task with the same ID.
-		// Then replace the old task with the new one.
-		if t, ok := cr.existTasks[tid]; ok {
-			t.f = f
-			t.submittedAt = time.Now()
-			return nil
-		}
 		if !task.retained {
-			maxWait := time.Since(cr.pendingTasks[0].submittedAt)
+			maxWait := time.Since(cr.pendingTasks[cr.pendingHead].submittedAt)
 			if maxWait > cr.maxPendingDuration {
-				runnerFailedTasks.WithLabelValues(cr.name, task.name).Inc()
+				runnerFailedTasks.WithLabelValues(cr.name, name).Inc()
 				return errs.ErrMaxWaitingTasksExceeded
 			}
 		}
-		if pendingTaskNum > maxPendingTaskNum {
-			runnerFailedTasks.WithLabelValues(cr.name, task.name).Inc()
+		if pendingTaskNum >= cr.maxPendingTaskNum {
+			runnerFailedTasks.WithLabelValues(cr.name, name).Inc()
 			return errs.ErrMaxWaitingTasksExceeded
 		}
 	}
 	cr.pendingTasks = append(cr.pendingTasks, task)
 	cr.existTasks[tid] = task
-	cr.pendingTaskCount[task.name]++
+	cr.pendingTaskCount[name]++
 	return nil
 }
 

--- a/pkg/ratelimit/runner.go
+++ b/pkg/ratelimit/runner.go
@@ -81,6 +81,7 @@ type ConcurrentRunner struct {
 	pendingTaskCount   map[string]int
 	pendingTasks       []*Task
 	pendingHead        int
+	pendingLen         int
 	existTasks         map[taskID]*Task
 	maxWaitingDuration prometheus.Gauge
 }
@@ -174,11 +175,9 @@ func (cr *ConcurrentRunner) processPendingTasks() {
 		task := cr.pendingTasks[cr.pendingHead]
 		select {
 		case cr.taskChan <- task:
-			cr.pendingTasks[cr.pendingHead] = nil
-			cr.pendingHead++
 			cr.pendingTaskCount[task.name]--
 			delete(cr.existTasks, taskID{id: task.id, name: task.name})
-			cr.compactPendingTasks()
+			cr.popPendingTask()
 		default:
 		}
 		return
@@ -186,15 +185,56 @@ func (cr *ConcurrentRunner) processPendingTasks() {
 }
 
 func (cr *ConcurrentRunner) pendingTaskNum() int {
-	return len(cr.pendingTasks) - cr.pendingHead
+	return cr.pendingLen
 }
 
-// compactPendingTasks releases the consumed prefix and the high-water capacity
-// of the task index after a burst. It must be called with pendingMu held.
-func (cr *ConcurrentRunner) compactPendingTasks() {
-	pendingTaskNum := cr.pendingTaskNum()
-	if pendingTaskNum == 0 {
-		if cr.pendingHead >= initialCapacity {
+// pendingTaskAt returns a pending task by its FIFO offset. It must be called
+// with pendingMu held.
+func (cr *ConcurrentRunner) pendingTaskAt(offset int) *Task {
+	index := cr.pendingHead + offset
+	if index >= cap(cr.pendingTasks) {
+		index -= cap(cr.pendingTasks)
+	}
+	return cr.pendingTasks[index]
+}
+
+// pushPendingTask appends a task to the pending ring. It must be called with
+// pendingMu held.
+func (cr *ConcurrentRunner) pushPendingTask(task *Task) {
+	if cr.pendingLen == 0 {
+		cr.pendingTasks = append(cr.pendingTasks, task)
+		cr.pendingHead = 0
+		cr.pendingLen = 1
+		return
+	}
+	if cr.pendingLen == cap(cr.pendingTasks) {
+		capacity := max(initialCapacity, cr.pendingLen*2)
+		pendingTasks := make([]*Task, cr.pendingLen, capacity)
+		for i := range cr.pendingLen {
+			pendingTasks[i] = cr.pendingTaskAt(i)
+		}
+		cr.pendingTasks = pendingTasks
+		cr.pendingHead = 0
+	}
+
+	index := cr.pendingHead + cr.pendingLen
+	if index >= cap(cr.pendingTasks) {
+		index -= cap(cr.pendingTasks)
+	}
+	if index == len(cr.pendingTasks) {
+		cr.pendingTasks = append(cr.pendingTasks, task)
+	} else {
+		cr.pendingTasks[index] = task
+	}
+	cr.pendingLen++
+}
+
+// popPendingTask removes the FIFO head. It must be called with pendingMu held.
+func (cr *ConcurrentRunner) popPendingTask() {
+	cr.pendingTasks[cr.pendingHead] = nil
+	if cr.pendingLen == 1 {
+		cr.pendingLen = 0
+		if len(cr.pendingTasks) >= initialCapacity {
 			cr.resetPendingTasks(initialCapacity)
 		} else {
 			cr.pendingTasks = cr.pendingTasks[:0]
@@ -202,19 +242,11 @@ func (cr *ConcurrentRunner) compactPendingTasks() {
 		}
 		return
 	}
-	if cr.pendingHead < initialCapacity || cr.pendingHead < pendingTaskNum {
-		return
+	cr.pendingHead++
+	if cr.pendingHead == cap(cr.pendingTasks) {
+		cr.pendingHead = 0
 	}
-
-	capacity := max(initialCapacity, pendingTaskNum*2)
-	pendingTasks := make([]*Task, pendingTaskNum, capacity)
-	copy(pendingTasks, cr.pendingTasks[cr.pendingHead:])
-	cr.pendingTasks = pendingTasks
-	cr.pendingHead = 0
-	cr.existTasks = make(map[taskID]*Task, pendingTaskNum)
-	for _, task := range cr.pendingTasks {
-		cr.existTasks[taskID{id: task.id, name: task.name}] = task
-	}
+	cr.pendingLen--
 }
 
 // resetPendingTasks releases all pending task storage. It must be called with
@@ -223,6 +255,7 @@ func (cr *ConcurrentRunner) compactPendingTasks() {
 func (cr *ConcurrentRunner) resetPendingTasks(capacity int) {
 	cr.pendingTasks = make([]*Task, 0, capacity)
 	cr.pendingHead = 0
+	cr.pendingLen = 0
 	cr.existTasks = make(map[taskID]*Task)
 	for taskName := range cr.pendingTaskCount {
 		cr.pendingTaskCount[taskName] = 0
@@ -275,7 +308,7 @@ func (cr *ConcurrentRunner) RunTask(id uint64, name string, f func(context.Conte
 			return errs.ErrMaxWaitingTasksExceeded
 		}
 	}
-	cr.pendingTasks = append(cr.pendingTasks, task)
+	cr.pushPendingTask(task)
 	cr.existTasks[tid] = task
 	cr.pendingTaskCount[name]++
 	return nil

--- a/pkg/ratelimit/runner.go
+++ b/pkg/ratelimit/runner.go
@@ -253,7 +253,11 @@ func (cr *ConcurrentRunner) popPendingTask() {
 // pendingMu held. capacity is kept small during normal operation and zero when
 // the runner stops.
 func (cr *ConcurrentRunner) resetPendingTasks(capacity int) {
-	cr.pendingTasks = make([]*Task, 0, capacity)
+	if cap(cr.pendingTasks) == capacity {
+		cr.pendingTasks = cr.pendingTasks[:0]
+	} else {
+		cr.pendingTasks = make([]*Task, 0, capacity)
+	}
 	cr.pendingHead = 0
 	cr.pendingLen = 0
 	cr.existTasks = make(map[taskID]*Task)

--- a/pkg/ratelimit/runner_benchmark_test.go
+++ b/pkg/ratelimit/runner_benchmark_test.go
@@ -50,6 +50,7 @@ func BenchmarkConcurrentRunnerUniqueTask(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := range b.N {
+		<-runner.taskChan
 		if err := runner.RunTask(uint64(i+1), "unique", noop); err != nil {
 			b.Fatal(err)
 		}

--- a/pkg/ratelimit/runner_benchmark_test.go
+++ b/pkg/ratelimit/runner_benchmark_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ratelimit
+
+import (
+	"context"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func BenchmarkConcurrentRunnerDuplicateTask(b *testing.B) {
+	runner := NewConcurrentRunner("test", NewConcurrencyLimiter(1), time.Minute)
+	noop := func(context.Context) {}
+	if err := runner.RunTask(0, "duplicate", noop, WithRetained(true)); err != nil {
+		b.Fatal(err)
+	}
+	if err := runner.RunTask(1, "duplicate", noop, WithRetained(true)); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if err := runner.RunTask(1, "duplicate", noop, WithRetained(true)); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkConcurrentRunnerUniqueTask(b *testing.B) {
+	runner := NewConcurrentRunner("test", NewConcurrencyLimiter(1), time.Minute)
+	noop := func(context.Context) {}
+	if err := runner.RunTask(0, "unique", noop); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := range b.N {
+		if err := runner.RunTask(uint64(i+1), "unique", noop); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkConcurrentRunnerBurstRetention(b *testing.B) {
+	const taskCount = 20000
+	// Initialize the metric labels before measuring retained queue storage.
+	_ = NewConcurrentRunner("test", NewConcurrencyLimiter(1), time.Minute)
+	noop := func(context.Context) {}
+	var totalRetainedBytes uint64
+	for range b.N {
+		runtime.GC()
+		var before runtime.MemStats
+		runtime.ReadMemStats(&before)
+
+		runner := NewConcurrentRunner("test", NewConcurrencyLimiter(1), time.Minute)
+		if err := runner.RunTask(0, "burst", noop); err != nil {
+			b.Fatal(err)
+		}
+		for i := 1; i <= taskCount; i++ {
+			if err := runner.RunTask(uint64(i), "burst", noop); err != nil {
+				b.Fatal(err)
+			}
+		}
+		for len(runner.existTasks) > 0 {
+			<-runner.taskChan
+			runner.processPendingTasks()
+		}
+		<-runner.taskChan
+
+		runtime.GC()
+		var after runtime.MemStats
+		runtime.ReadMemStats(&after)
+		if after.HeapAlloc > before.HeapAlloc {
+			totalRetainedBytes += after.HeapAlloc - before.HeapAlloc
+		}
+		runtime.KeepAlive(runner)
+	}
+	b.ReportMetric(float64(totalRetainedBytes)/float64(b.N), "retained-B/op")
+}

--- a/pkg/ratelimit/runner_test.go
+++ b/pkg/ratelimit/runner_test.go
@@ -114,12 +114,13 @@ func TestConcurrentRunner(t *testing.T) {
 			runner.pendingMu.Lock()
 			defer runner.pendingMu.Unlock()
 			var originalSubmitted time.Time
-			for _, task := range runner.pendingTasks[runner.pendingHead:] {
+			for i := range runner.pendingTaskNum() {
+				task := runner.pendingTaskAt(i)
 				if task.id == 6 {
 					originalSubmitted = task.submittedAt
 				}
 			}
-			lastSubmitted := runner.pendingTasks[len(runner.pendingTasks)-1].submittedAt
+			lastSubmitted := runner.pendingTaskAt(runner.pendingTaskNum() - 1).submittedAt
 			return originalSubmitted, lastSubmitted
 		}()
 		require.Less(t, originalSubmitted, lastSubmitted)
@@ -151,9 +152,9 @@ func TestConcurrentRunner(t *testing.T) {
 		require.NoError(t, runner.RunTask(2, "test4", func(context.Context) {}))
 
 		originalSubmitted := time.Now().Add(-2 * time.Second)
-		runner.pendingTasks[runner.pendingHead].submittedAt = originalSubmitted
+		runner.pendingTaskAt(0).submittedAt = originalSubmitted
 		require.NoError(t, runner.RunTask(2, "test4", func(context.Context) {}))
-		require.Equal(t, originalSubmitted, runner.pendingTasks[runner.pendingHead].submittedAt)
+		require.Equal(t, originalSubmitted, runner.pendingTaskAt(0).submittedAt)
 		require.ErrorIs(
 			t,
 			runner.RunTask(3, "test4", func(context.Context) {}),
@@ -179,7 +180,7 @@ func TestConcurrentRunner(t *testing.T) {
 		require.Equal(t, runner.maxPendingTaskNum, runner.pendingTaskNum())
 	})
 
-	t.Run("CompactPendingTasks", func(t *testing.T) {
+	t.Run("ReleasePendingStorage", func(t *testing.T) {
 		runner := NewConcurrentRunner("test", NewConcurrencyLimiter(1), time.Minute)
 		require.NoError(t, runner.RunTask(0, "test6", func(context.Context) {}))
 		for i := 1; i <= initialCapacity*2; i++ {
@@ -193,6 +194,39 @@ func TestConcurrentRunner(t *testing.T) {
 		}
 		<-runner.taskChan
 		require.Empty(t, runner.pendingTasks)
+		require.Equal(t, initialCapacity, cap(runner.pendingTasks))
+		require.Empty(t, runner.existTasks)
+	})
+
+	t.Run("ReusePendingStorage", func(t *testing.T) {
+		runner := NewConcurrentRunner("test", NewConcurrencyLimiter(1), time.Minute)
+		require.NoError(t, runner.RunTask(0, "test7", func(context.Context) {}))
+		for i := 1; i <= initialCapacity; i++ {
+			require.NoError(t, runner.RunTask(uint64(i), "test7", func(context.Context) {}))
+		}
+
+		storage := &runner.pendingTasks[0]
+		for range initialCapacity / 2 {
+			<-runner.taskChan
+			runner.processPendingTasks()
+		}
+		for i := initialCapacity + 1; i <= initialCapacity+initialCapacity/2; i++ {
+			require.NoError(t, runner.RunTask(uint64(i), "test7", func(context.Context) {}))
+		}
+
+		require.Equal(t, initialCapacity, runner.pendingTaskNum())
+		require.Equal(t, initialCapacity, cap(runner.pendingTasks))
+		require.Same(t, storage, &runner.pendingTasks[0])
+		require.Equal(t, uint64(initialCapacity/2+1), runner.pendingTaskAt(0).id)
+		require.Equal(t, uint64(initialCapacity+initialCapacity/2), runner.pendingTaskAt(runner.pendingTaskNum()-1).id)
+		require.Len(t, runner.existTasks, initialCapacity)
+
+		for id := initialCapacity / 2; id <= initialCapacity+initialCapacity/2; id++ {
+			task := <-runner.taskChan
+			require.Equal(t, uint64(id), task.id)
+			runner.processPendingTasks()
+		}
+		require.Zero(t, runner.pendingTaskNum())
 		require.Equal(t, initialCapacity, cap(runner.pendingTasks))
 		require.Empty(t, runner.existTasks)
 	})

--- a/pkg/ratelimit/runner_test.go
+++ b/pkg/ratelimit/runner_test.go
@@ -21,6 +21,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/tikv/pd/pkg/errs"
 )
 
 func TestConcurrentRunner(t *testing.T) {
@@ -108,13 +110,65 @@ func TestConcurrentRunner(t *testing.T) {
 			time.Sleep(1 * time.Millisecond)
 		}
 
-		var updatedSubmitted time.Time
-		for _, task := range runner.pendingTasks {
+		var originalSubmitted time.Time
+		for _, task := range runner.pendingTasks[runner.pendingHead:] {
 			if task.id == 6 {
-				updatedSubmitted = task.submittedAt
+				originalSubmitted = task.submittedAt
 			}
 		}
 		lastSubmitted := runner.pendingTasks[len(runner.pendingTasks)-1].submittedAt
-		require.Greater(t, updatedSubmitted, lastSubmitted)
+		require.Less(t, originalSubmitted, lastSubmitted)
+	})
+
+	t.Run("DuplicatedTaskKeepsQueueAge", func(t *testing.T) {
+		runner := NewConcurrentRunner("test", NewConcurrencyLimiter(1), time.Second)
+		require.NoError(t, runner.RunTask(1, "test4", func(context.Context) {}))
+		require.NoError(t, runner.RunTask(2, "test4", func(context.Context) {}))
+
+		originalSubmitted := time.Now().Add(-2 * time.Second)
+		runner.pendingTasks[runner.pendingHead].submittedAt = originalSubmitted
+		require.NoError(t, runner.RunTask(2, "test4", func(context.Context) {}))
+		require.Equal(t, originalSubmitted, runner.pendingTasks[runner.pendingHead].submittedAt)
+		require.ErrorIs(
+			t,
+			runner.RunTask(3, "test4", func(context.Context) {}),
+			errs.ErrMaxWaitingTasksExceeded,
+		)
+	})
+
+	t.Run("MaxPendingTasks", func(t *testing.T) {
+		runner := NewConcurrentRunner("test", NewConcurrencyLimiter(1), time.Minute)
+		runner.maxPendingTaskNum = 3
+		require.NoError(t, runner.RunTask(0, "test5", func(context.Context) {}))
+		for i := 1; i <= runner.maxPendingTaskNum; i++ {
+			require.NoError(t, runner.RunTask(uint64(i), "test5", func(context.Context) {}))
+		}
+
+		require.Equal(t, runner.maxPendingTaskNum, runner.pendingTaskNum())
+		require.NoError(t, runner.RunTask(1, "test5", func(context.Context) {}))
+		require.ErrorIs(
+			t,
+			runner.RunTask(4, "test5", func(context.Context) {}, WithRetained(true)),
+			errs.ErrMaxWaitingTasksExceeded,
+		)
+		require.Equal(t, runner.maxPendingTaskNum, runner.pendingTaskNum())
+	})
+
+	t.Run("CompactPendingTasks", func(t *testing.T) {
+		runner := NewConcurrentRunner("test", NewConcurrencyLimiter(1), time.Minute)
+		require.NoError(t, runner.RunTask(0, "test6", func(context.Context) {}))
+		for i := 1; i <= initialCapacity*2; i++ {
+			require.NoError(t, runner.RunTask(uint64(i), "test6", func(context.Context) {}))
+		}
+		require.Greater(t, cap(runner.pendingTasks), initialCapacity)
+
+		for runner.pendingTaskNum() > 0 {
+			<-runner.taskChan
+			runner.processPendingTasks()
+		}
+		<-runner.taskChan
+		require.Empty(t, runner.pendingTasks)
+		require.Equal(t, initialCapacity, cap(runner.pendingTasks))
+		require.Empty(t, runner.existTasks)
 	})
 }

--- a/pkg/ratelimit/runner_test.go
+++ b/pkg/ratelimit/runner_test.go
@@ -110,14 +110,39 @@ func TestConcurrentRunner(t *testing.T) {
 			time.Sleep(1 * time.Millisecond)
 		}
 
-		var originalSubmitted time.Time
-		for _, task := range runner.pendingTasks[runner.pendingHead:] {
-			if task.id == 6 {
-				originalSubmitted = task.submittedAt
+		originalSubmitted, lastSubmitted := func() (time.Time, time.Time) {
+			runner.pendingMu.Lock()
+			defer runner.pendingMu.Unlock()
+			var originalSubmitted time.Time
+			for _, task := range runner.pendingTasks[runner.pendingHead:] {
+				if task.id == 6 {
+					originalSubmitted = task.submittedAt
+				}
 			}
-		}
-		lastSubmitted := runner.pendingTasks[len(runner.pendingTasks)-1].submittedAt
+			lastSubmitted := runner.pendingTasks[len(runner.pendingTasks)-1].submittedAt
+			return originalSubmitted, lastSubmitted
+		}()
 		require.Less(t, originalSubmitted, lastSubmitted)
+	})
+
+	t.Run("DuplicatedTaskBeforeDispatch", func(t *testing.T) {
+		runner := NewConcurrentRunner("test", NewConcurrencyLimiter(1), time.Minute)
+		require.NoError(t, runner.RunTask(0, "test4", func(context.Context) {}))
+
+		oldCalls := 0
+		newCalls := 0
+		require.NoError(t, runner.RunTask(1, "test4", func(context.Context) { oldCalls++ }))
+
+		// Reproduce the state where the channel task has been consumed while
+		// another task with the duplicated ID is still pending.
+		<-runner.taskChan
+		require.NoError(t, runner.RunTask(1, "test4", func(context.Context) { newCalls++ }))
+
+		task := <-runner.taskChan
+		task.f(context.Background())
+		require.Zero(t, oldCalls)
+		require.Equal(t, 1, newCalls)
+		require.Zero(t, runner.pendingTaskNum())
 	})
 
 	t.Run("DuplicatedTaskKeepsQueueAge", func(t *testing.T) {

--- a/pkg/ratelimit/runner_test.go
+++ b/pkg/ratelimit/runner_test.go
@@ -229,5 +229,9 @@ func TestConcurrentRunner(t *testing.T) {
 		require.Zero(t, runner.pendingTaskNum())
 		require.Equal(t, initialCapacity, cap(runner.pendingTasks))
 		require.Empty(t, runner.existTasks)
+
+		require.NoError(t, runner.RunTask(initialCapacity*2, "test7", func(context.Context) {}))
+		require.NoError(t, runner.RunTask(initialCapacity*2+1, "test7", func(context.Context) {}))
+		require.Same(t, storage, &runner.pendingTasks[0])
 	})
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #11164

`ConcurrentRunner` allocates before duplicate coalescing and retains queue/index capacity after bursts. It can also dispatch a pending task before replacing its duplicate, allowing both callbacks to run.

### What is changed and how does it work?

- Coalesce pending duplicates before allocation and dispatch.
- Preserve the original queue age and compact consumed queue/index storage.
- Keep the existing 20,000,000 pending-task limit unchanged.

```commit-message
Reduce ConcurrentRunner allocation and retained queue storage.
```

### Check List

- Unit and race tests
- `make check`
- Duplicate submissions: `64 B/op, 1 alloc/op` → `0 B/op, 0 alloc/op`
- Retained storage after a 20,000-task burst: `1.51 MB` → `0.10 MB`

This change does not reduce peak memory for a live backlog of unique tasks.

### Release note

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved concurrent task queue processing and memory efficiency.
  * Added benchmarks for duplicate tasks, unique tasks, and burst workloads.

* **Bug Fixes**
  * Improved duplicate-task dispatch and queue-order preservation.
  * Strengthened pending-task limit enforcement and related error handling.
  * Reduced retained storage after queued work is processed.

* **Tests**
  * Expanded coverage for queue behavior, storage reuse, task limits, and concurrent processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->