### PR TITLE
server: report IA row storage size to metering

### DIFF
--- a/client/go.mod
+++ b/client/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86
-	github.com/pingcap/kvproto v0.0.0-20260810080205-543bb79c8a8a
+	github.com/pingcap/kvproto v0.0.0-20260903054228-107095f1d250
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3
 	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/client_model v0.6.1

--- a/client/go.sum
+++ b/client/go.sum
@@ -53,8 +53,8 @@ github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c h1:xpW9bvK+HuuTm
 github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c/go.mod h1:X2r9ueLEUZgtx2cIogM0v4Zj5uvvzhuuiu7Pn8HzMPg=
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 h1:tdMsjOqUR7YXHoBitzdebTvOjs/swniBTOLy5XiMtuE=
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86/go.mod h1:exzhVYca3WRtd6gclGNErRWb1qEgff3LYta0LvRmON4=
-github.com/pingcap/kvproto v0.0.0-20260810080205-543bb79c8a8a h1:FC9R8jnaSn7hr40qFf3WqaWKTz6njtOlZJQZ65/HAR4=
-github.com/pingcap/kvproto v0.0.0-20260810080205-543bb79c8a8a/go.mod h1:z6+aAHB7dBkA+LyinEX+48/ImRJ3jag0Hg0c7wkhEvE=
+github.com/pingcap/kvproto v0.0.0-20260903054228-107095f1d250 h1:6yUryXKVbKpCNdZWL58/OcZj8NPLUA/xsJYXSbsD59w=
+github.com/pingcap/kvproto v0.0.0-20260903054228-107095f1d250/go.mod h1:z6+aAHB7dBkA+LyinEX+48/ImRJ3jag0Hg0c7wkhEvE=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8IDP+SZrdhV1Kibl9KrHxJ9eciw=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/pingcap/errcode v0.3.0
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86
-	github.com/pingcap/kvproto v0.0.0-20260810080205-543bb79c8a8a
+	github.com/pingcap/kvproto v0.0.0-20260903054228-107095f1d250
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3
 	github.com/pingcap/metering_sdk v0.0.0-20260814062708-9e3b68cd9adf
 	github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21

--- a/go.sum
+++ b/go.sum
@@ -490,8 +490,8 @@ github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c/go.mod h1:X2r9ue
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 h1:tdMsjOqUR7YXHoBitzdebTvOjs/swniBTOLy5XiMtuE=
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86/go.mod h1:exzhVYca3WRtd6gclGNErRWb1qEgff3LYta0LvRmON4=
 github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
-github.com/pingcap/kvproto v0.0.0-20260810080205-543bb79c8a8a h1:FC9R8jnaSn7hr40qFf3WqaWKTz6njtOlZJQZ65/HAR4=
-github.com/pingcap/kvproto v0.0.0-20260810080205-543bb79c8a8a/go.mod h1:z6+aAHB7dBkA+LyinEX+48/ImRJ3jag0Hg0c7wkhEvE=
+github.com/pingcap/kvproto v0.0.0-20260903054228-107095f1d250 h1:6yUryXKVbKpCNdZWL58/OcZj8NPLUA/xsJYXSbsD59w=
+github.com/pingcap/kvproto v0.0.0-20260903054228-107095f1d250/go.mod h1:z6+aAHB7dBkA+LyinEX+48/ImRJ3jag0Hg0c7wkhEvE=
 github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7/go.mod h1:8AanEdAHATuRurdGxZXBz0At+9avep+ub7U1AGYLIMM=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8IDP+SZrdhV1Kibl9KrHxJ9eciw=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=

--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -720,7 +720,7 @@ func (r *RegionInfo) GetApproximateKvSize() int64 {
 	return r.approximateKvSize
 }
 
-// GetApproximateIAKvSize returns the approximate IA kv size of the region.
+// GetApproximateIAKvSize returns the approximate IA row-based logical KV size in MiB.
 func (r *RegionInfo) GetApproximateIAKvSize() int64 {
 	return r.approximateIAKvSize
 }

--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -994,7 +994,10 @@ func GenerateRegionGuideFunc(enableLog bool) RegionGuideFunc {
 				return
 			}
 			if region.GetApproximateSize() != origin.GetApproximateSize() ||
