### PR TITLE
statistics: reduce hot cache task memory retention

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -37,25 +37,7 @@ type Cluster interface {
 
 // HandleStatsAsync handles the flow asynchronously.
 func HandleStatsAsync(c Cluster, region *core.RegionInfo) {
-	checkWritePeerTask := func(cache *statistics.HotPeerCache) {
-		reportInterval := region.GetInterval()
-		interval := reportInterval.GetEndTimestamp() - reportInterval.GetStartTimestamp()
-		stats := cache.CheckPeerFlow(region, region.GetPeers(), region.GetWriteLoads(), interval)
-		for _, stat := range stats {
-			cache.UpdateStat(stat)
-		}
-	}
-
-	checkExpiredTask := func(cache *statistics.HotPeerCache) {
-		expiredStats := cache.CollectExpiredItems(region)
-		for _, stat := range expiredStats {
-			cache.UpdateStat(stat)
-		}
-	}
-
-	c.GetHotStat().CheckWriteAsync(checkExpiredTask)
-	c.GetHotStat().CheckReadAsync(checkExpiredTask)
-	c.GetHotStat().CheckWriteAsync(checkWritePeerTask)
+	c.GetHotStat().CheckRegionFlowAsync(region)
 	c.GetCoordinator().GetSchedulersController().CheckTransferWitnessLeader(region)
 }
 

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -1,0 +1,90 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pingcap/kvproto/pkg/metapb"
+
+	"github.com/tikv/pd/pkg/core"
+	"github.com/tikv/pd/pkg/mock/mockcluster"
+	"github.com/tikv/pd/pkg/mock/mockconfig"
+	"github.com/tikv/pd/pkg/schedule"
+	"github.com/tikv/pd/pkg/schedule/hbstream"
+	"github.com/tikv/pd/pkg/statistics"
+	"github.com/tikv/pd/pkg/statistics/utils"
+)
+
+type hotCacheBenchmarkCluster struct {
+	*mockcluster.Cluster
+	coordinator *schedule.Coordinator
+}
+
+func newHotCacheBenchmarkCluster(ctx context.Context) *hotCacheBenchmarkCluster {
+	cluster := mockcluster.NewCluster(ctx, mockconfig.NewTestOptions())
+	return &hotCacheBenchmarkCluster{
+		Cluster:     cluster,
+		coordinator: schedule.NewCoordinator(ctx, cluster, hbstream.NewTestHeartbeatStreams(ctx, cluster, true)),
+	}
+}
+
+func (c *hotCacheBenchmarkCluster) GetHotStat() *statistics.HotStat {
+	return c.HotStat
+}
+
+func (*hotCacheBenchmarkCluster) GetRegionStats() *statistics.RegionStatistics {
+	return nil
+}
+
+func (*hotCacheBenchmarkCluster) GetLabelStats() *statistics.LabelStatistics {
+	return nil
+}
+
+func (c *hotCacheBenchmarkCluster) GetCoordinator() *schedule.Coordinator {
+	return c.coordinator
+}
+
+func BenchmarkHandleStatsAsync(b *testing.B) {
+	ctx, cancel := context.WithCancel(context.Background())
+	b.Cleanup(cancel)
+	cluster := newHotCacheBenchmarkCluster(ctx)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := range b.N {
+		HandleStatsAsync(cluster, newHotCacheBenchmarkRegion(uint64(i+1)))
+	}
+	cluster.GetHotStat().GetHotPeerStats(utils.Write, 0)
+	cluster.GetHotStat().GetHotPeerStats(utils.Read, 0)
+}
+
+func newHotCacheBenchmarkRegion(regionID uint64) *core.RegionInfo {
+	peers := []*metapb.Peer{
+		{Id: regionID*10 + 1, StoreId: 1},
+		{Id: regionID*10 + 2, StoreId: 2},
+		{Id: regionID*10 + 3, StoreId: 3},
+	}
+	return core.NewRegionInfo(
+		&metapb.Region{
+			Id:          regionID,
+			RegionEpoch: &metapb.RegionEpoch{ConfVer: 1, Version: 1},
+			Peers:       peers,
+		},
+		peers[0],
+		core.SetReportInterval(0, utils.RegionHeartBeatReportInterval),
+	)
+}

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -19,9 +19,10 @@ import (
 	"fmt"
 	"testing"
 
+	"go.uber.org/zap/zapcore"
+
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/log"
-	"go.uber.org/zap/zapcore"
 
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/mock/mockcluster"
@@ -64,7 +65,7 @@ func (c *hotCacheBenchmarkCluster) GetCoordinator() *schedule.Coordinator {
 func BenchmarkHandleStatsAsync(b *testing.B) {
 	for _, peerCount := range []int{1, 3, 5} {
 		b.Run(fmt.Sprintf("%d-peers", peerCount), func(b *testing.B) {
-			benchmarkHandleStatsAsync(b, peerCount, 0)
+			runHandleStatsAsyncBenchmark(b, peerCount, 0)
 		})
 	}
 }
@@ -72,12 +73,12 @@ func BenchmarkHandleStatsAsync(b *testing.B) {
 func BenchmarkHandleStatsAsyncSteady(b *testing.B) {
 	for _, peerCount := range []int{1, 3, 5} {
 		b.Run(fmt.Sprintf("%d-peers", peerCount), func(b *testing.B) {
-			benchmarkHandleStatsAsync(b, peerCount, 64)
+			runHandleStatsAsyncBenchmark(b, peerCount, 64)
 		})
 	}
 }
 
-func benchmarkHandleStatsAsync(b *testing.B, peerCount, drainEvery int) {
+func runHandleStatsAsyncBenchmark(b *testing.B, peerCount, drainEvery int) {
 	log.SetLevel(zapcore.FatalLevel)
 	ctx, cancel := context.WithCancel(context.Background())
 	b.Cleanup(cancel)

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -16,9 +16,12 @@ package cluster
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/log"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/mock/mockcluster"
@@ -59,6 +62,23 @@ func (c *hotCacheBenchmarkCluster) GetCoordinator() *schedule.Coordinator {
 }
 
 func BenchmarkHandleStatsAsync(b *testing.B) {
+	for _, peerCount := range []int{1, 3, 5} {
+		b.Run(fmt.Sprintf("%d-peers", peerCount), func(b *testing.B) {
+			benchmarkHandleStatsAsync(b, peerCount, 0)
+		})
+	}
+}
+
+func BenchmarkHandleStatsAsyncSteady(b *testing.B) {
+	for _, peerCount := range []int{1, 3, 5} {
+		b.Run(fmt.Sprintf("%d-peers", peerCount), func(b *testing.B) {
+			benchmarkHandleStatsAsync(b, peerCount, 64)
+		})
+	}
+}
+
+func benchmarkHandleStatsAsync(b *testing.B, peerCount, drainEvery int) {
+	log.SetLevel(zapcore.FatalLevel)
 	ctx, cancel := context.WithCancel(context.Background())
 	b.Cleanup(cancel)
 	cluster := newHotCacheBenchmarkCluster(ctx)
@@ -66,17 +86,20 @@ func BenchmarkHandleStatsAsync(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := range b.N {
-		HandleStatsAsync(cluster, newHotCacheBenchmarkRegion(uint64(i+1)))
+		HandleStatsAsync(cluster, newHotCacheBenchmarkRegion(uint64(i+1), peerCount))
+		if drainEvery > 0 && (i+1)%drainEvery == 0 {
+			cluster.GetHotStat().GetHotPeerStats(utils.Write, 0)
+			cluster.GetHotStat().GetHotPeerStats(utils.Read, 0)
+		}
 	}
 	cluster.GetHotStat().GetHotPeerStats(utils.Write, 0)
 	cluster.GetHotStat().GetHotPeerStats(utils.Read, 0)
 }
 
-func newHotCacheBenchmarkRegion(regionID uint64) *core.RegionInfo {
-	peers := []*metapb.Peer{
-		{Id: regionID*10 + 1, StoreId: 1},
-		{Id: regionID*10 + 2, StoreId: 2},
-		{Id: regionID*10 + 3, StoreId: 3},
+func newHotCacheBenchmarkRegion(regionID uint64, peerCount int) *core.RegionInfo {
+	peers := make([]*metapb.Peer, peerCount)
+	for i := range peerCount {
+		peers[i] = &metapb.Peer{Id: regionID*10 + uint64(i+1), StoreId: uint64(i + 1)}
 	}
 	return core.NewRegionInfo(
 		&metapb.Region{

--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -593,11 +593,11 @@ func (c *Cluster) HandleStoreHeartbeat(heartbeat *schedulingpb.StoreHeartbeatReq
 	reportInterval := stats.GetInterval()
 	interval := reportInterval.GetEndTimestamp() - reportInterval.GetStartTimestamp()
 
-	regions := make(map[uint64]*core.RegionInfo, len(stats.GetPeerStats()))
+	reportedRegions := make(map[uint64]struct{}, len(stats.GetPeerStats()))
 	for _, peerStat := range stats.GetPeerStats() {
 		regionID := peerStat.GetRegionId()
 		region := c.GetRegion(regionID)
-		regions[regionID] = region
+		reportedRegions[regionID] = struct{}{}
 		if region == nil {
 			log.Warn("discard hot peer stat for unknown region",
 				zap.Uint64("region-id", regionID),
@@ -623,23 +623,11 @@ func (c *Cluster) HandleStoreHeartbeat(heartbeat *schedulingpb.StoreHeartbeatReq
 			utils.RegionReadCPU:       regionReadCPU * float64(interval),
 			utils.RegionWriteCPU:      0,
 		}
-		checkReadPeerTask := func(cache *statistics.HotPeerCache) {
-			stats := cache.CheckPeerFlow(region, []*metapb.Peer{peer}, loads, interval)
-			for _, stat := range stats {
-				cache.UpdateStat(stat)
-			}
-		}
-		c.hotStat.CheckReadAsync(checkReadPeerTask)
+		c.hotStat.CheckReadPeerAsync(region, peer, loads, interval)
 	}
 
 	// Here we will compare the reported regions with the previous hot peers to decide if it is still hot.
-	collectUnReportedPeerTask := func(cache *statistics.HotPeerCache) {
-		stats := cache.CheckColdPeer(storeID, regions, interval)
-		for _, stat := range stats {
-			cache.UpdateStat(stat)
-		}
-	}
-	c.hotStat.CheckReadAsync(collectUnReportedPeerTask)
+	c.hotStat.CheckColdPeerAsync(storeID, reportedRegions, interval)
 	return nil
 }
 

--- a/pkg/statistics/hot_cache.go
+++ b/pkg/statistics/hot_cache.go
@@ -73,6 +73,77 @@ func (w *HotCache) CheckReadAsync(task func(cache *HotPeerCache)) bool {
 	}
 }
 
+// CheckRegionFlowAsync checks the expired read and write items and the write
+// flow for a region asynchronously. It preserves the original task count and
+// enqueue order while keeping only the fields used by HotPeerCache.
+func (w *HotCache) CheckRegionFlowAsync(region *core.RegionInfo) {
+	checkExpiredTask, checkWritePeerTask := newRegionFlowTasks(region)
+	w.CheckWriteAsync(checkExpiredTask)
+	w.CheckReadAsync(checkExpiredTask)
+	w.CheckWriteAsync(checkWritePeerTask)
+}
+
+func newRegionFlowTasks(region *core.RegionInfo) (checkExpiredTask, checkWritePeerTask func(*HotPeerCache)) {
+	regionInfo := newHotRegionInfo(region)
+	reportInterval := region.GetInterval()
+	interval := reportInterval.GetEndTimestamp() - reportInterval.GetStartTimestamp()
+	writtenBytes := region.GetBytesWritten()
+	writtenKeys := region.GetKeysWritten()
+	writeQueryNum := region.GetWriteQueryNum()
+	return newExpiredRegionTask(regionInfo), newWriteRegionTask(regionInfo, interval, writtenBytes, writtenKeys, writeQueryNum)
+}
+
+func newExpiredRegionTask(regionInfo *hotRegionInfo) func(*HotPeerCache) {
+	return func(cache *HotPeerCache) {
+		expiredStats := cache.collectExpiredItemsForRegion(regionInfo)
+		for _, stat := range expiredStats {
+			cache.UpdateStat(stat)
+		}
+	}
+}
+
+func newWriteRegionTask(regionInfo *hotRegionInfo, interval, writtenBytes, writtenKeys, writeQueryNum uint64) func(*HotPeerCache) {
+	return func(cache *HotPeerCache) {
+		var loads [utils.RegionStatCount]float64
+		loads[utils.RegionWriteBytes] = float64(writtenBytes)
+		loads[utils.RegionWriteKeys] = float64(writtenKeys)
+		loads[utils.RegionWriteQueryNum] = float64(writeQueryNum)
+		stats := cache.checkPeerFlowForRegion(regionInfo, nil, loads[:], interval)
+		for _, stat := range stats {
+			cache.UpdateStat(stat)
+		}
+	}
+}
+
+// CheckReadPeerAsync checks the read flow for one peer asynchronously without
+// retaining the complete RegionInfo or Peer in the pending task.
+func (w *HotCache) CheckReadPeerAsync(region *core.RegionInfo, peer *metapb.Peer, loads []float64, interval uint64) bool {
+	return w.CheckReadAsync(newReadPeerTask(region, peer, loads, interval))
+}
+
+func newReadPeerTask(region *core.RegionInfo, peer *metapb.Peer, loads []float64, interval uint64) func(*HotPeerCache) {
+	regionInfo := newHotRegionInfo(region)
+	storeID := peer.GetStoreId()
+	return func(cache *HotPeerCache) {
+		stats := cache.checkPeerFlowForRegion(regionInfo, []uint64{storeID}, loads, interval)
+		for _, stat := range stats {
+			cache.UpdateStat(stat)
+		}
+	}
+}
+
+// CheckColdPeerAsync checks peers missing from a store heartbeat
+// asynchronously. The pending task only keeps the reported region IDs.
+func (w *HotCache) CheckColdPeerAsync(storeID uint64, reportedRegions map[uint64]struct{}, interval uint64) bool {
+	checkColdPeerTask := func(cache *HotPeerCache) {
+		stats := cache.checkColdPeerByRegionIDs(storeID, reportedRegions, interval)
+		for _, stat := range stats {
+			cache.UpdateStat(stat)
+		}
+	}
+	return w.CheckReadAsync(checkColdPeerTask)
+}
+
 // GetHotPeerStats returns hot peer stats for the specified kind (read/write).
 // It returns a map where the keys are store IDs and the values are slices of HotPeerStat.
 func (w *HotCache) GetHotPeerStats(kind utils.RWType, minHotDegree int) map[uint64][]*HotPeerStat {

--- a/pkg/statistics/hot_cache.go
+++ b/pkg/statistics/hot_cache.go
@@ -83,6 +83,9 @@ func (w *HotCache) CheckRegionFlowAsync(region *core.RegionInfo) {
 }
 
 func newRegionFlowTasks(region *core.RegionInfo) (checkExpiredTask, checkWritePeerTask func(*HotPeerCache)) {
+	// Preserve the original one-peer fast path so this optimization doesn't add
+	// task-construction overhead to single-peer regions. The common multi-peer
+	// path below avoids retaining the complete RegionInfo.
 	if len(region.GetPeers()) <= 1 {
 		checkExpiredTask = func(cache *HotPeerCache) {
 			expiredStats := cache.CollectExpiredItems(region)

--- a/pkg/statistics/hot_cache.go
+++ b/pkg/statistics/hot_cache.go
@@ -83,30 +83,6 @@ func (w *HotCache) CheckRegionFlowAsync(region *core.RegionInfo) {
 }
 
 func newRegionFlowTasks(region *core.RegionInfo) (checkExpiredTask, checkWritePeerTask func(*HotPeerCache)) {
-	// Preserve the original one-peer fast path so this optimization doesn't add
-	// task-construction overhead to single-peer regions. The common multi-peer
-	// path below avoids retaining the complete RegionInfo.
-	if len(region.GetPeers()) <= 1 {
-		checkExpiredTask = func(cache *HotPeerCache) {
-			expiredStats := cache.CollectExpiredItems(region)
-			for _, stat := range expiredStats {
-				cache.UpdateStat(stat)
-			}
-		}
-		checkWritePeerTask = func(cache *HotPeerCache) {
-			reportInterval := region.GetInterval()
-			interval := reportInterval.GetEndTimestamp() - reportInterval.GetStartTimestamp()
-			var loads [utils.RegionStatCount]float64
-			loads[utils.RegionWriteBytes] = float64(region.GetBytesWritten())
-			loads[utils.RegionWriteKeys] = float64(region.GetKeysWritten())
-			loads[utils.RegionWriteQueryNum] = float64(region.GetWriteQueryNum())
-			stats := cache.CheckPeerFlow(region, region.GetPeers(), loads[:], interval)
-			for _, stat := range stats {
-				cache.UpdateStat(stat)
-			}
-		}
-		return checkExpiredTask, checkWritePeerTask
-	}
 	regionInfo := hotRegionInfo{
 		meta:          region.GetMeta(),
 		leaderStoreID: region.GetLeader().GetStoreId(),

--- a/pkg/statistics/hot_cache.go
+++ b/pkg/statistics/hot_cache.go
@@ -74,8 +74,7 @@ func (w *HotCache) CheckReadAsync(task func(cache *HotPeerCache)) bool {
 }
 
 // CheckRegionFlowAsync checks the expired read and write items and the write
-// flow for a region asynchronously. It preserves the original task count and
-// enqueue order while keeping only the fields used by HotPeerCache.
+// flow for a region asynchronously while retaining only immutable metadata.
 func (w *HotCache) CheckRegionFlowAsync(region *core.RegionInfo) {
 	checkExpiredTask, checkWritePeerTask := newRegionFlowTasks(region)
 	w.CheckWriteAsync(checkExpiredTask)
@@ -84,31 +83,64 @@ func (w *HotCache) CheckRegionFlowAsync(region *core.RegionInfo) {
 }
 
 func newRegionFlowTasks(region *core.RegionInfo) (checkExpiredTask, checkWritePeerTask func(*HotPeerCache)) {
-	regionInfo := newHotRegionInfo(region)
+	if len(region.GetPeers()) <= 1 {
+		checkExpiredTask = func(cache *HotPeerCache) {
+			expiredStats := cache.CollectExpiredItems(region)
+			for _, stat := range expiredStats {
+				cache.UpdateStat(stat)
+			}
+		}
+		checkWritePeerTask = func(cache *HotPeerCache) {
+			reportInterval := region.GetInterval()
+			interval := reportInterval.GetEndTimestamp() - reportInterval.GetStartTimestamp()
+			var loads [utils.RegionStatCount]float64
+			loads[utils.RegionWriteBytes] = float64(region.GetBytesWritten())
+			loads[utils.RegionWriteKeys] = float64(region.GetKeysWritten())
+			loads[utils.RegionWriteQueryNum] = float64(region.GetWriteQueryNum())
+			stats := cache.CheckPeerFlow(region, region.GetPeers(), loads[:], interval)
+			for _, stat := range stats {
+				cache.UpdateStat(stat)
+			}
+		}
+		return checkExpiredTask, checkWritePeerTask
+	}
+	regionInfo := hotRegionInfo{
+		meta:          region.GetMeta(),
+		leaderStoreID: region.GetLeader().GetStoreId(),
+	}
 	reportInterval := region.GetInterval()
 	interval := reportInterval.GetEndTimestamp() - reportInterval.GetStartTimestamp()
 	writtenBytes := region.GetBytesWritten()
 	writtenKeys := region.GetKeysWritten()
 	writeQueryNum := region.GetWriteQueryNum()
-	return newExpiredRegionTask(regionInfo), newWriteRegionTask(regionInfo, interval, writtenBytes, writtenKeys, writeQueryNum)
+	return newExpiredRegionTask(regionInfo.meta), newWriteRegionTask(
+		regionInfo.meta,
+		regionInfo.leaderStoreID,
+		interval,
+		writtenBytes,
+		writtenKeys,
+		writeQueryNum,
+	)
 }
 
-func newExpiredRegionTask(regionInfo *hotRegionInfo) func(*HotPeerCache) {
+func newExpiredRegionTask(meta *metapb.Region) func(*HotPeerCache) {
 	return func(cache *HotPeerCache) {
-		expiredStats := cache.collectExpiredItemsForRegion(regionInfo)
+		regionInfo := hotRegionInfo{meta: meta}
+		expiredStats := cache.collectExpiredItemsForRegion(&regionInfo)
 		for _, stat := range expiredStats {
 			cache.UpdateStat(stat)
 		}
 	}
 }
 
-func newWriteRegionTask(regionInfo *hotRegionInfo, interval, writtenBytes, writtenKeys, writeQueryNum uint64) func(*HotPeerCache) {
+func newWriteRegionTask(meta *metapb.Region, leaderStoreID, interval, writtenBytes, writtenKeys, writeQueryNum uint64) func(*HotPeerCache) {
 	return func(cache *HotPeerCache) {
+		regionInfo := hotRegionInfo{meta: meta, leaderStoreID: leaderStoreID}
 		var loads [utils.RegionStatCount]float64
 		loads[utils.RegionWriteBytes] = float64(writtenBytes)
 		loads[utils.RegionWriteKeys] = float64(writtenKeys)
 		loads[utils.RegionWriteQueryNum] = float64(writeQueryNum)
-		stats := cache.checkPeerFlowForRegion(regionInfo, nil, loads[:], interval)
+		stats := cache.checkPeerFlowForRegion(&regionInfo, nil, loads[:], interval)
 		for _, stat := range stats {
 			cache.UpdateStat(stat)
 		}
@@ -122,10 +154,12 @@ func (w *HotCache) CheckReadPeerAsync(region *core.RegionInfo, peer *metapb.Peer
 }
 
 func newReadPeerTask(region *core.RegionInfo, peer *metapb.Peer, loads []float64, interval uint64) func(*HotPeerCache) {
-	regionInfo := newHotRegionInfo(region)
+	meta := region.GetMeta()
+	leaderStoreID := region.GetLeader().GetStoreId()
 	storeID := peer.GetStoreId()
 	return func(cache *HotPeerCache) {
-		stats := cache.checkPeerFlowForRegion(regionInfo, []uint64{storeID}, loads, interval)
+		regionInfo := hotRegionInfo{meta: meta, leaderStoreID: leaderStoreID}
+		stats := cache.checkPeerFlowForRegion(&regionInfo, []uint64{storeID}, loads, interval)
 		for _, stat := range stats {
 			cache.UpdateStat(stat)
 		}

--- a/pkg/statistics/hot_cache_test.go
+++ b/pkg/statistics/hot_cache_test.go
@@ -16,10 +16,13 @@ package statistics
 
 import (
 	"context"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
+
+	"github.com/pingcap/kvproto/pkg/metapb"
 
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/statistics/utils"
@@ -49,4 +52,84 @@ func TestIsHot(t *testing.T) {
 			re.True(cache.IsRegionHot(region, 1))
 		}
 	}
+}
+
+func BenchmarkPendingRegionHeartbeatTasks(b *testing.B) {
+	b.Run("retain-region-info", func(b *testing.B) {
+		runPendingRegionHeartbeatTaskBenchmark(b, newRetainedRegionFlowTasks)
+	})
+	b.Run("compact-region-info", func(b *testing.B) {
+		runPendingRegionHeartbeatTaskBenchmark(b, newRegionFlowTasks)
+	})
+}
+
+func runPendingRegionHeartbeatTaskBenchmark(
+	b *testing.B,
+	newTasks func(*core.RegionInfo) (func(*HotPeerCache), func(*HotPeerCache)),
+) {
+	const maxPendingHeartbeats = 16 * 1024
+	pending := make([][3]func(*HotPeerCache), min(b.N, maxPendingHeartbeats))
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := range b.N {
+		region := newBenchmarkRegion(uint64(i + 1))
+		checkExpiredTask, checkWritePeerTask := newTasks(region)
+		pending[i%len(pending)] = [3]func(*HotPeerCache){
+			checkExpiredTask,
+			checkExpiredTask,
+			checkWritePeerTask,
+		}
+	}
+	b.StopTimer()
+
+	runtime.GC()
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+	retainedBytes := max(int64(after.HeapAlloc)-int64(before.HeapAlloc), 0)
+	b.ReportMetric(float64(retainedBytes)/float64(len(pending)), "retained-B/heartbeat")
+	b.ReportMetric(float64(retainedBytes)/float64(len(pending)*3), "retained-B/task")
+	runtime.KeepAlive(pending)
+}
+
+func newRetainedRegionFlowTasks(region *core.RegionInfo) (checkExpiredTask, checkWritePeerTask func(*HotPeerCache)) {
+	checkExpiredTask = func(cache *HotPeerCache) {
+		expiredStats := cache.CollectExpiredItems(region)
+		for _, stat := range expiredStats {
+			cache.UpdateStat(stat)
+		}
+	}
+	checkWritePeerTask = func(cache *HotPeerCache) {
+		reportInterval := region.GetInterval()
+		interval := reportInterval.GetEndTimestamp() - reportInterval.GetStartTimestamp()
+		stats := cache.CheckPeerFlow(region, region.GetPeers(), region.GetWriteLoads(), interval)
+		for _, stat := range stats {
+			cache.UpdateStat(stat)
+		}
+	}
+	return checkExpiredTask, checkWritePeerTask
+}
+
+func newBenchmarkRegion(regionID uint64) *core.RegionInfo {
+	peers := []*metapb.Peer{
+		{Id: regionID*10 + 1, StoreId: 1},
+		{Id: regionID*10 + 2, StoreId: 2},
+		{Id: regionID*10 + 3, StoreId: 3},
+	}
+	return core.NewRegionInfo(
+		&metapb.Region{
+			Id:          regionID,
+			StartKey:    make([]byte, 32),
+			EndKey:      make([]byte, 32),
+			RegionEpoch: &metapb.RegionEpoch{ConfVer: 1, Version: 1},
+			Peers:       peers,
+		},
+		peers[0],
+		core.SetWrittenBytes(1<<20),
+		core.SetWrittenKeys(1024),
+		core.SetReportInterval(0, utils.RegionHeartBeatReportInterval),
+	)
 }

--- a/pkg/statistics/hot_cache_test.go
+++ b/pkg/statistics/hot_cache_test.go
@@ -55,6 +55,29 @@ func TestIsHot(t *testing.T) {
 	}
 }
 
+func TestRegionFlowTasksMatchOriginalForAnyPeerCount(t *testing.T) {
+	for _, peerCount := range []int{0, 1, 2, 3, 5, 9} {
+		t.Run(fmt.Sprintf("%d-peers", peerCount), func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			originalCache := NewHotPeerCache(ctx, core.NewBasicCluster(), utils.Write)
+			compactCache := NewHotPeerCache(ctx, core.NewBasicCluster(), utils.Write)
+			region := newBenchmarkRegion(1, peerCount)
+
+			originalExpired, originalWrite := newOriginalRegionFlowTasks(region)
+			compactExpired, compactWrite := newRegionFlowTasks(region)
+			originalExpired(originalCache)
+			originalWrite(originalCache)
+			compactExpired(compactCache)
+			compactWrite(compactCache)
+
+			require.Equal(t, originalCache.GetHotPeerStats(0), compactCache.GetHotPeerStats(0))
+			require.Equal(t, originalCache.storesOfRegion, compactCache.storesOfRegion)
+			require.Equal(t, originalCache.regionsOfStore, compactCache.regionsOfStore)
+		})
+	}
+}
+
 func BenchmarkPendingRegionHeartbeatTasks(b *testing.B) {
 	for _, peerCount := range []int{1, 3, 5} {
 		b.Run(fmt.Sprintf("%d-peers", peerCount), func(b *testing.B) {
@@ -124,6 +147,10 @@ func newBenchmarkRegion(regionID uint64, peerCount int) *core.RegionInfo {
 	for i := range peerCount {
 		peers[i] = &metapb.Peer{Id: regionID*10 + uint64(i+1), StoreId: uint64(i + 1)}
 	}
+	var leader *metapb.Peer
+	if len(peers) > 0 {
+		leader = peers[0]
+	}
 	return core.NewRegionInfo(
 		&metapb.Region{
 			Id:          regionID,
@@ -132,7 +159,7 @@ func newBenchmarkRegion(regionID uint64, peerCount int) *core.RegionInfo {
 			RegionEpoch: &metapb.RegionEpoch{ConfVer: 1, Version: 1},
 			Peers:       peers,
 		},
-		peers[0],
+		leader,
 		core.SetWrittenBytes(1<<20),
 		core.SetWrittenKeys(1024),
 		core.SetReportInterval(0, utils.RegionHeartBeatReportInterval),

--- a/pkg/statistics/hot_cache_test.go
+++ b/pkg/statistics/hot_cache_test.go
@@ -60,8 +60,29 @@ func TestRegionFlowTasksMatchOriginalForAnyPeerCount(t *testing.T) {
 		t.Run(fmt.Sprintf("%d-peers", peerCount), func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			originalCache := NewHotPeerCache(ctx, core.NewBasicCluster(), utils.Write)
-			compactCache := NewHotPeerCache(ctx, core.NewBasicCluster(), utils.Write)
+			previousRegion := newBenchmarkRegion(1, peerCount+1)
+			newCache := func() *HotPeerCache {
+				cluster := core.NewBasicCluster()
+				for _, peer := range previousRegion.GetPeers() {
+					cluster.PutStore(core.NewStoreInfo(&metapb.Store{Id: peer.GetStoreId()}))
+				}
+				return NewHotPeerCache(ctx, cluster, utils.Write)
+			}
+			originalCache := newCache()
+			compactCache := newCache()
+
+			_, seedWrite := newOriginalRegionFlowTasks(previousRegion)
+			seedWrite(originalCache)
+			seedWrite(compactCache)
+			originalStats := originalCache.GetHotPeerStats(0)
+			compactStats := compactCache.GetHotPeerStats(0)
+			require.Len(t, originalStats, peerCount+1)
+			require.Len(t, compactStats, peerCount+1)
+			for _, peer := range previousRegion.GetPeers() {
+				require.NotEmpty(t, originalStats[peer.GetStoreId()])
+				require.NotEmpty(t, compactStats[peer.GetStoreId()])
+			}
+
 			region := newBenchmarkRegion(1, peerCount)
 
 			originalExpired, originalWrite := newOriginalRegionFlowTasks(region)
@@ -71,9 +92,21 @@ func TestRegionFlowTasksMatchOriginalForAnyPeerCount(t *testing.T) {
 			compactExpired(compactCache)
 			compactWrite(compactCache)
 
-			require.Equal(t, originalCache.GetHotPeerStats(0), compactCache.GetHotPeerStats(0))
+			originalStats = originalCache.GetHotPeerStats(0)
+			compactStats = compactCache.GetHotPeerStats(0)
+			require.Equal(t, originalStats, compactStats)
 			require.Equal(t, originalCache.storesOfRegion, compactCache.storesOfRegion)
 			require.Equal(t, originalCache.regionsOfStore, compactCache.regionsOfStore)
+
+			expiredStoreID := uint64(peerCount + 1)
+			require.Empty(t, originalStats[expiredStoreID])
+			require.Empty(t, compactStats[expiredStoreID])
+			require.Nil(t, originalCache.getHotPeerStat(region.GetID(), expiredStoreID))
+			require.Nil(t, compactCache.getHotPeerStat(region.GetID(), expiredStoreID))
+			for _, peer := range region.GetPeers() {
+				require.NotEmpty(t, originalStats[peer.GetStoreId()])
+				require.NotEmpty(t, compactStats[peer.GetStoreId()])
+			}
 		})
 	}
 }

--- a/pkg/statistics/hot_cache_test.go
+++ b/pkg/statistics/hot_cache_test.go
@@ -16,6 +16,7 @@ package statistics
 
 import (
 	"context"
+	"fmt"
 	"runtime"
 	"testing"
 
@@ -55,16 +56,21 @@ func TestIsHot(t *testing.T) {
 }
 
 func BenchmarkPendingRegionHeartbeatTasks(b *testing.B) {
-	b.Run("retain-region-info", func(b *testing.B) {
-		runPendingRegionHeartbeatTaskBenchmark(b, newRetainedRegionFlowTasks)
-	})
-	b.Run("compact-region-info", func(b *testing.B) {
-		runPendingRegionHeartbeatTaskBenchmark(b, newRegionFlowTasks)
-	})
+	for _, peerCount := range []int{1, 3, 5} {
+		b.Run(fmt.Sprintf("%d-peers", peerCount), func(b *testing.B) {
+			b.Run("retain-region-info", func(b *testing.B) {
+				runPendingRegionHeartbeatTaskBenchmark(b, peerCount, newOriginalRegionFlowTasks)
+			})
+			b.Run("retain-region-meta", func(b *testing.B) {
+				runPendingRegionHeartbeatTaskBenchmark(b, peerCount, newRegionFlowTasks)
+			})
+		})
+	}
 }
 
 func runPendingRegionHeartbeatTaskBenchmark(
 	b *testing.B,
+	peerCount int,
 	newTasks func(*core.RegionInfo) (func(*HotPeerCache), func(*HotPeerCache)),
 ) {
 	const maxPendingHeartbeats = 16 * 1024
@@ -76,7 +82,7 @@ func runPendingRegionHeartbeatTaskBenchmark(
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := range b.N {
-		region := newBenchmarkRegion(uint64(i + 1))
+		region := newBenchmarkRegion(uint64(i+1), peerCount)
 		checkExpiredTask, checkWritePeerTask := newTasks(region)
 		pending[i%len(pending)] = [3]func(*HotPeerCache){
 			checkExpiredTask,
@@ -95,7 +101,7 @@ func runPendingRegionHeartbeatTaskBenchmark(
 	runtime.KeepAlive(pending)
 }
 
-func newRetainedRegionFlowTasks(region *core.RegionInfo) (checkExpiredTask, checkWritePeerTask func(*HotPeerCache)) {
+func newOriginalRegionFlowTasks(region *core.RegionInfo) (checkExpiredTask, checkWritePeerTask func(*HotPeerCache)) {
 	checkExpiredTask = func(cache *HotPeerCache) {
 		expiredStats := cache.CollectExpiredItems(region)
 		for _, stat := range expiredStats {
@@ -113,11 +119,10 @@ func newRetainedRegionFlowTasks(region *core.RegionInfo) (checkExpiredTask, chec
 	return checkExpiredTask, checkWritePeerTask
 }
 
-func newBenchmarkRegion(regionID uint64) *core.RegionInfo {
-	peers := []*metapb.Peer{
-		{Id: regionID*10 + 1, StoreId: 1},
-		{Id: regionID*10 + 2, StoreId: 2},
-		{Id: regionID*10 + 3, StoreId: 3},
+func newBenchmarkRegion(regionID uint64, peerCount int) *core.RegionInfo {
+	peers := make([]*metapb.Peer, peerCount)
+	for i := range peerCount {
+		peers[i] = &metapb.Peer{Id: regionID*10 + uint64(i+1), StoreId: uint64(i + 1)}
 	}
 	return core.NewRegionInfo(
 		&metapb.Region{

--- a/pkg/statistics/hot_peer_cache.go
+++ b/pkg/statistics/hot_peer_cache.go
@@ -69,40 +69,32 @@ type thresholds struct {
 	metrics     [utils.DimLen + 1]prometheus.Gauge // 0 is for byte, 1 is for key, 2 is for query, 3 is for cpu, 4 is for total length.
 }
 
-// hotRegionInfo contains only the immutable region fields used by HotPeerCache.
-// Keeping this compact snapshot in asynchronous tasks avoids retaining the
-// complete RegionInfo until the tasks are consumed.
+// hotRegionInfo references only the immutable region metadata used by
+// HotPeerCache. Asynchronous tasks can retain it without keeping the much
+// larger RegionInfo and its heartbeat statistics alive.
 type hotRegionInfo struct {
-	id               uint64
-	leaderStoreID    uint64
-	storeCount       int
-	inlineStoreIDs   [3]uint64 // Avoid an extra allocation for the common three-replica case.
-	overflowStoreIDs []uint64
+	meta          *metapb.Region
+	leaderStoreID uint64
 }
 
 func newHotRegionInfo(region *core.RegionInfo) *hotRegionInfo {
-	peers := region.GetPeers()
-	info := hotRegionInfo{
-		id:            region.GetID(),
+	return &hotRegionInfo{
+		meta:          region.GetMeta(),
 		leaderStoreID: region.GetLeader().GetStoreId(),
-		storeCount:    len(peers),
 	}
-	if len(peers) > len(info.inlineStoreIDs) {
-		info.overflowStoreIDs = make([]uint64, len(peers)-len(info.inlineStoreIDs))
-	}
-	for i, peer := range peers {
-		if i < len(info.inlineStoreIDs) {
-			info.inlineStoreIDs[i] = peer.GetStoreId()
-		} else {
-			info.overflowStoreIDs[i-len(info.inlineStoreIDs)] = peer.GetStoreId()
-		}
-	}
-	return &info
+}
+
+func (r *hotRegionInfo) id() uint64 {
+	return r.meta.GetId()
+}
+
+func (r *hotRegionInfo) storeCount() int {
+	return len(r.meta.GetPeers())
 }
 
 func (r *hotRegionInfo) containsStore(storeID uint64) bool {
-	for i := range r.storeCount {
-		if r.storeID(i) == storeID {
+	for _, peer := range r.meta.GetPeers() {
+		if peer.GetStoreId() == storeID {
 			return true
 		}
 	}
@@ -110,10 +102,7 @@ func (r *hotRegionInfo) containsStore(storeID uint64) bool {
 }
 
 func (r *hotRegionInfo) storeID(i int) uint64 {
-	if i < len(r.inlineStoreIDs) {
-		return r.inlineStoreIDs[i]
-	}
-	return r.overflowStoreIDs[i-len(r.inlineStoreIDs)]
+	return r.meta.GetPeers()[i].GetStoreId()
 }
 
 // HotPeerCache saves the hot peer's statistics.
@@ -199,7 +188,7 @@ func (f *HotPeerCache) CollectExpiredItems(region *core.RegionInfo) []*HotPeerSt
 }
 
 func (f *HotPeerCache) collectExpiredItemsForRegion(region *hotRegionInfo) []*HotPeerStat {
-	regionID := region.id
+	regionID := region.id()
 	items := make([]*HotPeerStat, 0)
 	if ids, ok := f.storesOfRegion[regionID]; ok {
 		for storeID := range ids {
@@ -235,11 +224,11 @@ func (f *HotPeerCache) checkPeerFlowForRegion(region *hotRegionInfo, peerStoreID
 		return nil
 	}
 
-	regionID := region.id
+	regionID := region.id()
 
 	peerCount := len(peerStoreIDs)
 	if peerStoreIDs == nil {
-		peerCount = region.storeCount
+		peerCount = region.storeCount()
 	}
 	stats := make([]*HotPeerStat, 0, peerCount)
 	for i := range peerCount {
@@ -263,13 +252,7 @@ func (f *HotPeerCache) checkPeerFlowForRegion(region *hotRegionInfo, peerStoreID
 		// check whether the peer is allowed to be inherited
 		source := utils.Direct
 		if oldItem == nil {
-			for _, storeID := range f.getAllStoreIDs(region) {
-				oldItem = f.getOldHotPeerStat(regionID, storeID)
-				if oldItem != nil && oldItem.allowInherited {
-					source = utils.Inherit
-					break
-				}
-			}
+			oldItem, source = f.findOldHotPeerStatForInheritance(region)
 		}
 		// check new item whether is hot
 		if oldItem == nil {
@@ -289,9 +272,9 @@ func (f *HotPeerCache) checkPeerFlowForRegion(region *hotRegionInfo, peerStoreID
 			Loads:      f.kind.GetLoadRates(deltaLoads, interval),
 			isLeader:   region.leaderStoreID == storeID,
 			actionType: utils.Update,
-			stores:     make([]uint64, region.storeCount),
+			stores:     make([]uint64, region.storeCount()),
 		}
-		for i := range region.storeCount {
+		for i := range region.storeCount() {
 			newItem.stores[i] = region.storeID(i)
 		}
 		if oldItem == nil {
@@ -417,32 +400,28 @@ func (f *HotPeerCache) calcHotThresholds(storeID uint64) []float64 {
 	return t.rates
 }
 
-// gets the storeIDs, including old region and new region
-func (f *HotPeerCache) getAllStoreIDs(region *hotRegionInfo) []uint64 {
-	ret := make([]uint64, 0, region.storeCount)
-	isInSlice := func(id uint64) bool {
-		for _, storeID := range ret {
-			if storeID == id {
-				return true
-			}
-		}
-		return false
-	}
-	// old stores
-	if ids, ok := f.storesOfRegion[region.id]; ok {
-		for storeID := range ids {
-			ret = append(ret, storeID)
+// findOldHotPeerStatForInheritance preserves getAllStoreIDs' lookup order
+// without allocating its temporary store-ID slice.
+func (f *HotPeerCache) findOldHotPeerStatForInheritance(region *hotRegionInfo) (*HotPeerStat, utils.SourceKind) {
+	oldStoreIDs := f.storesOfRegion[region.id()]
+	var oldItem *HotPeerStat
+	for storeID := range oldStoreIDs {
+		oldItem = f.getOldHotPeerStat(region.id(), storeID)
+		if oldItem != nil && oldItem.allowInherited {
+			return oldItem, utils.Inherit
 		}
 	}
-	// new stores
-	for i := range region.storeCount {
-		storeID := region.storeID(i)
-		if isInSlice(storeID) {
+	for _, peer := range region.meta.GetPeers() {
+		storeID := peer.GetStoreId()
+		if _, ok := oldStoreIDs[storeID]; ok {
 			continue
 		}
-		ret = append(ret, storeID)
+		oldItem = f.getOldHotPeerStat(region.id(), storeID)
+		if oldItem != nil && oldItem.allowInherited {
+			return oldItem, utils.Inherit
+		}
 	}
-	return ret
+	return oldItem, utils.Direct
 }
 
 func (f *HotPeerCache) isOldColdPeer(oldItem *HotPeerStat, storeID uint64) bool {
@@ -472,10 +451,10 @@ func (f *HotPeerCache) justTransferLeader(region *hotRegionInfo, oldItem *HotPee
 	if oldItem.isLeader { // old item is not nil according to the function
 		return oldItem.StoreID != region.leaderStoreID
 	}
-	ids, ok := f.storesOfRegion[region.id]
+	ids, ok := f.storesOfRegion[region.id()]
 	if ok {
 		for storeID := range ids {
-			oldItem := f.getOldHotPeerStat(region.id, storeID)
+			oldItem := f.getOldHotPeerStat(region.id(), storeID)
 			if oldItem == nil {
 				continue
 			}

--- a/pkg/statistics/hot_peer_cache.go
+++ b/pkg/statistics/hot_peer_cache.go
@@ -69,6 +69,53 @@ type thresholds struct {
 	metrics     [utils.DimLen + 1]prometheus.Gauge // 0 is for byte, 1 is for key, 2 is for query, 3 is for cpu, 4 is for total length.
 }
 
+// hotRegionInfo contains only the immutable region fields used by HotPeerCache.
+// Keeping this compact snapshot in asynchronous tasks avoids retaining the
+// complete RegionInfo until the tasks are consumed.
+type hotRegionInfo struct {
+	id               uint64
+	leaderStoreID    uint64
+	storeCount       int
+	inlineStoreIDs   [3]uint64 // Avoid an extra allocation for the common three-replica case.
+	overflowStoreIDs []uint64
+}
+
+func newHotRegionInfo(region *core.RegionInfo) *hotRegionInfo {
+	peers := region.GetPeers()
+	info := hotRegionInfo{
+		id:            region.GetID(),
+		leaderStoreID: region.GetLeader().GetStoreId(),
+		storeCount:    len(peers),
+	}
+	if len(peers) > len(info.inlineStoreIDs) {
+		info.overflowStoreIDs = make([]uint64, len(peers)-len(info.inlineStoreIDs))
+	}
+	for i, peer := range peers {
+		if i < len(info.inlineStoreIDs) {
+			info.inlineStoreIDs[i] = peer.GetStoreId()
+		} else {
+			info.overflowStoreIDs[i-len(info.inlineStoreIDs)] = peer.GetStoreId()
+		}
+	}
+	return &info
+}
+
+func (r *hotRegionInfo) containsStore(storeID uint64) bool {
+	for i := range r.storeCount {
+		if r.storeID(i) == storeID {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *hotRegionInfo) storeID(i int) uint64 {
+	if i < len(r.inlineStoreIDs) {
+		return r.inlineStoreIDs[i]
+	}
+	return r.overflowStoreIDs[i-len(r.inlineStoreIDs)]
+}
+
 // HotPeerCache saves the hot peer's statistics.
 type HotPeerCache struct {
 	kind              utils.RWType
@@ -147,11 +194,16 @@ func (f *HotPeerCache) incMetrics(action utils.ActionType, storeID uint64) {
 
 // CollectExpiredItems collects expired items, mark them as needDelete and puts them into inherit items
 func (f *HotPeerCache) CollectExpiredItems(region *core.RegionInfo) []*HotPeerStat {
-	regionID := region.GetID()
+	regionInfo := newHotRegionInfo(region)
+	return f.collectExpiredItemsForRegion(regionInfo)
+}
+
+func (f *HotPeerCache) collectExpiredItemsForRegion(region *hotRegionInfo) []*HotPeerStat {
+	regionID := region.id
 	items := make([]*HotPeerStat, 0)
 	if ids, ok := f.storesOfRegion[regionID]; ok {
 		for storeID := range ids {
-			if region.GetStorePeer(storeID) == nil {
+			if !region.containsStore(storeID) {
 				item := f.getOldHotPeerStat(regionID, storeID)
 				if item != nil {
 					item.actionType = utils.Remove
@@ -170,13 +222,31 @@ func (f *HotPeerCache) CheckPeerFlow(region *core.RegionInfo, peers []*metapb.Pe
 	if isDenoisingEnabled() && interval < HotRegionReportMinInterval { // for test or simulator purpose
 		return nil
 	}
+	peerStoreIDs := make([]uint64, len(peers))
+	for i, peer := range peers {
+		peerStoreIDs[i] = peer.GetStoreId()
+	}
+	regionInfo := newHotRegionInfo(region)
+	return f.checkPeerFlowForRegion(regionInfo, peerStoreIDs, deltaLoads, interval)
+}
 
-	regionID := region.GetID()
+func (f *HotPeerCache) checkPeerFlowForRegion(region *hotRegionInfo, peerStoreIDs []uint64, deltaLoads []float64, interval uint64) []*HotPeerStat {
+	if isDenoisingEnabled() && interval < HotRegionReportMinInterval { // for test or simulator purpose
+		return nil
+	}
 
-	regionPeers := region.GetPeers()
-	stats := make([]*HotPeerStat, 0, len(peers))
-	for _, peer := range peers {
-		storeID := peer.GetStoreId()
+	regionID := region.id
+
+	peerCount := len(peerStoreIDs)
+	if peerStoreIDs == nil {
+		peerCount = region.storeCount
+	}
+	stats := make([]*HotPeerStat, 0, peerCount)
+	for i := range peerCount {
+		storeID := region.storeID(i)
+		if peerStoreIDs != nil {
+			storeID = peerStoreIDs[i]
+		}
 		// A tombstoned store can still show up as a peer here: the leader reporting
 		// this region may not have caught up with a raft config change removing it
 		// yet. Skip it so gc() cleaning up its entries at bury time doesn't get
@@ -215,12 +285,12 @@ func (f *HotPeerCache) CheckPeerFlow(region *core.RegionInfo, peers []*metapb.Pe
 			StoreID:    storeID,
 			RegionID:   regionID,
 			Loads:      f.kind.GetLoadRates(deltaLoads, interval),
-			isLeader:   region.GetLeader().GetStoreId() == storeID,
+			isLeader:   region.leaderStoreID == storeID,
 			actionType: utils.Update,
-			stores:     make([]uint64, len(regionPeers)),
+			stores:     make([]uint64, region.storeCount),
 		}
-		for i, peer := range regionPeers {
-			newItem.stores[i] = peer.GetStoreId()
+		for i := range region.storeCount {
+			newItem.stores[i] = region.storeID(i)
 		}
 		if oldItem == nil {
 			stats = append(stats, f.updateNewHotPeerStat(newItem, deltaLoads, time.Duration(interval)*time.Second))
@@ -233,6 +303,14 @@ func (f *HotPeerCache) CheckPeerFlow(region *core.RegionInfo, peers []*metapb.Pe
 
 // CheckColdPeer checks the collect the un-heartbeat peer and maintain it.
 func (f *HotPeerCache) CheckColdPeer(storeID uint64, reportRegions map[uint64]*core.RegionInfo, interval uint64) (ret []*HotPeerStat) {
+	return checkColdPeerForReportedRegions(f, storeID, reportRegions, interval)
+}
+
+func (f *HotPeerCache) checkColdPeerByRegionIDs(storeID uint64, reportedRegions map[uint64]struct{}, interval uint64) (ret []*HotPeerStat) {
+	return checkColdPeerForReportedRegions(f, storeID, reportedRegions, interval)
+}
+
+func checkColdPeerForReportedRegions[T any](f *HotPeerCache, storeID uint64, reportedRegions map[uint64]T, interval uint64) (ret []*HotPeerStat) {
 	// for test or simulator purpose
 	if isDenoisingEnabled() && interval < HotRegionReportMinInterval {
 		return
@@ -245,7 +323,7 @@ func (f *HotPeerCache) CheckColdPeer(storeID uint64, reportRegions map[uint64]*c
 	// Check if the original hot regions are still reported by the store heartbeat.
 	for regionID := range previousHotStat {
 		// If it's not reported, we need to update the original information.
-		if region, ok := reportRegions[regionID]; !ok {
+		if _, ok := reportedRegions[regionID]; !ok {
 			oldItem := f.getOldHotPeerStat(regionID, storeID)
 			// The region is not hot in the store, do nothing.
 			if oldItem == nil {
@@ -269,7 +347,7 @@ func (f *HotPeerCache) CheckColdPeer(storeID uint64, reportRegions map[uint64]*c
 			for i, loads := range thresholds {
 				deltaLoads[i] = loads * float64(interval)
 			}
-			stat := f.updateHotPeerStat(region, newItem, oldItem, deltaLoads, time.Duration(interval)*time.Second, source)
+			stat := f.updateHotPeerStat(nil, newItem, oldItem, deltaLoads, time.Duration(interval)*time.Second, source)
 			if stat != nil {
 				ret = append(ret, stat)
 			}
@@ -338,9 +416,8 @@ func (f *HotPeerCache) calcHotThresholds(storeID uint64) []float64 {
 }
 
 // gets the storeIDs, including old region and new region
-func (f *HotPeerCache) getAllStoreIDs(region *core.RegionInfo) []uint64 {
-	regionPeers := region.GetPeers()
-	ret := make([]uint64, 0, len(regionPeers))
+func (f *HotPeerCache) getAllStoreIDs(region *hotRegionInfo) []uint64 {
+	ret := make([]uint64, 0, region.storeCount)
 	isInSlice := func(id uint64) bool {
 		for _, storeID := range ret {
 			if storeID == id {
@@ -350,14 +427,14 @@ func (f *HotPeerCache) getAllStoreIDs(region *core.RegionInfo) []uint64 {
 		return false
 	}
 	// old stores
-	if ids, ok := f.storesOfRegion[region.GetID()]; ok {
+	if ids, ok := f.storesOfRegion[region.id]; ok {
 		for storeID := range ids {
 			ret = append(ret, storeID)
 		}
 	}
 	// new stores
-	for _, peer := range regionPeers {
-		storeID := peer.GetStoreId()
+	for i := range region.storeCount {
+		storeID := region.storeID(i)
 		if isInSlice(storeID) {
 			continue
 		}
@@ -386,22 +463,22 @@ func (f *HotPeerCache) isOldColdPeer(oldItem *HotPeerStat, storeID uint64) bool 
 	return isOldPeer() && !isInHotCache()
 }
 
-func (f *HotPeerCache) justTransferLeader(region *core.RegionInfo, oldItem *HotPeerStat) bool {
+func (f *HotPeerCache) justTransferLeader(region *hotRegionInfo, oldItem *HotPeerStat) bool {
 	if region == nil {
 		return false
 	}
 	if oldItem.isLeader { // old item is not nil according to the function
-		return oldItem.StoreID != region.GetLeader().GetStoreId()
+		return oldItem.StoreID != region.leaderStoreID
 	}
-	ids, ok := f.storesOfRegion[region.GetID()]
+	ids, ok := f.storesOfRegion[region.id]
 	if ok {
 		for storeID := range ids {
-			oldItem := f.getOldHotPeerStat(region.GetID(), storeID)
+			oldItem := f.getOldHotPeerStat(region.id, storeID)
 			if oldItem == nil {
 				continue
 			}
 			if oldItem.isLeader {
-				return oldItem.StoreID != region.GetLeader().GetStoreId()
+				return oldItem.StoreID != region.leaderStoreID
 			}
 		}
 	}
@@ -436,7 +513,7 @@ func (f *HotPeerCache) getHotPeerStat(regionID, storeID uint64) *HotPeerStat {
 	return nil
 }
 
-func (f *HotPeerCache) updateHotPeerStat(region *core.RegionInfo, newItem, oldItem *HotPeerStat, deltaLoads []float64, interval time.Duration, source utils.SourceKind) *HotPeerStat {
+func (f *HotPeerCache) updateHotPeerStat(region *hotRegionInfo, newItem, oldItem *HotPeerStat, deltaLoads []float64, interval time.Duration, source utils.SourceKind) *HotPeerStat {
 	regionStats := f.kind.RegionStats()
 
 	if source == utils.Inherit {

--- a/pkg/statistics/hot_peer_cache.go
+++ b/pkg/statistics/hot_peer_cache.go
@@ -243,8 +243,10 @@ func (f *HotPeerCache) checkPeerFlowForRegion(region *hotRegionInfo, peerStoreID
 	}
 	stats := make([]*HotPeerStat, 0, peerCount)
 	for i := range peerCount {
-		storeID := region.storeID(i)
-		if peerStoreIDs != nil {
+		var storeID uint64
+		if peerStoreIDs == nil {
+			storeID = region.storeID(i)
+		} else {
 			storeID = peerStoreIDs[i]
 		}
 		// A tombstoned store can still show up as a peer here: the leader reporting

--- a/pkg/statistics/hot_peer_cache.go
+++ b/pkg/statistics/hot_peer_cache.go
@@ -411,9 +411,20 @@ func (f *HotPeerCache) findOldHotPeerStatForInheritance(region *hotRegionInfo) (
 			return oldItem, utils.Inherit
 		}
 	}
-	for _, peer := range region.meta.GetPeers() {
+	peers := region.meta.GetPeers()
+	for i, peer := range peers {
 		storeID := peer.GetStoreId()
 		if _, ok := oldStoreIDs[storeID]; ok {
+			continue
+		}
+		seen := false
+		for _, previousPeer := range peers[:i] {
+			if previousPeer.GetStoreId() == storeID {
+				seen = true
+				break
+			}
+		}
+		if seen {
 			continue
 		}
 		oldItem = f.getOldHotPeerStat(region.id(), storeID)

--- a/pkg/statistics/hot_peer_cache_test.go
+++ b/pkg/statistics/hot_peer_cache_test.go
@@ -101,6 +101,72 @@ func TestCheckPeerFlowWithMoreExplicitPeersThanRegionPeers(t *testing.T) {
 	re.Len(stats, len(peers))
 }
 
+func TestFindOldHotPeerStatForInheritance(t *testing.T) {
+	const regionID uint64 = 100
+	newCache := func() *HotPeerCache {
+		return &HotPeerCache{
+			peersOfStore:   make(map[uint64]*utils.TopN),
+			storesOfRegion: make(map[uint64]map[uint64]struct{}),
+		}
+	}
+	putPeer := func(cache *HotPeerCache, storeID uint64, allowInherited bool) *HotPeerStat {
+		stat := &HotPeerStat{
+			StoreID:        storeID,
+			RegionID:       regionID,
+			Loads:          make([]float64, utils.DimLen),
+			allowInherited: allowInherited,
+		}
+		peers := utils.NewTopN(utils.DimLen, TopNN, time.Minute)
+		peers.Put(stat)
+		cache.peersOfStore[storeID] = peers
+		return stat
+	}
+	newRegion := func(storeIDs ...uint64) *hotRegionInfo {
+		peers := make([]*metapb.Peer, len(storeIDs))
+		for i, storeID := range storeIDs {
+			peers[i] = &metapb.Peer{StoreId: storeID}
+		}
+		return &hotRegionInfo{meta: &metapb.Region{Id: regionID, Peers: peers}}
+	}
+
+	t.Run("inherit-from-old-store", func(t *testing.T) {
+		cache := newCache()
+		want := putPeer(cache, 1, true)
+		cache.storesOfRegion[regionID] = map[uint64]struct{}{1: {}}
+		got, source := cache.findOldHotPeerStatForInheritance(newRegion(2))
+		require.Same(t, want, got)
+		require.Equal(t, utils.Inherit, source)
+	})
+
+	t.Run("inherit-from-new-store", func(t *testing.T) {
+		cache := newCache()
+		putPeer(cache, 1, false)
+		want := putPeer(cache, 2, true)
+		cache.storesOfRegion[regionID] = map[uint64]struct{}{1: {}}
+		got, source := cache.findOldHotPeerStatForInheritance(newRegion(2))
+		require.Same(t, want, got)
+		require.Equal(t, utils.Inherit, source)
+	})
+
+	t.Run("preserve-last-direct-item", func(t *testing.T) {
+		cache := newCache()
+		want := putPeer(cache, 1, false)
+		cache.storesOfRegion[regionID] = map[uint64]struct{}{1: {}}
+		got, source := cache.findOldHotPeerStatForInheritance(newRegion(1))
+		require.Same(t, want, got)
+		require.Equal(t, utils.Direct, source)
+	})
+
+	t.Run("preserve-final-miss", func(t *testing.T) {
+		cache := newCache()
+		putPeer(cache, 1, false)
+		cache.storesOfRegion[regionID] = map[uint64]struct{}{1: {}}
+		got, source := cache.findOldHotPeerStatForInheritance(newRegion(2))
+		require.Nil(t, got)
+		require.Equal(t, utils.Direct, source)
+	})
+}
+
 func orderingPeers(cache *HotPeerCache, region *core.RegionInfo) []*metapb.Peer {
 	var peers []*metapb.Peer
 	for _, peer := range region.GetPeers() {

--- a/pkg/statistics/hot_peer_cache_test.go
+++ b/pkg/statistics/hot_peer_cache_test.go
@@ -86,6 +86,21 @@ func TestCache(t *testing.T) {
 	}
 }
 
+func TestCheckPeerFlowWithMoreExplicitPeersThanRegionPeers(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cluster := core.NewBasicCluster()
+	cache := NewHotPeerCache(ctx, cluster, utils.Write)
+	region, err := buildRegion(cluster, utils.Write, 3, 60)
+	re.NoError(err)
+
+	peers := append([]*metapb.Peer{}, region.GetPeers()...)
+	peers = append(peers, &metapb.Peer{Id: 4, StoreId: 4})
+	stats := cache.CheckPeerFlow(region, peers, region.GetLoads(), 60)
+	re.Len(stats, len(peers))
+}
+
 func orderingPeers(cache *HotPeerCache, region *core.RegionInfo) []*metapb.Peer {
 	var peers []*metapb.Peer
 	for _, peer := range region.GetPeers() {

--- a/pkg/statistics/hot_peer_cache_test.go
+++ b/pkg/statistics/hot_peer_cache_test.go
@@ -95,10 +95,16 @@ func TestCheckPeerFlowWithMoreExplicitPeersThanRegionPeers(t *testing.T) {
 	region, err := buildRegion(cluster, utils.Write, 3, 60)
 	re.NoError(err)
 
+	peerID, _, err := getIDAllocator().Alloc(1)
+	re.NoError(err)
+	storeID, _, err := getIDAllocator().Alloc(1)
+	re.NoError(err)
+	re.Nil(region.GetStorePeer(storeID))
 	peers := append([]*metapb.Peer{}, region.GetPeers()...)
-	peers = append(peers, &metapb.Peer{Id: 4, StoreId: 4})
+	peers = append(peers, &metapb.Peer{Id: peerID, StoreId: storeID})
 	stats := cache.CheckPeerFlow(region, peers, region.GetLoads(), 60)
 	re.Len(stats, len(peers))
+	re.Equal(storeID, stats[len(stats)-1].StoreID)
 }
 
 func TestFindOldHotPeerStatForInheritance(t *testing.T) {

--- a/pkg/statistics/hot_peer_cache_test.go
+++ b/pkg/statistics/hot_peer_cache_test.go
@@ -171,6 +171,14 @@ func TestFindOldHotPeerStatForInheritance(t *testing.T) {
 		require.Nil(t, got)
 		require.Equal(t, utils.Direct, source)
 	})
+
+	t.Run("deduplicate-new-stores", func(t *testing.T) {
+		cache := newCache()
+		putPeer(cache, 2, false)
+		got, source := cache.findOldHotPeerStatForInheritance(newRegion(2, 3, 2))
+		require.Nil(t, got)
+		require.Equal(t, utils.Direct, source)
+	})
 }
 
 func orderingPeers(cache *HotPeerCache, region *core.RegionInfo) []*metapb.Peer {

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1212,8 +1212,8 @@ func (c *RaftCluster) HandleStoreHeartbeat(heartbeat *pdpb.StoreHeartbeatRequest
 	resp.State = store.GetNodeState()
 	c.PutStore(newStore, opts...)
 	var (
-		regions  map[uint64]*core.RegionInfo
-		interval uint64
+		reportedRegions map[uint64]struct{}
+		interval        uint64
 	)
 	if !c.IsServiceIndependent(constant.SchedulingServiceName) {
 		c.hotStat.Observe(storeID, newStore.GetStoreStats())
@@ -1222,11 +1222,11 @@ func (c *RaftCluster) HandleStoreHeartbeat(heartbeat *pdpb.StoreHeartbeatRequest
 		reportInterval := stats.GetInterval()
 		interval = reportInterval.GetEndTimestamp() - reportInterval.GetStartTimestamp()
 
-		regions = make(map[uint64]*core.RegionInfo, len(stats.GetPeerStats()))
+		reportedRegions = make(map[uint64]struct{}, len(stats.GetPeerStats()))
 		for _, peerStat := range stats.GetPeerStats() {
 			regionID := peerStat.GetRegionId()
 			region := c.GetRegion(regionID)
-			regions[regionID] = region
+			reportedRegions[regionID] = struct{}{}
 			if region == nil {
 				log.Warn("discard hot peer stat for unknown region",
 					zap.Uint64("region-id", regionID),
@@ -1252,13 +1252,7 @@ func (c *RaftCluster) HandleStoreHeartbeat(heartbeat *pdpb.StoreHeartbeatRequest
 				utils.RegionReadCPU:       regionReadCPU * float64(interval),
 				utils.RegionWriteCPU:      0,
 			}
-			checkReadPeerTask := func(cache *statistics.HotPeerCache) {
-				stats := cache.CheckPeerFlow(region, []*metapb.Peer{peer}, loads, interval)
-				for _, stat := range stats {
-					cache.UpdateStat(stat)
-				}
-			}
-			c.hotStat.CheckReadAsync(checkReadPeerTask)
+			c.hotStat.CheckReadPeerAsync(region, peer, loads, interval)
 		}
 	}
 	for _, stat := range stats.GetSnapshotStats() {
@@ -1281,13 +1275,7 @@ func (c *RaftCluster) HandleStoreHeartbeat(heartbeat *pdpb.StoreHeartbeatRequest
 	}
 	if !c.IsServiceIndependent(constant.SchedulingServiceName) {
 		// Here we will compare the reported regions with the previous hot peers to decide if it is still hot.
-		collectUnReportedPeerTask := func(cache *statistics.HotPeerCache) {
-			stats := cache.CheckColdPeer(storeID, regions, interval)
-			for _, stat := range stats {
-				cache.UpdateStat(stat)
-			}
-		}
-		c.hotStat.CheckReadAsync(collectUnReportedPeerTask)
+		c.hotStat.CheckColdPeerAsync(storeID, reportedRegions, interval)
 	}
 	c.adjustNetworkSlowStore(storeID)
 	return nil


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #11164

Pending HotCache tasks retain complete `RegionInfo` objects while waiting in the queue.

### What is changed and how does it work?

Retain only immutable region metadata and required counters for multi-peer heartbeat tasks. Keep the task count, order, queue limits, and hot-cache calculations unchanged.

Benchmarks for three replicas:

- Pending retention: 664 → 368 B/heartbeat (-45%).
- Steady path: 774 → 750 B/op, 20 → 17 allocs/op, with no runtime regression.

### Check List

- Unit test
- Affected benchmarks

### Release note

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved efficiency when processing hot-region, hot-peer, and cold-peer statistics.
  - Reduced memory retained during heartbeat processing.
  - Streamlined handling of reported and unreported regions during store heartbeats.

- **Bug Fixes**
  - Improved handling of peer statistics when reported peers differ from configured region peers.

- **Testing**
  - Added benchmarks for heartbeat-task memory retention and asynchronous statistics processing.
  - Added coverage for peer-statistics inheritance and processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->