-				region.GetApproximateKeys() != origin.GetApproximateKeys() {
+				region.GetApproximateKeys() != origin.GetApproximateKeys() ||
+				region.GetApproximateKvSize() != origin.GetApproximateKvSize() ||
+				region.GetApproximateIAKvSize() != origin.GetApproximateIAKvSize() ||
+				region.GetApproximateColumnarKvSize() != origin.GetApproximateColumnarKvSize() {
 				saveCache = true
 				return
 			}

--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -83,6 +83,7 @@ type RegionInfo struct {
 	readKeys                  uint64
 	approximateSize           int64
 	approximateKvSize         int64 // Unit: MiB
+	approximateIAKvSize       int64 // Unit: MiB
 	approximateColumnarKvSize int64 // Unit: MiB
 	approximateKeys           int64
 	interval                  *pdpb.TimeInterval
@@ -258,6 +259,7 @@ func RegionFromHeartbeat(heartbeat RegionHeartbeatRequest, flowRoundDivisor uint
 	// scheduling service doesn't need the following fields.
 	if h, ok := heartbeat.(*pdpb.RegionHeartbeatRequest); ok {
 		region.approximateKvSize = int64(h.GetApproximateKvSize() / units.MiB)
+		region.approximateIAKvSize = int64(h.GetApproximateIaKvSize() / units.MiB)
 		region.approximateColumnarKvSize = int64(h.GetApproximateColumnarKvSize() / units.MiB)
 		region.replicationStatus = h.GetReplicationStatus()
 		region.cpuStats = h.GetCpuStats()
@@ -335,6 +337,7 @@ func (r *RegionInfo) Clone(opts ...RegionCreateOption) *RegionInfo {
 		readKeys:                  r.readKeys,
 		approximateSize:           r.approximateSize,
 		approximateKvSize:         r.approximateKvSize,
+		approximateIAKvSize:       r.approximateIAKvSize,
 		approximateColumnarKvSize: r.approximateColumnarKvSize,
 		approximateKeys:           r.approximateKeys,
 		interval:                  typeutil.DeepClone(r.interval, TimeIntervalFactory),
@@ -715,6 +718,11 @@ func (r *RegionInfo) GetStorePeerApproximateKeys(storeID uint64) int64 {
 // GetApproximateKvSize returns the approximate kv size of the region.
 func (r *RegionInfo) GetApproximateKvSize() int64 {
 	return r.approximateKvSize
+}
+
+// GetApproximateIAKvSize returns the approximate IA kv size of the region.
+func (r *RegionInfo) GetApproximateIAKvSize() int64 {
+	return r.approximateIAKvSize
 }
 
 // GetApproximateColumnarKvSize returns the approximate columnar kv size of the region.

--- a/pkg/core/region_option.go
+++ b/pkg/core/region_option.go
@@ -308,6 +308,13 @@ func SetApproximateKvSize(v int64) RegionCreateOption {
 	}
 }
 
+// SetApproximateIAKvSize sets the approximate IA size for the region.
+func SetApproximateIAKvSize(v int64) RegionCreateOption {
+	return func(region *RegionInfo) {
+		region.approximateIAKvSize = v
+	}
+}
+
 // SetApproximateKeys sets the approximate keys for the region.
 func SetApproximateKeys(v int64) RegionCreateOption {
 	return func(region *RegionInfo) {

--- a/pkg/core/region_test.go
+++ b/pkg/core/region_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/docker/go-units"
 	"github.com/stretchr/testify/require"
 
 	"github.com/pingcap/failpoint"
@@ -72,6 +73,26 @@ func TestNeedMerge(t *testing.T) {
 		}
 		re.Equal(v.expect, r.NeedMerge(mererSize, mergeKeys))
 	}
+}
+
+func TestRegionFromHeartbeatIAKVSize(t *testing.T) {
+	re := require.New(t)
+	heartbeat := &pdpb.RegionHeartbeatRequest{
+		Region:              &metapb.Region{},
+		ApproximateKvSize:   100 * units.MiB,
+		ApproximateIaKvSize: 40 * units.MiB,
+	}
+
+	region := RegionFromHeartbeat(heartbeat, 1)
+	re.Equal(int64(100), region.GetApproximateKvSize())
+	re.Equal(int64(40), region.GetApproximateIAKvSize())
+	re.Equal(int64(40), region.Clone().GetApproximateIAKvSize())
+
+	oldHeartbeat := &pdpb.RegionHeartbeatRequest{
+		Region:            &metapb.Region{},
+		ApproximateKvSize: 100 * units.MiB,
+	}
+	re.Zero(RegionFromHeartbeat(oldHeartbeat, 1).GetApproximateIAKvSize())
 }
 
 func TestSortedEqual(t *testing.T) {

--- a/pkg/core/region_test.go
+++ b/pkg/core/region_test.go
@@ -452,6 +452,45 @@ func TestNeedSync(t *testing.T) {
 	}
 }
 
+func TestRegionGuideLogicalStorageSizeChanged(t *testing.T) {
+	regionGuide := GenerateRegionGuideFunc(false)
+	origin := NewRegionInfo(&metapb.Region{Id: 1}, nil)
+	testCases := []struct {
+		name   string
+		update func(*RegionInfo)
+	}{
+		{
+			name: "row-based storage size",
+			update: func(region *RegionInfo) {
+				region.approximateKvSize = 1
+			},
+		},
+		{
+			name: "IA row-based storage size",
+			update: func(region *RegionInfo) {
+				region.approximateIAKvSize = 1
+			},
+		},
+		{
+			name: "columnar storage size",
+			update: func(region *RegionInfo) {
+				region.approximateColumnarKvSize = 1
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			region := origin.Clone()
+			testCase.update(region)
+			saveKV, saveCache, needSync, _ := regionGuide(ContextTODO(), region, origin)
+			require.False(t, saveKV)
+			require.True(t, saveCache)
+			require.False(t, needSync)
+		})
+	}
+}
+
 func TestRegionMap(t *testing.T) {
 	re := require.New(t)
 	rm := make(map[uint64]*regionItem)

--- a/pkg/statistics/region.go
+++ b/pkg/statistics/region.go
@@ -23,10 +23,12 @@ import (
 
 // RegionStats records a list of regions' statistics and distribution status.
 type RegionStats struct {
-	Count                   int               `json:"count"`
-	EmptyCount              int               `json:"empty_count"`
-	StorageSize             int64             `json:"storage_size"`
-	UserStorageSize         int64             `json:"user_storage_size"`
+	Count           int   `json:"count"`
+	EmptyCount      int   `json:"empty_count"`
+	StorageSize     int64 `json:"storage_size"`
+	UserStorageSize int64 `json:"user_storage_size"`
+	// UserIAStorageSize is the approximate IA row-based logical KV size in MiB,
+	// bounded by UserStorageSize.
 	UserIAStorageSize       int64             `json:"user_ia_storage_size"`
 	UserColumnarStorageSize int64             `json:"user_columnar_storage_size"`
 	StorageKeys             int64             `json:"storage_keys"`

--- a/pkg/statistics/region.go
+++ b/pkg/statistics/region.go
@@ -27,6 +27,7 @@ type RegionStats struct {
 	EmptyCount              int               `json:"empty_count"`
 	StorageSize             int64             `json:"storage_size"`
 	UserStorageSize         int64             `json:"user_storage_size"`
+	UserIAStorageSize       int64             `json:"user_ia_storage_size"`
 	UserColumnarStorageSize int64             `json:"user_columnar_storage_size"`
 	StorageKeys             int64             `json:"storage_keys"`
 	StoreLeaderCount        map[uint64]int    `json:"store_leader_count"`
@@ -45,13 +46,6 @@ type RegionStats struct {
 	StorePeerReadKeys       map[uint64]uint64 `json:"store_peer_read_keys,omitempty"`
 	StorePeerReadQuery      map[uint64]uint64 `json:"store_peer_read_query,omitempty"`
 	StoreEngine             map[uint64]string `json:"store_engine,omitempty"`
-	// userIAStorageSize is only used by storage metering and is not exposed by the region stats API.
-	userIAStorageSize int64
-}
-
-// GetUserIAStorageSize returns the IA subset of the user row-based storage size.
-func (s *RegionStats) GetUserIAStorageSize() int64 {
-	return s.userIAStorageSize
 }
 
 // GetRegionStatsOption is used to filter the peer statistics.
@@ -109,7 +103,7 @@ func (s *RegionStats) Observe(r *core.RegionInfo, cluster RegionStatInformer, op
 	}
 	s.StorageSize += approximateSize
 	s.UserStorageSize += approximateKvSize
-	s.userIAStorageSize += approximateIAKvSize
+	s.UserIAStorageSize += approximateIAKvSize
 	s.UserColumnarStorageSize += approximateColumnarKvSize
 	s.StorageKeys += approximateKeys
 	leader := r.GetLeader()

--- a/pkg/statistics/region.go
+++ b/pkg/statistics/region.go
@@ -45,6 +45,13 @@ type RegionStats struct {
 	StorePeerReadKeys       map[uint64]uint64 `json:"store_peer_read_keys,omitempty"`
 	StorePeerReadQuery      map[uint64]uint64 `json:"store_peer_read_query,omitempty"`
 	StoreEngine             map[uint64]string `json:"store_engine,omitempty"`
+	// userIAStorageSize is only used by storage metering and is not exposed by the region stats API.
+	userIAStorageSize int64
+}
+
+// GetUserIAStorageSize returns the IA subset of the user row-based storage size.
+func (s *RegionStats) GetUserIAStorageSize() int64 {
+	return s.userIAStorageSize
 }
 
 // GetRegionStatsOption is used to filter the peer statistics.
@@ -95,12 +102,14 @@ func (s *RegionStats) Observe(r *core.RegionInfo, cluster RegionStatInformer, op
 	approximateKeys := r.GetApproximateKeys()
 	approximateSize := r.GetApproximateSize()
 	approximateKvSize := r.GetApproximateKvSize()
+	approximateIAKvSize := min(r.GetApproximateIAKvSize(), approximateKvSize)
 	approximateColumnarKvSize := r.GetApproximateColumnarKvSize()
 	if approximateSize <= core.EmptyRegionApproximateSize {
 		s.EmptyCount++
 	}
 	s.StorageSize += approximateSize
 	s.UserStorageSize += approximateKvSize
+	s.userIAStorageSize += approximateIAKvSize
 	s.UserColumnarStorageSize += approximateColumnarKvSize
 	s.StorageKeys += approximateKeys
 	leader := r.GetLeader()

--- a/pkg/statistics/region_collection_test.go
+++ b/pkg/statistics/region_collection_test.go
@@ -16,6 +16,7 @@ package statistics
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -40,11 +41,16 @@ func TestRegionStatsObserveIAKVSize(t *testing.T) {
 
 	stats := GetRegionStats([]*core.RegionInfo{region}, nil)
 	re.Equal(int64(100), stats.UserStorageSize)
-	re.Equal(int64(40), stats.GetUserIAStorageSize())
+	re.Equal(int64(40), stats.UserIAStorageSize)
+	data, err := json.Marshal(stats)
+	re.NoError(err)
+	var response map[string]any
+	re.NoError(json.Unmarshal(data, &response))
+	re.Equal(float64(40), response["user_ia_storage_size"])
 
 	region = region.Clone(core.SetApproximateIAKvSize(120))
 	stats = GetRegionStats([]*core.RegionInfo{region}, nil)
-	re.Equal(int64(100), stats.GetUserIAStorageSize())
+	re.Equal(int64(100), stats.UserIAStorageSize)
 }
 
 func TestRegionStatistics(t *testing.T) {

--- a/pkg/statistics/region_collection_test.go
+++ b/pkg/statistics/region_collection_test.go
@@ -29,6 +29,24 @@ import (
 	"github.com/tikv/pd/pkg/storage"
 )
 
+func TestRegionStatsObserveIAKVSize(t *testing.T) {
+	re := require.New(t)
+	region := core.NewRegionInfo(
+		&metapb.Region{Id: 1},
+		nil,
+		core.SetApproximateKvSize(100),
+		core.SetApproximateIAKvSize(40),
+	)
+
+	stats := GetRegionStats([]*core.RegionInfo{region}, nil)
+	re.Equal(int64(100), stats.UserStorageSize)
+	re.Equal(int64(40), stats.GetUserIAStorageSize())
+
+	region = region.Clone(core.SetApproximateIAKvSize(120))
+	stats = GetRegionStats([]*core.RegionInfo{region}, nil)
+	re.Equal(int64(100), stats.GetUserIAStorageSize())
+}
+
 func TestRegionStatistics(t *testing.T) {
 	re := require.New(t)
 	store := storage.NewStorageWithMemoryBackend()

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -2904,6 +2904,7 @@ func (c *RaftCluster) collectStorageSize(
 			keyspaceName: keyspaceName,
 			// Use the user storage size to record the logical storage size.
 			rowBasedStorageSize:    uint64(regionStats.UserStorageSize),
+			rowBasedIAStorageSize:  uint64(regionStats.GetUserIAStorageSize()),
 			columnBasedStorageSize: uint64(regionStats.UserColumnarStorageSize),
 		})
 	}

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -2904,7 +2904,7 @@ func (c *RaftCluster) collectStorageSize(
 			keyspaceName: keyspaceName,
 			// Use the user storage size to record the logical storage size.
 			rowBasedStorageSize:    uint64(regionStats.UserStorageSize),
-			rowBasedIAStorageSize:  uint64(regionStats.GetUserIAStorageSize()),
+			rowBasedIAStorageSize:  uint64(regionStats.UserIAStorageSize),
 			columnBasedStorageSize: uint64(regionStats.UserColumnarStorageSize),
 		})
 	}

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -1198,6 +1198,13 @@ func TestRegionHeartbeat(t *testing.T) {
 		re.NoError(cluster.processRegionHeartbeat(core.ContextTODO(), region))
 		checkRegions(re, cluster.BasicCluster, regions[:i+1])
 
+		// Change only the IA row-based logical storage size.
+		region = region.Clone(core.SetApproximateIAKvSize(40))
+		regions[i] = region
+		re.NoError(cluster.processRegionHeartbeat(core.ContextTODO(), region))
+		re.Equal(int64(40), cluster.GetRegion(region.GetID()).GetApproximateIAKvSize())
+		checkRegions(re, cluster.BasicCluster, regions[:i+1])
+
 		// Change bytes written.
 		region = region.Clone(core.SetWrittenBytes(24000))
 		regions[i] = region

--- a/server/cluster/metering.go
+++ b/server/cluster/metering.go
@@ -26,9 +26,11 @@ import (
 
 const (
 	storageSizeCollectorCategory = "storage-size"
-	storageSizeMeteringVersion   = "1"
+	// The IA field is additive, so older consumers can keep using the total row-based size.
+	storageSizeMeteringVersion = "1"
 
 	meteringDataRowBasedStorageSizeField    = "row_based_storage_size"
+	meteringDataRowBasedIAStorageSizeField  = "row_based_ia_storage_size"
 	meteringDataColumnBasedStorageSizeField = "column_based_storage_size"
 )
 
@@ -36,13 +38,18 @@ var _ metering.Collector = (*storageSizeCollector)(nil)
 
 type storageSizeInfo struct {
 	keyspaceName string
-	// Both storage size are in MiB.
+	// All storage sizes are in MiB.
 	rowBasedStorageSize    uint64
+	rowBasedIAStorageSize  uint64 // IA subset; Standard is derived from total minus IA.
 	columnBasedStorageSize uint64
 }
 
 func (s *storageSizeInfo) rowBasedStorageSizeMeteringValue() common.MeteringValue {
 	return metering.NewBytesValue(s.rowBasedStorageSize * units.MiB)
+}
+
+func (s *storageSizeInfo) rowBasedIAStorageSizeMeteringValue() common.MeteringValue {
+	return metering.NewBytesValue(s.rowBasedIAStorageSize * units.MiB)
 }
 
 func (s *storageSizeInfo) columnBasedStorageSizeMeteringValue() common.MeteringValue {
@@ -88,6 +95,7 @@ func (c *storageSizeCollector) Aggregate() []map[string]any {
 			metering.DataClusterIDField:             keyspaceName, // keyspaceName is the logical cluster ID in the metering data.
 			metering.DataSourceNameField:            metering.SourceNamePD,
 			meteringDataRowBasedStorageSizeField:    storageSizeInfo.rowBasedStorageSizeMeteringValue(),
+			meteringDataRowBasedIAStorageSizeField:  storageSizeInfo.rowBasedIAStorageSizeMeteringValue(),
 			meteringDataColumnBasedStorageSizeField: storageSizeInfo.columnBasedStorageSizeMeteringValue(),
 		})
 	}

--- a/server/cluster/metering_test.go
+++ b/server/cluster/metering_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/docker/go-units"
 	"github.com/stretchr/testify/require"
 
+	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/keyspace"
 	"github.com/tikv/pd/pkg/metering"
 	"github.com/tikv/pd/pkg/mock/mockid"
@@ -52,13 +53,25 @@ func TestCollectStorageSize(t *testing.T) {
 	keyspaceGroupManager := keyspace.NewKeyspaceGroupManager(ctx, tc.storage, tc.etcdClient)
 	re.NoError(keyspaceGroupManager.Bootstrap(ctx))
 	keyspaceManager := keyspace.NewKeyspaceManager(ctx, tc.storage, tc, mockid.NewIDAllocator(), &config.KeyspaceConfig{}, keyspaceGroupManager, nil)
+	var meteredKeyspaceID uint32
 	for i := range 10 {
-		_, err = keyspaceManager.CreateKeyspace(&keyspace.CreateKeyspaceRequest{
+		created, err := keyspaceManager.CreateKeyspace(&keyspace.CreateKeyspaceRequest{
 			Name:       fmt.Sprintf("test-keyspace-%d", i),
 			CreateTime: time.Now().Unix(),
 		})
 		re.NoError(err)
+		if i == 0 {
+			meteredKeyspaceID = created.GetId()
+		}
 	}
+	regionBounds := keyspace.MakeRegionBound(meteredKeyspaceID)
+	meteredRegion := regions[0].Clone(
+		core.WithStartKey(regionBounds.TxnLeftBound),
+		core.WithEndKey(regionBounds.TxnRightBound),
+		core.SetApproximateKvSize(100),
+		core.SetApproximateIAKvSize(40),
+	)
+	re.NoError(tc.putRegion(meteredRegion))
 
 	storageSizeInfoList := tc.collectStorageSize(tc.regionLabeler, keyspaceManager)
 	re.Len(storageSizeInfoList, 10)
@@ -66,6 +79,9 @@ func TestCollectStorageSize(t *testing.T) {
 	sort.Slice(storageSizeInfoList, func(i, j int) bool {
 		return storageSizeInfoList[i].keyspaceName < storageSizeInfoList[j].keyspaceName
 	})
+	re.Equal("test-keyspace-0", storageSizeInfoList[0].keyspaceName)
+	re.Equal(uint64(100), storageSizeInfoList[0].rowBasedStorageSize)
+	re.Equal(uint64(40), storageSizeInfoList[0].rowBasedIAStorageSize)
 	// Mock the storage size info since the region split won't work in the test.
 	for i := range storageSizeInfoList {
 		storageSizeInfoList[i].rowBasedStorageSize = uint64(i)

--- a/server/cluster/metering_test.go
+++ b/server/cluster/metering_test.go
@@ -69,6 +69,7 @@ func TestCollectStorageSize(t *testing.T) {
 	// Mock the storage size info since the region split won't work in the test.
 	for i := range storageSizeInfoList {
 		storageSizeInfoList[i].rowBasedStorageSize = uint64(i)
+		storageSizeInfoList[i].rowBasedIAStorageSize = uint64(i) / 2
 		storageSizeInfoList[i].columnBasedStorageSize = uint64(i)
 	}
 
@@ -82,8 +83,10 @@ func TestCollectStorageSize(t *testing.T) {
 	})
 	for idx, record := range records {
 		storageSizeInfo := storageSizeInfoList[idx]
+		re.Equal(storageSizeMeteringVersion, record[metering.DataVersionField])
 		re.Equal(storageSizeInfo.keyspaceName, record[metering.DataClusterIDField])
 		re.Equal(metering.NewBytesValue(storageSizeInfo.rowBasedStorageSize*units.MiB), record[meteringDataRowBasedStorageSizeField])
+		re.Equal(metering.NewBytesValue(storageSizeInfo.rowBasedIAStorageSize*units.MiB), record[meteringDataRowBasedIAStorageSizeField])
 		re.Equal(metering.NewBytesValue(storageSizeInfo.columnBasedStorageSize*units.MiB), record[meteringDataColumnBasedStorageSizeField])
 	}
 }

--- a/tests/integrations/go.mod
+++ b/tests/integrations/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/golang/protobuf v1.5.4
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86
-	github.com/pingcap/kvproto v0.0.0-20260810080205-543bb79c8a8a
+	github.com/pingcap/kvproto v0.0.0-20260903054228-107095f1d250
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3
 	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/client_model v0.6.1

--- a/tests/integrations/go.sum
+++ b/tests/integrations/go.sum
@@ -483,8 +483,8 @@ github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c/go.mod h1:X2r9ue
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 h1:tdMsjOqUR7YXHoBitzdebTvOjs/swniBTOLy5XiMtuE=
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86/go.mod h1:exzhVYca3WRtd6gclGNErRWb1qEgff3LYta0LvRmON4=
 github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
-github.com/pingcap/kvproto v0.0.0-20260810080205-543bb79c8a8a h1:FC9R8jnaSn7hr40qFf3WqaWKTz6njtOlZJQZ65/HAR4=
-github.com/pingcap/kvproto v0.0.0-20260810080205-543bb79c8a8a/go.mod h1:z6+aAHB7dBkA+LyinEX+48/ImRJ3jag0Hg0c7wkhEvE=
+github.com/pingcap/kvproto v0.0.0-20260903054228-107095f1d250 h1:6yUryXKVbKpCNdZWL58/OcZj8NPLUA/xsJYXSbsD59w=
+github.com/pingcap/kvproto v0.0.0-20260903054228-107095f1d250/go.mod h1:z6+aAHB7dBkA+LyinEX+48/ImRJ3jag0Hg0c7wkhEvE=
 github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7/go.mod h1:8AanEdAHATuRurdGxZXBz0At+9avep+ub7U1AGYLIMM=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8IDP+SZrdhV1Kibl9KrHxJ9eciw=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86
-	github.com/pingcap/kvproto v0.0.0-20260810080205-543bb79c8a8a
+	github.com/pingcap/kvproto v0.0.0-20260903054228-107095f1d250
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/prometheus/client_golang v1.20.5

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -488,8 +488,8 @@ github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c/go.mod h1:X2r9ue
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 h1:tdMsjOqUR7YXHoBitzdebTvOjs/swniBTOLy5XiMtuE=
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86/go.mod h1:exzhVYca3WRtd6gclGNErRWb1qEgff3LYta0LvRmON4=
 github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
-github.com/pingcap/kvproto v0.0.0-20260810080205-543bb79c8a8a h1:FC9R8jnaSn7hr40qFf3WqaWKTz6njtOlZJQZ65/HAR4=
-github.com/pingcap/kvproto v0.0.0-20260810080205-543bb79c8a8a/go.mod h1:z6+aAHB7dBkA+LyinEX+48/ImRJ3jag0Hg0c7wkhEvE=
+github.com/pingcap/kvproto v0.0.0-20260903054228-107095f1d250 h1:6yUryXKVbKpCNdZWL58/OcZj8NPLUA/xsJYXSbsD59w=
+github.com/pingcap/kvproto v0.0.0-20260903054228-107095f1d250/go.mod h1:z6+aAHB7dBkA+LyinEX+48/ImRJ3jag0Hg0c7wkhEvE=
 github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7/go.mod h1:8AanEdAHATuRurdGxZXBz0At+9avep+ub7U1AGYLIMM=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8IDP+SZrdhV1Kibl9KrHxJ9eciw=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=


### PR DESCRIPTION
### What problem does this PR solve?

PD currently reports only the total row-based logical storage size, so metering cannot distinguish IA storage from Standard storage.

Issue Number: ref #9707

### What is changed and how does it work?

```commit-message
Update kvproto to consume approximate_ia_kv_size from region heartbeats. Preserve and aggregate the IA row-based logical storage size per keyspace, clamping it to the total row-based size. Expose user_ia_storage_size through the RegionStats API. Report row_based_ia_storage_size alongside the unchanged row_based_storage_size so metering can derive Standard as total minus IA. Heartbeats from old TiKV versions leave the IA size at zero.
```

### Check List

Tests

- Unit test

Related changes

- Depends on https://github.com/pingcap/kvproto/pull/1518

### Release note

```release-note
Report IA row-based logical storage size in PD metering records.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added tracking for approximate IA KV storage at the region level, including heartbeat updates and cloning.
  - Region statistics now separately report IA user storage, bounded by total approximate KV storage.
  - Storage metering now includes IA storage size alongside row-based and column-based metrics.
  - IA storage data is included in serialized statistics.

- **Tests**
  - Added coverage for IA storage conversion, propagation, aggregation, cloning, serialization, region-guide updates, and zero-value behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
