### PR TITLE
*: fix ignored lint findings

### DIFF
--- a/client/clients/tso/stream_test.go
+++ b/client/clients/tso/stream_test.go
@@ -308,7 +308,7 @@ func (s *testTSOStreamSuite) processRequestWithResultCh(count int64) (<-chan cal
 	ch := make(chan callbackInvocation, 1)
 	err := s.stream.processRequests(1, 2, 3, count, time.Now(), func(result tsoRequestResult, reqKeyspaceGroupID uint32, err error) {
 		if err == nil {
-			s.re.Equal(uint32(3), reqKeyspaceGroupID)
+			s.Equal(uint32(3), reqKeyspaceGroupID)
 		}
 		ch <- callbackInvocation{
 			result: result,
@@ -533,7 +533,10 @@ func (s *testTSOStreamSuite) TestEstimatedLatency() {
 		for time.Since(startTime) < time.Second {
 			<-tokenCh
 			reqStartTimeCh <- time.Now()
-			r := s.mustProcessRequestWithResultCh(1)
+			r, err := s.processRequestWithResultCh(1)
+			if !s.NoError(err) {
+				break
+			}
 			resCh <- r
 		}
 		close(reqStartTimeCh)

--- a/client/http/types.go
+++ b/client/http/types.go
@@ -17,6 +17,7 @@ package http
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/pingcap/kvproto/pkg/encryptionpb"
@@ -405,8 +406,8 @@ func (r *Rule) String() string {
 func (r *Rule) Clone() *Rule {
 	var clone Rule
 	_ = json.Unmarshal([]byte(r.String()), &clone)
-	clone.StartKey = append(r.StartKey[:0:0], r.StartKey...)
-	clone.EndKey = append(r.EndKey[:0:0], r.EndKey...)
+	clone.StartKey = slices.Clone(r.StartKey)
+	clone.EndKey = slices.Clone(r.EndKey)
 	return &clone
 }
 

--- a/client/pkg/circuitbreaker/circuit_breaker_test.go
+++ b/client/pkg/circuitbreaker/circuit_breaker_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
@@ -159,7 +160,7 @@ func TestCircuitBreakerHalfOpenFailOverPendingCount(t *testing.T) {
 				<-wait
 				return No, nil
 			})
-			re.NoError(err)
+			assert.NoError(t, err)
 		}()
 	}
 	// make sure all requests are started
@@ -198,7 +199,7 @@ func TestCircuitBreakerCountOnlyRequestsInSameWindow(t *testing.T) {
 			<-wait
 			return No, nil
 		})
-		re.NoError(err)
+		assert.NoError(t, err)
 	}()
 	<-start // make sure the request is started
 	// assert running request is not counted

--- a/client/pkg/utils/grpcutil/grpcutil.go
+++ b/client/pkg/utils/grpcutil/grpcutil.go
@@ -230,7 +230,7 @@ func GetOrCreateGRPCConn(ctx context.Context, clientConns *sync.Map, url string,
 // The callee ID is used to identify the callee in gRPC communication, and it is usually the host:port of the advertise address. If the advertise address is invalid, it will panic.
 func GetCalleeID(addr string) string {
 	parsed, err := url.Parse(addr)
-	callerID := ""
+	var callerID string
 	if err != nil {
 		if _, _, splitErr := net.SplitHostPort(addr); splitErr != nil {
 			return ""

--- a/client/resource_group/controller/limiter_test.go
+++ b/client/resource_group/controller/limiter_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -314,7 +315,7 @@ func TestCancel(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		_, err := WaitReservations(ctx2, t3, []*Reservation{r1, r2})
-		re.Error(err)
+		assert.Error(t, err)
 		wg.Done()
 	}()
 	time.Sleep(1 * time.Second)

--- a/pkg/core/region_option.go
+++ b/pkg/core/region_option.go
@@ -17,6 +17,7 @@ package core
 import (
 	"math"
 	"math/rand/v2"
+	"slices"
 	"sort"
 
 	"github.com/pingcap/kvproto/pkg/metapb"
@@ -30,7 +31,7 @@ type RegionCreateOption func(region *RegionInfo)
 // WithDownPeers sets the down peers for the region.
 func WithDownPeers(downPeers []*pdpb.PeerStats) RegionCreateOption {
 	return func(region *RegionInfo) {
-		region.downPeers = append(downPeers[:0:0], downPeers...)
+		region.downPeers = slices.Clone(downPeers)
 		sort.Sort(peerStatsSlice(region.downPeers))
 	}
 }
@@ -51,7 +52,7 @@ func GetFlowRoundDivisorByDigit(digit int) uint64 {
 // WithPendingPeers sets the pending peers for the region.
 func WithPendingPeers(pendingPeers []*metapb.Peer) RegionCreateOption {
 	return func(region *RegionInfo) {
-		region.pendingPeers = append(pendingPeers[:0:0], pendingPeers...)
+		region.pendingPeers = slices.Clone(pendingPeers)
 		sort.Sort(peerSlice(region.pendingPeers))
 	}
 }

--- a/pkg/core/region_test.go
+++ b/pkg/core/region_test.go
@@ -22,6 +22,7 @@ import (
 	mrand "math/rand/v2"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -582,12 +583,16 @@ func TestSetRegionConcurrence(t *testing.T) {
 	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/core/UpdateSubTree", `return()`))
 	regions := NewRegionsInfo()
 	region := NewTestRegionInfo(1, 1, []byte("a"), []byte("b"))
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		_, err := regions.AtomicCheckAndPutRegion(ContextTODO(), region)
 		assert.NoError(t, err)
 	}()
 	_, err := regions.AtomicCheckAndPutRegion(ContextTODO(), region)
 	re.NoError(err)
+	wg.Wait()
 	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/core/UpdateSubTree"))
 }
 

--- a/pkg/core/region_test.go
+++ b/pkg/core/region_test.go
@@ -28,6 +28,7 @@ import (
 	"unsafe"
 
 	"github.com/docker/go-units"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/pingcap/failpoint"
@@ -583,7 +584,7 @@ func TestSetRegionConcurrence(t *testing.T) {
 	region := NewTestRegionInfo(1, 1, []byte("a"), []byte("b"))
 	go func() {
 		_, err := regions.AtomicCheckAndPutRegion(ContextTODO(), region)
-		re.NoError(err)
+		assert.NoError(t, err)
 	}()
 	_, err := regions.AtomicCheckAndPutRegion(ContextTODO(), region)
 	re.NoError(err)

--- a/pkg/dashboard/adapter/redirector_test.go
+++ b/pkg/dashboard/adapter/redirector_test.go
@@ -48,11 +48,10 @@ func TestRedirectorTestSuite(t *testing.T) {
 }
 
 func (suite *redirectorTestSuite) SetupSuite() {
-	re := suite.Require()
 	suite.tempText = "temp1"
 	suite.tempServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, err := io.WriteString(w, suite.tempText)
-		re.NoError(err)
+		suite.NoError(err)
 	}))
 
 	suite.testName = "test1"

--- a/pkg/gc/gc_state_manager_test.go
+++ b/pkg/gc/gc_state_manager_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -654,6 +655,7 @@ func (s *gcStateManagerTestSuite) TestCompatibleGCSafePointUpdateConcurrently() 
 
 func (s *gcStateManagerTestSuite) TestCompatibleServiceGCSafePointUpdateNullKeyspace() {
 	keyspaceID := constant.NullKeyspaceID
+	as := assert.New(s.T())
 	re := s.Require()
 	gcWorkerServiceID := "gc_worker"
 	cdcServiceID := "cdc"
@@ -670,20 +672,22 @@ func (s *gcStateManagerTestSuite) TestCompatibleServiceGCSafePointUpdateNullKeys
 	go func() {
 		defer wg.Done()
 		min, updated, err := s.manager.CompatibleUpdateServiceGCSafePoint(keyspaceID, cdcServiceID, cdcServiceSafePoint, 10000, time.Now())
-		re.NoError(err)
-		re.True(updated)
+		if !as.NoError(err) || !as.True(updated) || !as.NotNil(min) {
+			return
+		}
 		// The service will init the service safepoint to 0(<10 for cdc) for gc_worker.
-		re.Equal(gcWorkerServiceID, min.ServiceID)
+		as.Equal(gcWorkerServiceID, min.ServiceID)
 	}()
 
 	// Updating the service safe point for br to 15 should success
 	go func() {
 		defer wg.Done()
 		min, updated, err := s.manager.CompatibleUpdateServiceGCSafePoint(keyspaceID, brServiceID, brSafePoint, 10000, time.Now())
-		re.NoError(err)
-		re.True(updated)
+		if !as.NoError(err) || !as.True(updated) || !as.NotNil(min) {
+			return
+		}
 		// the service will init the service safepoint to 0(<10 for cdc) for gc_worker.
-		re.Equal(gcWorkerServiceID, min.ServiceID)
+		as.Equal(gcWorkerServiceID, min.ServiceID)
 	}()
 
 	// Updating the service safe point to 8 for gc_worker should be success
@@ -691,11 +695,12 @@ func (s *gcStateManagerTestSuite) TestCompatibleServiceGCSafePointUpdateNullKeys
 		defer wg.Done()
 		// update with valid ttl for gc_worker should be success.
 		min, updated, err := s.manager.CompatibleUpdateServiceGCSafePoint(keyspaceID, gcWorkerServiceID, gcWorkerSafePoint, math.MaxInt64, time.Now())
-		re.NoError(err)
-		re.True(updated)
+		if !as.NoError(err) || !as.True(updated) || !as.NotNil(min) {
+			return
+		}
 		// the current min safepoint should be 8 for gc_worker(cdc 10)
-		re.Equal(gcWorkerSafePoint, min.SafePoint)
-		re.Equal(gcWorkerServiceID, min.ServiceID)
+		as.Equal(gcWorkerSafePoint, min.SafePoint)
+		as.Equal(gcWorkerServiceID, min.ServiceID)
 	}()
 
 	// Updating the service safe point to 14 for native_br should succeed
@@ -703,18 +708,21 @@ func (s *gcStateManagerTestSuite) TestCompatibleServiceGCSafePointUpdateNullKeys
 		defer wg.Done()
 		// update with valid ttl for native_br should succeed
 		min, updated, err := s.manager.CompatibleUpdateServiceGCSafePoint(keyspaceID, nativeBRServiceID, nativeBRSafePoint, math.MaxInt64, time.Now())
-		re.NoError(err)
-		re.True(updated)
+		if !as.NoError(err) || !as.True(updated) || !as.NotNil(min) {
+			return
+		}
 		// the current min safepoint should be 8 for gc_worker(cdc 10)
-		re.Equal(gcWorkerServiceID, min.ServiceID)
+		as.Equal(gcWorkerServiceID, min.ServiceID)
 	}()
 
 	go func() {
 		defer wg.Done()
 		// Updating the service safe point of gc_worker's service with ttl not infinity should be failed.
 		_, updated, err := s.manager.CompatibleUpdateServiceGCSafePoint(keyspaceID, gcWorkerServiceID, 10000, 10, time.Now())
-		re.Error(err)
-		re.False(updated)
+		if !as.Error(err) {
+			return
+		}
+		as.False(updated)
 	}()
 
 	// Updating the service safe point with negative ttl should be failed.
@@ -722,8 +730,10 @@ func (s *gcStateManagerTestSuite) TestCompatibleServiceGCSafePointUpdateNullKeys
 		defer wg.Done()
 		brTTL := int64(-100)
 		_, updated, err := s.manager.CompatibleUpdateServiceGCSafePoint(keyspaceID, brServiceID, uint64(10000), brTTL, time.Now())
-		re.NoError(err)
-		re.False(updated)
+		if !as.NoError(err) {
+			return
+		}
+		as.False(updated)
 	}()
 
 	wg.Wait()
@@ -3265,7 +3275,8 @@ func benchmarkGetGCStateImpl(b *testing.B, excludeGCBarriers bool, keyspacesCoun
 					if errors.ErrorEqual(err, errs.ErrDecreasingTxnSafePoint) {
 						continue
 					}
-					re.NoError(err)
+					b.Error(err)
+					return
 				}
 			}
 		}()

--- a/pkg/mcs/resourcemanager/server/grpc_service.go
+++ b/pkg/mcs/resourcemanager/server/grpc_service.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"io"
 	"net/http"
-	"slices"
 	"time"
 
 	"go.uber.org/zap"
@@ -227,10 +226,11 @@ func (s *Service) AcquireTokenBuckets(stream rmpb.ResourceManager_AcquireTokenBu
 		for _, req := range request.Requests {
 			keyspaceID := ExtractKeyspaceID(req.GetKeyspaceId())
 			resourceGroupName := req.GetResourceGroupName()
-			requestFields := slices.Concat(logFields, []zap.Field{
+			requestFields := logFields
+			requestFields = append(requestFields,
 				zap.Uint32("keyspace-id", keyspaceID),
 				zap.String("resource-group", resourceGroupName),
-			})
+			)
 			// Get keyspace resource group manager to apply service limit later.
 			krgm, err := s.manager.accessKeyspaceResourceGroupManager(keyspaceID, resourceGroupName)
 			if krgm == nil {

--- a/pkg/mcs/resourcemanager/server/grpc_service.go
+++ b/pkg/mcs/resourcemanager/server/grpc_service.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"slices"
 	"time"
 
 	"go.uber.org/zap"
@@ -226,10 +227,10 @@ func (s *Service) AcquireTokenBuckets(stream rmpb.ResourceManager_AcquireTokenBu
 		for _, req := range request.Requests {
 			keyspaceID := ExtractKeyspaceID(req.GetKeyspaceId())
 			resourceGroupName := req.GetResourceGroupName()
-			requestFields := append(logFields,
+			requestFields := slices.Concat(logFields, []zap.Field{
 				zap.Uint32("keyspace-id", keyspaceID),
 				zap.String("resource-group", resourceGroupName),
-			)
+			})
 			// Get keyspace resource group manager to apply service limit later.
 			krgm, err := s.manager.accessKeyspaceResourceGroupManager(keyspaceID, resourceGroupName)
 			if krgm == nil {

--- a/pkg/mcs/resourcemanager/server/keyspace_manager.go
+++ b/pkg/mcs/resourcemanager/server/keyspace_manager.go
@@ -775,13 +775,11 @@ func (krgm *keyspaceResourceGroupManager) calculateDemandInfo(queue []*ResourceG
 		di.totalBasicRUDemand += basicRUDemand
 		di.basicRUDemandMap[group.Name] = basicRUDemand
 		// Calculate the burst RU demand of the resource group.
-		burstRUDemand := 0.0
+		var burstRUDemand float64
 		// If the burst limit setting is within the range of [0, fillRateSetting],
 		// it means the resource group is not allowed to consume extra tokens,
 		// so the burst RU demand should always be 0.
-		if 0 <= burstLimitSetting && burstLimitSetting <= fillRateSetting {
-			burstRUDemand = 0
-		} else {
+		if !(0 <= burstLimitSetting && burstLimitSetting <= fillRateSetting) {
 			burstRUDemand = math.Max(0, ruPerSec-fillRateSetting)
 		}
 		di.totalBurstRUDemand += burstRUDemand

--- a/pkg/mcs/resourcemanager/server/manager.go
+++ b/pkg/mcs/resourcemanager/server/manager.go
@@ -78,7 +78,6 @@ func (cfg *pushMetricsConfig) syncPushMetricsTicker(
 	*cfg = newCfg
 	if ticker != nil {
 		ticker.Stop()
-		ticker = nil
 	}
 	if newCfg.address == "" {
 		return nil

--- a/pkg/metering/writer.go
+++ b/pkg/metering/writer.go
@@ -22,6 +22,7 @@ package metering
 import (
 	"context"
 	"math"
+	"slices"
 	"sync"
 	"time"
 
@@ -285,10 +286,10 @@ func (mw *Writer) flushMeteringData(ctx context.Context, ts int64) {
 			}
 		}
 		cost := time.Since(start)
-		logFields := append(baseLogFields,
+		logFields := slices.Concat(baseLogFields, []zap.Field{
 			zap.Int("attempts", attempt),
 			zap.Duration("cost", cost),
-		)
+		})
 		if err != nil {
 			log.Error("failed to write metering data to underlying storage",
 				append(logFields, zap.Error(err))...)

--- a/pkg/ratelimit/concurrency_limiter_test.go
+++ b/pkg/ratelimit/concurrency_limiter_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 )
@@ -84,7 +85,7 @@ func TestConcurrencyLimiter2(t *testing.T) {
 	// Try to acquire third token, it should not be able to acquire immediately due to limit
 	go func() {
 		_, err := limiter.AcquireToken(ctx)
-		require.NoError(t, err, "Failed to acquire token")
+		assert.NoError(t, err, "Failed to acquire token")
 	}()
 
 	time.Sleep(100 * time.Millisecond) // Give some time for the goroutine to run

--- a/pkg/ratelimit/controller_test.go
+++ b/pkg/ratelimit/controller_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/time/rate"
 
@@ -43,7 +44,7 @@ type labelCase struct {
 }
 
 func runMulitLabelLimiter(t *testing.T, limiter *Controller, testCase []labelCase) {
-	re := require.New(t)
+	as := assert.New(t)
 	var caseWG sync.WaitGroup
 	for _, tempCas := range testCase {
 		caseWG.Add(1)
@@ -64,8 +65,9 @@ func runMulitLabelLimiter(t *testing.T, limiter *Controller, testCase []labelCas
 					}()
 				}
 				wg.Wait()
-				re.Equal(rd.fail, failedCount)
-				re.Equal(rd.success, successCount)
+				if !as.Equal(rd.fail, failedCount) || !as.Equal(rd.success, successCount) {
+					return
+				}
 				for range rd.release {
 					r.release()
 				}

--- a/pkg/schedule/handler/handler.go
+++ b/pkg/schedule/handler/handler.go
@@ -688,7 +688,7 @@ func (h *Handler) AddScatterRegionsOperators(regionIDs []uint64, startKeyHex, en
 	if err != nil {
 		return 0, err
 	}
-	opsCount := 0
+	var opsCount int
 	var failures map[uint64]error
 	// If startKey and endKey are both defined, use them first.
 	if len(startKeyHex) > 0 && len(endKeyHex) > 0 {

--- a/pkg/schedule/operator/create_operator_test.go
+++ b/pkg/schedule/operator/create_operator_test.go
@@ -17,6 +17,7 @@ package operator
 import (
 	"context"
 	"encoding/hex"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -316,7 +317,8 @@ func (suite *createOperatorTestSuite) TestCreateMergeRegionOperator() {
 		re.Equal(1, ops[1].Len())
 		re.Equal(MergeRegion{source.GetMeta(), target.GetMeta(), true}, ops[1].Step(0).(MergeRegion))
 
-		expectedSteps := append(testCase.prepareSteps, MergeRegion{source.GetMeta(), target.GetMeta(), false})
+		expectedSteps := slices.Clone(testCase.prepareSteps)
+		expectedSteps = append(expectedSteps, MergeRegion{source.GetMeta(), target.GetMeta(), false})
 		for i := range ops[0].Len() {
 			switch step := ops[0].Step(i).(type) {
 			case TransferLeader:

--- a/pkg/schedule/operator/operator_controller_test.go
+++ b/pkg/schedule/operator/operator_controller_test.go
@@ -111,7 +111,11 @@ func (suite *operatorControllerTestSuite) TestGetOpInfluence() {
 	oc.SetOperator(op1)
 	re.True(op2.Start())
 	oc.SetOperator(op2)
+	ctx, cancel := context.WithCancel(suite.ctx)
+	var wg sync.WaitGroup
+	wg.Add(2)
 	go func(ctx context.Context) {
+		defer wg.Done()
 		as := assert.New(suite.T())
 		if !as.True(oc.RemoveOperator(op1)) ||
 			!as.True(op1.IsEnd()) ||
@@ -128,8 +132,9 @@ func (suite *operatorControllerTestSuite) TestGetOpInfluence() {
 				}
 			}
 		}
-	}(suite.ctx)
+	}(ctx)
 	go func(ctx context.Context) {
+		defer wg.Done()
 		for {
 			select {
 			case <-ctx.Done():
@@ -138,8 +143,10 @@ func (suite *operatorControllerTestSuite) TestGetOpInfluence() {
 				oc.GetOpInfluence(tc.GetBasicCluster())
 			}
 		}
-	}(suite.ctx)
+	}(ctx)
 	time.Sleep(time.Second)
+	cancel()
+	wg.Wait()
 	re.NotNil(oc.GetOperator(2))
 }
 
@@ -325,19 +332,20 @@ func (suite *operatorControllerTestSuite) TestConcurrentRemoveOperator() {
 
 	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/schedule/operator/concurrentRemoveOperator", "return(true)"))
 	var wg sync.WaitGroup
+	var success bool
 	wg.Add(2)
 	go func() {
+		defer wg.Done()
 		oc.Dispatch(region1, "test", nil)
-		wg.Done()
 	}()
 	go func() {
+		defer wg.Done()
 		time.Sleep(50 * time.Millisecond)
-		success := oc.AddOperator(op2)
-		wg.Done()
-		suite.True(success)
+		success = oc.AddOperator(op2)
 	}()
 	wg.Wait()
 
+	re.True(success)
 	re.Equal(op2, oc.GetOperator(1))
 	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/schedule/operator/concurrentRemoveOperator"))
 }

--- a/pkg/schedule/operator/operator_controller_test.go
+++ b/pkg/schedule/operator/operator_controller_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
@@ -111,13 +112,20 @@ func (suite *operatorControllerTestSuite) TestGetOpInfluence() {
 	re.True(op2.Start())
 	oc.SetOperator(op2)
 	go func(ctx context.Context) {
-		checkRemoveOperatorSuccess(re, oc, op1)
+		as := assert.New(suite.T())
+		if !as.True(oc.RemoveOperator(op1)) ||
+			!as.True(op1.IsEnd()) ||
+			!as.Equal(op1, oc.GetOperatorStatus(op1.RegionID()).Operator) {
+			return
+		}
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			default:
-				re.False(oc.RemoveOperator(op1))
+				if !as.False(oc.RemoveOperator(op1)) {
+					return
+				}
 			}
 		}
 	}(suite.ctx)
@@ -325,9 +333,8 @@ func (suite *operatorControllerTestSuite) TestConcurrentRemoveOperator() {
 	go func() {
 		time.Sleep(50 * time.Millisecond)
 		success := oc.AddOperator(op2)
-		// If the assert failed before wg.Done, the test will be blocked.
-		defer re.True(success)
 		wg.Done()
+		suite.True(success)
 	}()
 	wg.Wait()
 
@@ -521,12 +528,14 @@ func (suite *operatorControllerTestSuite) TestConcurrentMergeConflict() {
 			go func() {
 				defer wg.Done()
 				ops1, err := CreateMergeRegionOperator("merge-region", cluster, left, middle, OpMerge)
-				re.NoError(err)
-				re.Len(ops1, 2)
+				if !suite.NoError(err) || !suite.Len(ops1, 2) {
+					return
+				}
 				controller.AddWaitingOperator(ops1...)
 				ops2, err := CreateMergeRegionOperator("merge-region", cluster, middle, right, OpMerge)
-				re.NoError(err)
-				re.Len(ops2, 2)
+				if !suite.NoError(err) || !suite.Len(ops2, 2) {
+					return
+				}
 				controller.AddWaitingOperator(ops2...)
 			}()
 		}
@@ -1049,7 +1058,7 @@ func (suite *operatorControllerTestSuite) TestInvalidStoreId() {
 }
 
 func TestConcurrentAddOperatorAndSetStoreLimit(t *testing.T) {
-	re := require.New(t)
+	as := assert.New(t)
 	opt := mockconfig.NewTestOptions()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -1077,7 +1086,9 @@ func TestConcurrentAddOperatorAndSetStoreLimit(t *testing.T) {
 			for j := 1; j < 10; j++ {
 				regionID := uint64(j) + i*100
 				op := NewTestOperator(regionID, tc.GetRegion(regionID).GetRegionEpoch(), OpRegion, AddPeer{ToStore: storeID, PeerID: regionID})
-				re.True(oc.AddOperator(op))
+				if !as.True(oc.AddOperator(op)) {
+					return
+				}
 				tc.SetStoreLimit(storeID, storelimit.AddPeer, limit-float64(j)) // every goroutine set a different limit
 			}
 		}(uint64(i))

--- a/pkg/schedule/operator/operator_controller_test.go
+++ b/pkg/schedule/operator/operator_controller_test.go
@@ -112,7 +112,7 @@ func (suite *operatorControllerTestSuite) TestGetOpInfluence() {
 	re.True(op2.Start())
 	oc.SetOperator(op2)
 	ctx, cancel := context.WithCancel(suite.ctx)
-	var wg sync.WaitGroup
+	wg := &sync.WaitGroup{}
 	wg.Add(2)
 	go func(ctx context.Context) {
 		defer wg.Done()

--- a/pkg/schedule/operator/operator_test.go
+++ b/pkg/schedule/operator/operator_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
@@ -637,7 +638,7 @@ func TestOperatorCheckConcurrently(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			re.Nil(op.Check(region))
+			assert.Nil(t, op.Check(region))
 		}()
 	}
 	wg.Wait()

--- a/pkg/schedule/placement/rule.go
+++ b/pkg/schedule/placement/rule.go
@@ -17,6 +17,7 @@ package placement
 import (
 	"encoding/hex"
 	"encoding/json"
+	"slices"
 	"sort"
 
 	"github.com/pingcap/kvproto/pkg/metapb"
@@ -91,8 +92,8 @@ func (r *Rule) String() string {
 func (r *Rule) Clone() *Rule {
 	var clone Rule
 	_ = json.Unmarshal([]byte(r.String()), &clone)
-	clone.StartKey = append(r.StartKey[:0:0], r.StartKey...)
-	clone.EndKey = append(r.EndKey[:0:0], r.EndKey...)
+	clone.StartKey = slices.Clone(r.StartKey)
+	clone.EndKey = slices.Clone(r.EndKey)
 	return &clone
 }
 

--- a/pkg/schedule/schedulers/balance_leader.go
+++ b/pkg/schedule/schedulers/balance_leader.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"slices"
 	"sort"
 	"strconv"
 
@@ -460,7 +461,8 @@ func (s *balanceLeaderScheduler) transferLeaderOut(solver *solver, collector *pl
 	finalFilters := s.filters
 	conf := solver.GetSchedulerConfig()
 	if leaderFilter := filter.NewPlacementLeaderSafeguard(s.GetName(), conf, solver.GetBasicCluster(), solver.GetRuleManager(), solver.Region, solver.Source, false /*allowMoveLeader*/); leaderFilter != nil {
-		finalFilters = append(s.filters, leaderFilter)
+		finalFilters = slices.Clone(s.filters)
+		finalFilters = append(finalFilters, leaderFilter)
 	}
 	targets = filter.SelectTargetStores(targets, finalFilters, conf, collector, s.filterCounter)
 	leaderSchedulePolicy := conf.GetLeaderSchedulePolicy()
@@ -525,7 +527,8 @@ func (s *balanceLeaderScheduler) transferLeaderIn(solver *solver, collector *pla
 	// Check if the target store is available as a target.
 	finalFilters := s.filters
 	if leaderFilter := filter.NewPlacementLeaderSafeguard(s.GetName(), conf, solver.GetBasicCluster(), solver.GetRuleManager(), solver.Region, solver.Source, false /*allowMoveLeader*/); leaderFilter != nil {
-		finalFilters = append(s.filters, leaderFilter)
+		finalFilters = slices.Clone(s.filters)
+		finalFilters = append(finalFilters, leaderFilter)
 	}
 	target := filter.NewCandidates([]*core.StoreInfo{solver.Target}).
 		FilterTarget(conf, nil, s.filterCounter, finalFilters...).

--- a/pkg/schedule/schedulers/balance_leader.go
+++ b/pkg/schedule/schedulers/balance_leader.go
@@ -461,8 +461,7 @@ func (s *balanceLeaderScheduler) transferLeaderOut(solver *solver, collector *pl
 	finalFilters := s.filters
 	conf := solver.GetSchedulerConfig()
 	if leaderFilter := filter.NewPlacementLeaderSafeguard(s.GetName(), conf, solver.GetBasicCluster(), solver.GetRuleManager(), solver.Region, solver.Source, false /*allowMoveLeader*/); leaderFilter != nil {
-		finalFilters = slices.Clone(s.filters)
-		finalFilters = append(finalFilters, leaderFilter)
+		finalFilters = slices.Concat(s.filters, []filter.Filter{leaderFilter})
 	}
 	targets = filter.SelectTargetStores(targets, finalFilters, conf, collector, s.filterCounter)
 	leaderSchedulePolicy := conf.GetLeaderSchedulePolicy()
@@ -527,8 +526,7 @@ func (s *balanceLeaderScheduler) transferLeaderIn(solver *solver, collector *pla
 	// Check if the target store is available as a target.
 	finalFilters := s.filters
 	if leaderFilter := filter.NewPlacementLeaderSafeguard(s.GetName(), conf, solver.GetBasicCluster(), solver.GetRuleManager(), solver.Region, solver.Source, false /*allowMoveLeader*/); leaderFilter != nil {
-		finalFilters = slices.Clone(s.filters)
-		finalFilters = append(finalFilters, leaderFilter)
+		finalFilters = slices.Concat(s.filters, []filter.Filter{leaderFilter})
 	}
 	target := filter.NewCandidates([]*core.StoreInfo{solver.Target}).
 		FilterTarget(conf, nil, s.filterCounter, finalFilters...).

--- a/pkg/schedule/schedulers/balance_witness.go
+++ b/pkg/schedule/schedulers/balance_witness.go
@@ -308,8 +308,7 @@ func (s *balanceWitnessScheduler) transferWitnessOut(solver *solver, collector *
 	finalFilters := s.filters
 	conf := solver.GetSchedulerConfig()
 	if witnessFilter := filter.NewPlacementWitnessSafeguard(s.GetName(), conf, solver.GetBasicCluster(), solver.GetRuleManager(), solver.Region, solver.Source, solver.fit); witnessFilter != nil {
-		finalFilters = slices.Clone(s.filters)
-		finalFilters = append(finalFilters, witnessFilter)
+		finalFilters = slices.Concat(s.filters, []filter.Filter{witnessFilter})
 	}
 	targets = filter.SelectTargetStores(targets, finalFilters, conf, collector, s.filterCounter)
 	sort.Slice(targets, func(i, j int) bool {

--- a/pkg/schedule/schedulers/balance_witness.go
+++ b/pkg/schedule/schedulers/balance_witness.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"slices"
 	"sort"
 	"strconv"
 
@@ -307,7 +308,8 @@ func (s *balanceWitnessScheduler) transferWitnessOut(solver *solver, collector *
 	finalFilters := s.filters
 	conf := solver.GetSchedulerConfig()
 	if witnessFilter := filter.NewPlacementWitnessSafeguard(s.GetName(), conf, solver.GetBasicCluster(), solver.GetRuleManager(), solver.Region, solver.Source, solver.fit); witnessFilter != nil {
-		finalFilters = append(s.filters, witnessFilter)
+		finalFilters = slices.Clone(s.filters)
+		finalFilters = append(finalFilters, witnessFilter)
 	}
 	targets = filter.SelectTargetStores(targets, finalFilters, conf, collector, s.filterCounter)
 	sort.Slice(targets, func(i, j int) bool {

--- a/pkg/schedule/schedulers/diagnostic_recorder.go
+++ b/pkg/schedule/schedulers/diagnostic_recorder.go
@@ -183,7 +183,7 @@ func (d *DiagnosticRecorder) analyze(ops []*operator.Operator, plans []plan.Plan
 		}
 		res.Status = Pending
 		if d.summaryFunc != nil {
-			isAllNormal := false
+			var isAllNormal bool
 			res.StoreStatus, isAllNormal, _ = d.summaryFunc(plans)
 			if isAllNormal {
 				res.Status = Normal

--- a/pkg/storage/kv/kv_test.go
+++ b/pkg/storage/kv/kv_test.go
@@ -16,6 +16,7 @@ package kv
 
 import (
 	"context"
+	"slices"
 	"sort"
 	"strconv"
 	"testing"
@@ -100,7 +101,7 @@ func testRange(re *require.Assertions, kv Base) {
 		err := kv.Save(k, k)
 		re.NoError(err)
 	}
-	sortedKeys := append(keys[:0:0], keys...)
+	sortedKeys := slices.Clone(keys)
 	sort.Strings(sortedKeys)
 
 	testCases := []struct {

--- a/pkg/tso/keyspace_group_manager_test.go
+++ b/pkg/tso/keyspace_group_manager_test.go
@@ -880,7 +880,9 @@ func (suite *keyspaceGroupManagerTestSuite) runTestLoadKeyspaceGroupsAssignment(
 				err := addKeyspaceGroupAssignment(
 					suite.ctx, suite.etcdClient, uint32(j),
 					svcAddrs, []int{0}, []uint32{uint32(j)})
-				re.NoError(err)
+				if !suite.NoError(err) {
+					return
+				}
 			}
 		}(i)
 	}

--- a/pkg/unsaferecovery/unsafe_recovery_controller.go
+++ b/pkg/unsaferecovery/unsafe_recovery_controller.go
@@ -429,7 +429,7 @@ func (u *Controller) generatePlan(newestRegionTree *regionTree, peersMap map[uin
 
 	stage := u.stage
 	reCheck := false
-	hasPlan := false
+	var hasPlan bool
 	var err error
 	for {
 		switch stage {

--- a/pkg/utils/syncutil/ordered_single_flight_test.go
+++ b/pkg/utils/syncutil/ordered_single_flight_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/pingcap/errors"
@@ -48,6 +49,7 @@ func mustGetResult[T any](re *require.Assertions, ch chan T) T {
 }
 
 func TestOrderedSingleFlight(t *testing.T) {
+	as := assert.New(t)
 	re := require.New(t)
 
 	ctx := context.Background()
@@ -78,7 +80,7 @@ func TestOrderedSingleFlight(t *testing.T) {
 	// Start the first call
 	go func() {
 		res, err := s.Do(ctx, f)
-		re.NoError(err)
+		as.NoError(err)
 		outCh <- res
 	}()
 
@@ -94,7 +96,7 @@ func TestOrderedSingleFlight(t *testing.T) {
 				res, err := s.Do(ctx, func(context.Context) (int, error) {
 					return <-inCh, nil
 				})
-				re.NoError(err)
+				as.NoError(err)
 				outCh <- res
 			})
 		}()
@@ -520,7 +522,7 @@ func TestOrderedSingleFlightCancellationWithCancellableFunction(t *testing.T) {
 }
 
 func TestOrderedSingleFightRandom(t *testing.T) {
-	re := require.New(t)
+	as := assert.New(t)
 
 	const concurrency = 10
 	const testTime = time.Second * 10
@@ -607,21 +609,27 @@ func TestOrderedSingleFightRandom(t *testing.T) {
 					if shouldCancel {
 						// It might finish before the cancel takes effect.
 						if r.err != nil {
-							re.ErrorIs(r.err, context.Canceled)
+							if !as.ErrorIs(r.err, context.Canceled) {
+								return
+							}
 						}
 					} else {
-						re.NoError(r.err)
+						if !as.NoError(r.err) {
+							return
+						}
 					}
 
 					// Check the strong order if the invocation is successful
 					if r.err == nil {
-						re.GreaterOrEqual(r.v, beforeValue)
-						re.LessOrEqual(r.v, afterValue)
+						if !as.GreaterOrEqual(r.v, beforeValue) || !as.LessOrEqual(r.v, afterValue) {
+							return
+						}
 					}
 
 				case <-time.After(testTime * 2):
 					innerCancel()
-					re.FailNow("result blocked for too long")
+					as.Fail("result blocked for too long")
+					return
 				}
 			}
 		}()

--- a/pkg/utils/testutil/testutil.go
+++ b/pkg/utils/testutil/testutil.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -56,8 +57,7 @@ func WithTickInterval(tickInterval time.Duration) WaitOption {
 	return func(op *WaitOp) { op.tickInterval = tickInterval }
 }
 
-// Eventually asserts that given condition will be met in a period of time.
-func Eventually(re *require.Assertions, condition func() bool, opts ...WaitOption) {
+func newWaitOp(opts ...WaitOption) *WaitOp {
 	option := &WaitOp{
 		waitFor:      defaultWaitFor,
 		tickInterval: defaultTickInterval,
@@ -65,7 +65,23 @@ func Eventually(re *require.Assertions, condition func() bool, opts ...WaitOptio
 	for _, opt := range opts {
 		opt(option)
 	}
+	return option
+}
+
+// Eventually asserts that given condition will be met in a period of time.
+func Eventually(re *require.Assertions, condition func() bool, opts ...WaitOption) {
+	option := newWaitOp(opts...)
 	re.Eventually(
+		condition,
+		option.waitFor,
+		option.tickInterval,
+	)
+}
+
+// EventuallyWithAssert checks that the condition is met without stopping the calling goroutine.
+func EventuallyWithAssert(as *assert.Assertions, condition func() bool, opts ...WaitOption) bool {
+	option := newWaitOp(opts...)
+	return as.Eventually(
 		condition,
 		option.waitFor,
 		option.tickInterval,

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/docker/go-units"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
@@ -1426,7 +1427,7 @@ func TestConcurrentReportBucket(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		_, err := cluster.processRegionBuckets(bucket1)
-		re.NoError(err)
+		assert.NoError(t, err)
 	}()
 	time.Sleep(100 * time.Millisecond)
 	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/core/concurrentBucketHeartbeat"))
@@ -1466,7 +1467,7 @@ func TestConcurrentRegionHeartbeat(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		err := cluster.processRegionHeartbeat(core.ContextTODO(), source)
-		re.NoError(err)
+		assert.NoError(t, err)
 	}()
 	time.Sleep(100 * time.Millisecond)
 	re.NoError(failpoint.Disable("github.com/tikv/pd/server/cluster/concurrentRegionHeartbeat"))
@@ -2945,7 +2946,9 @@ func TestCollectMetricsConcurrent(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			for range 1000 {
-				re.NoError(tc.addRegionStore(uint64(i%5), rand.IntN(200)))
+				if !assert.NoError(t, tc.addRegionStore(uint64(i%5), rand.IntN(200))) {
+					return
+				}
 			}
 		}(i)
 	}

--- a/tests/integrations/client/client_test.go
+++ b/tests/integrations/client/client_test.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/docker/go-units"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -144,6 +145,7 @@ func TestClientLeaderChange(t *testing.T) {
 }
 
 func TestLeaderTransferAndMoveCluster(t *testing.T) {
+	as := assert.New(t)
 	re := require.New(t)
 	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/member/skipCampaignLeaderCheck", "return(true)"))
 	defer func() {
@@ -187,8 +189,9 @@ func TestLeaderTransferAndMoveCluster(t *testing.T) {
 			physical, logical, err := cli.GetTS(context.TODO())
 			if err == nil {
 				ts := tsoutil.ComposeTS(physical, logical)
-				re.True(cluster.CheckTSOUnique(ts))
-				re.Less(lastTS, ts)
+				if !as.True(cluster.CheckTSOUnique(ts)) || !as.Less(lastTS, ts) {
+					return
+				}
 				lastTS = ts
 			}
 			time.Sleep(time.Millisecond)
@@ -266,6 +269,7 @@ func TestGetTSAfterTransferLeader(t *testing.T) {
 }
 
 func TestTSOFollowerProxy(t *testing.T) {
+	as := assert.New(t)
 	re := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -290,15 +294,23 @@ func TestTSOFollowerProxy(t *testing.T) {
 			var lastTS uint64
 			for range tsoRequestRound {
 				physical, logical, err := cli2.GetTS(context.Background())
-				re.NoError(err)
+				if !as.NoError(err) {
+					return
+				}
 				ts := tsoutil.ComposeTS(physical, logical)
-				re.Less(lastTS, ts)
+				if !as.Less(lastTS, ts) {
+					return
+				}
 				lastTS = ts
 				// After requesting with the follower proxy, request with the leader directly.
 				physical, logical, err = cli1.GetTS(context.Background())
-				re.NoError(err)
+				if !as.NoError(err) {
+					return
+				}
 				ts = tsoutil.ComposeTS(physical, logical)
-				re.Less(lastTS, ts)
+				if !as.Less(lastTS, ts) {
+					return
+				}
 				lastTS = ts
 			}
 		}()
@@ -316,7 +328,7 @@ func TestTSOFollowerProxy(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		re.NoError(followerServer.Run())
+		as.NoError(followerServer.Run())
 	}()
 	re.Eventually(func() bool {
 		_, _, err := cli2.GetTS(context.Background())
@@ -343,22 +355,32 @@ func TestTSOFollowerProxy(t *testing.T) {
 				physical, logical, err := cli2.GetTS(context.Background())
 				if err != nil {
 					// It can only be the context canceled error caused by the stale stream cleanup.
-					re.ErrorContains(err, "context canceled")
+					if !as.ErrorContains(err, "context canceled") {
+						return
+					}
 					continue
 				}
-				re.NoError(err)
+				if !as.NoError(err) {
+					return
+				}
 				ts := tsoutil.ComposeTS(physical, logical)
-				re.Less(lastTS, ts)
+				if !as.Less(lastTS, ts) {
+					return
+				}
 				lastTS = ts
 				// After requesting with the follower proxy, request with the leader directly.
 				physical, logical, err = cli1.GetTS(context.Background())
-				re.NoError(err)
+				if !as.NoError(err) {
+					return
+				}
 				ts = tsoutil.ComposeTS(physical, logical)
-				re.Less(lastTS, ts)
+				if !as.Less(lastTS, ts) {
+					return
+				}
 				lastTS = ts
 			}
 			// Ensure at least one request is successful.
-			re.NotEmpty(lastTS)
+			as.NotEmpty(lastTS)
 		}()
 	}
 	wg.Wait()
@@ -393,6 +415,7 @@ func TestTSOFollowerProxyWithTSOService(t *testing.T) {
 
 // TestUnavailableTimeAfterLeaderIsReady is used to test https://github.com/tikv/pd/issues/5207
 func TestUnavailableTimeAfterLeaderIsReady(t *testing.T) {
+	as := assert.New(t)
 	re := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -416,8 +439,9 @@ func TestUnavailableTimeAfterLeaderIsReady(t *testing.T) {
 				maxUnavailableTime = time.Now()
 				continue
 			}
-			re.NoError(err)
-			re.Less(lastTS, ts)
+			if !as.Less(lastTS, ts) {
+				return
+			}
 			lastTS = ts
 		}
 	}
@@ -429,11 +453,12 @@ func TestUnavailableTimeAfterLeaderIsReady(t *testing.T) {
 		defer wg.Done()
 		leader := cluster.GetLeaderServer()
 		err := leader.Stop()
-		re.NoError(err)
-		re.NotEmpty(cluster.WaitLeader())
+		if !as.NoError(err) || !as.NotEmpty(cluster.WaitLeader()) {
+			return
+		}
 		leaderReadyTime = time.Now()
 		err = tests.RunServers([]*tests.TestServer{leader})
-		re.NoError(err)
+		as.NoError(err)
 	}()
 	wg.Wait()
 	re.Less(maxUnavailableTime.UnixMilli(), leaderReadyTime.Add(1*time.Second).UnixMilli())
@@ -445,11 +470,16 @@ func TestUnavailableTimeAfterLeaderIsReady(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		leader := cluster.GetLeaderServer()
-		re.NoError(failpoint.Enable("github.com/tikv/pd/client/clients/tso/unreachableNetwork", "return(true)"))
+		if !as.NoError(failpoint.Enable("github.com/tikv/pd/client/clients/tso/unreachableNetwork", "return(true)")) {
+			return
+		}
 		err := leader.Stop()
-		re.NoError(err)
-		re.NotEmpty(cluster.WaitLeader())
-		re.NoError(failpoint.Disable("github.com/tikv/pd/client/clients/tso/unreachableNetwork"))
+		if !as.NoError(err) || !as.NotEmpty(cluster.WaitLeader()) {
+			return
+		}
+		if !as.NoError(failpoint.Disable("github.com/tikv/pd/client/clients/tso/unreachableNetwork")) {
+			return
+		}
 		leaderReadyTime = time.Now()
 	}()
 	wg.Wait()
@@ -1424,6 +1454,7 @@ func (suite *clientStatelessTestSuite) TestScatterRegion() {
 }
 
 func TestWatch(t *testing.T) {
+	as := assert.New(t)
 	re := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -1449,11 +1480,15 @@ func TestWatch(t *testing.T) {
 				break
 			}
 		}
-		re.Equal(meta_storagepb.Event_PUT, events[0].GetType())
-		re.Equal("1", string(events[0].GetKv().GetValue()))
-		re.Equal(meta_storagepb.Event_PUT, events[1].GetType())
-		re.Equal("2", string(events[1].GetKv().GetValue()))
-		re.Equal(meta_storagepb.Event_DELETE, events[2].GetType())
+		if !as.Len(events, 3) {
+			exit <- struct{}{}
+			return
+		}
+		as.Equal(meta_storagepb.Event_PUT, events[0].GetType())
+		as.Equal("1", string(events[0].GetKv().GetValue()))
+		as.Equal(meta_storagepb.Event_PUT, events[1].GetType())
+		as.Equal("2", string(events[1].GetKv().GetValue()))
+		as.Equal(meta_storagepb.Event_DELETE, events[2].GetType())
 		exit <- struct{}{}
 	}()
 

--- a/tests/integrations/client/client_test.go
+++ b/tests/integrations/client/client_test.go
@@ -2428,13 +2428,13 @@ func (s *clientStatefulTestSuite) TestAdvanceGCSafePoint() {
 		s.checkGCSafePoint(re, keyspaceID, 5)
 
 		// Disallows going backward.
-		res, err = c.AdvanceGCSafePoint(ctx, 4)
+		_, err = c.AdvanceGCSafePoint(ctx, 4)
 		re.Error(err)
 		re.Contains(err.Error(), "ErrDecreasingGCSafePoint")
 		s.checkGCSafePoint(re, keyspaceID, 5)
 
 		// Disallows exceeding txn safe point.
-		res, err = c.AdvanceGCSafePoint(ctx, 11)
+		_, err = c.AdvanceGCSafePoint(ctx, 11)
 		re.Error(err)
 		re.Contains(err.Error(), "ErrGCSafePointExceedsTxnSafePoint")
 		// Do not change the current value in this case.

--- a/tests/integrations/client/http_client_test.go
+++ b/tests/integrations/client/http_client_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
@@ -1144,6 +1145,7 @@ func (suite *httpClientTestSuite) TestGetHealthStatus() {
 }
 
 func (suite *httpClientTestSuite) TestRetryOnLeaderChange() {
+	as := assert.New(suite.T())
 	re := suite.Require()
 	ctx, cancel := context.WithCancel(suite.ctx)
 	defer cancel()
@@ -1159,8 +1161,9 @@ func (suite *httpClientTestSuite) TestRetryOnLeaderChange() {
 			if err != nil && strings.Contains(err.Error(), "context canceled") {
 				return
 			}
-			re.NoError(err)
-			re.Len(healths, 2)
+			if !as.NoError(err) || !as.Len(healths, 2) {
+				return
+			}
 			select {
 			case <-ctx.Done():
 				return

--- a/tests/integrations/client/router_client_test.go
+++ b/tests/integrations/client/router_client_test.go
@@ -317,7 +317,7 @@ func (suite *routerClientSuite) dispatchConcurrentRequests(ctx context.Context, 
 			switch seed % 3 {
 			case 0:
 				region := regions[0]
-				testutil.Eventually(re, func() bool {
+				if !testutil.EventuallyWithAssert(as, func() bool {
 					if allowFollowerHandle {
 						r, err = suite.client.GetRegion(ctx, region.GetStartKey(), opt.WithAllowFollowerHandle())
 					} else {
@@ -335,9 +335,11 @@ func (suite *routerClientSuite) dispatchConcurrentRequests(ctx context.Context, 
 					return reflect.DeepEqual(region, r.Meta) &&
 						reflect.DeepEqual(peers[0], r.Leader) &&
 						r.Buckets == nil
-				})
+				}) {
+					return
+				}
 			case 1:
-				testutil.Eventually(re, func() bool {
+				if !testutil.EventuallyWithAssert(as, func() bool {
 					if allowFollowerHandle {
 						r, err = suite.client.GetPrevRegion(ctx, regions[1].GetStartKey(), opt.WithAllowFollowerHandle())
 					} else {
@@ -355,10 +357,12 @@ func (suite *routerClientSuite) dispatchConcurrentRequests(ctx context.Context, 
 					return reflect.DeepEqual(regions[0], r.Meta) &&
 						reflect.DeepEqual(peers[0], r.Leader) &&
 						r.Buckets == nil
-				})
+				}) {
+					return
+				}
 			case 2:
 				region := regions[0]
-				testutil.Eventually(re, func() bool {
+				if !testutil.EventuallyWithAssert(as, func() bool {
 					if allowFollowerHandle {
 						r, err = suite.client.GetRegionByID(ctx, region.GetId(), opt.WithAllowFollowerHandle())
 					} else {
@@ -376,7 +380,9 @@ func (suite *routerClientSuite) dispatchConcurrentRequests(ctx context.Context, 
 					return reflect.DeepEqual(region, r.Meta) &&
 						reflect.DeepEqual(peers[0], r.Leader) &&
 						r.Buckets == nil
-				})
+				}) {
+					return
+				}
 			}
 		}()
 	}

--- a/tests/integrations/client/router_client_test.go
+++ b/tests/integrations/client/router_client_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
@@ -277,6 +278,7 @@ func (suite *routerClientSuite) TestGetRegionConcurrently() {
 }
 
 func (suite *routerClientSuite) dispatchConcurrentRequests(ctx context.Context, re *require.Assertions, wg *sync.WaitGroup) {
+	as := assert.New(suite.T())
 	regions := make([]*metapb.Region, 0, 2)
 	for i := range 2 {
 		regionID := regionIDAllocator.alloc()
@@ -325,7 +327,7 @@ func (suite *routerClientSuite) dispatchConcurrentRequests(ctx context.Context, 
 						if strings.Contains(err.Error(), "region not found") {
 							return false
 						}
-						re.ErrorContains(err, context.Canceled.Error())
+						as.Contains(err.Error(), context.Canceled.Error())
 					}
 					if r == nil {
 						return false
@@ -345,7 +347,7 @@ func (suite *routerClientSuite) dispatchConcurrentRequests(ctx context.Context, 
 						if strings.Contains(err.Error(), "region not found") {
 							return false
 						}
-						re.ErrorContains(err, context.Canceled.Error())
+						as.Contains(err.Error(), context.Canceled.Error())
 					}
 					if r == nil {
 						return false
@@ -366,7 +368,7 @@ func (suite *routerClientSuite) dispatchConcurrentRequests(ctx context.Context, 
 						if strings.Contains(err.Error(), "region not found") {
 							return false
 						}
-						re.ErrorContains(err, context.Canceled.Error())
+						as.Contains(err.Error(), context.Canceled.Error())
 					}
 					if r == nil {
 						return false

--- a/tests/integrations/mcs/scheduling/server_test.go
+++ b/tests/integrations/mcs/scheduling/server_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/docker/go-units"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/goleak"
@@ -1543,6 +1544,7 @@ func (suite *serverTestSuite) TestConcurrentBatchSplit() {
 }
 
 func (suite *serverTestSuite) checkConcurrentAllocatedID(re *require.Assertions, req *pdpb.AskBatchSplitRequest, grpcPDClient pdpb.PDClient) {
+	as := assert.New(suite.T())
 	var wg sync.WaitGroup
 	var allocatedIDs sync.Map
 	for range 100 {
@@ -1550,15 +1552,20 @@ func (suite *serverTestSuite) checkConcurrentAllocatedID(re *require.Assertions,
 		go func() {
 			defer wg.Done()
 			resp, err := grpcPDClient.AskBatchSplit(suite.ctx, req)
-			re.NoError(err)
-			re.Empty(resp.GetHeader().GetError())
+			if !as.NoError(err) || !as.Empty(resp.GetHeader().GetError()) {
+				return
+			}
 			for _, id := range resp.GetIds() {
 				_, ok := allocatedIDs.Load(id.NewRegionId)
-				re.False(ok)
+				if !as.False(ok) {
+					return
+				}
 				allocatedIDs.Store(id.NewRegionId, struct{}{})
 				for _, peer := range id.NewPeerIds {
 					_, ok := allocatedIDs.Load(peer)
-					re.False(ok)
+					if !as.False(ok) {
+						return
+					}
 					allocatedIDs.Store(peer, struct{}{})
 				}
 			}
@@ -1574,6 +1581,7 @@ func (suite *serverTestSuite) checkConcurrentAllocatedID(re *require.Assertions,
 }
 
 func (suite *serverTestSuite) TestForwardSplitRegion() {
+	as := assert.New(suite.T())
 	re := suite.Require()
 	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/schedule/changeCoordinatorTicker"))
 	tc, err := tests.NewTestSchedulingCluster(suite.ctx, 1, suite.cluster)
@@ -1664,7 +1672,9 @@ func (suite *serverTestSuite) TestForwardSplitRegion() {
 			ApproximateSize: 100 * units.MiB,
 			ApproximateKeys: 1000,
 		}
-		re.NoError(stream.Send(regionReq))
+		if !as.NoError(stream.Send(regionReq)) {
+			return
+		}
 		regionReq = &pdpb.RegionHeartbeatRequest{
 			Header: testutil.NewRequestHeader(suite.pdLeader.GetClusterID()),
 			Region: &metapb.Region{
@@ -1680,7 +1690,7 @@ func (suite *serverTestSuite) TestForwardSplitRegion() {
 			ApproximateSize: 100 * units.MiB,
 			ApproximateKeys: 1000,
 		}
-		re.NoError(stream.Send(regionReq))
+		as.NoError(stream.Send(regionReq))
 	}()
 
 	// Forward SplitRegions request through PD to scheduling service

--- a/tests/integrations/mcs/tso/api_test.go
+++ b/tests/integrations/mcs/tso/api_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
@@ -134,7 +133,6 @@ func mustGetKeyspaceGroupMembers(re *require.Assertions, server *tso.Server) map
 }
 
 func TestTSOServerStartFirst(t *testing.T) {
-	as := assert.New(t)
 	re := require.New(t)
 	re.NoError(failpoint.Enable("github.com/tikv/pd/server/delayStartServerLoop", `return(true)`))
 	ctx, cancel := context.WithCancel(context.Background())
@@ -147,17 +145,14 @@ func TestTSOServerStartFirst(t *testing.T) {
 	defer cluster.Destroy()
 	re.NoError(err)
 	addr := cluster.GetConfig().GetClientURL()
-	ch := make(chan struct{})
-	defer close(ch)
-	clusterCh := make(chan *tests.TestTSOCluster)
-	defer close(clusterCh)
+	type clusterResult struct {
+		cluster *tests.TestTSOCluster
+		err     error
+	}
+	clusterCh := make(chan clusterResult, 1)
 	go func() {
 		tsoCluster, err := tests.NewTestTSOCluster(ctx, 2, addr)
-		as.NoError(err)
-		primary := tsoCluster.WaitForDefaultPrimaryServing(re)
-		as.NotNil(primary)
-		clusterCh <- tsoCluster
-		ch <- struct{}{}
+		clusterCh <- clusterResult{cluster: tsoCluster, err: err}
 	}()
 	err = cluster.RunInitialServers()
 	re.NoError(err)
@@ -166,9 +161,12 @@ func TestTSOServerStartFirst(t *testing.T) {
 	pdLeaderServer := cluster.GetServer(leaderName)
 	re.NoError(pdLeaderServer.BootstrapCluster())
 	re.NoError(err)
-	tsoCluster := <-clusterCh
+	result := <-clusterCh
+	re.NoError(result.err)
+	tsoCluster := result.cluster
 	defer tsoCluster.Destroy()
-	<-ch
+	primary := tsoCluster.WaitForDefaultPrimaryServing(re)
+	re.NotNil(primary)
 
 	time.Sleep(time.Second * 1)
 	input := make(map[string]any)

--- a/tests/integrations/mcs/tso/api_test.go
+++ b/tests/integrations/mcs/tso/api_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
@@ -133,6 +134,7 @@ func mustGetKeyspaceGroupMembers(re *require.Assertions, server *tso.Server) map
 }
 
 func TestTSOServerStartFirst(t *testing.T) {
+	as := assert.New(t)
 	re := require.New(t)
 	re.NoError(failpoint.Enable("github.com/tikv/pd/server/delayStartServerLoop", `return(true)`))
 	ctx, cancel := context.WithCancel(context.Background())
@@ -151,9 +153,9 @@ func TestTSOServerStartFirst(t *testing.T) {
 	defer close(clusterCh)
 	go func() {
 		tsoCluster, err := tests.NewTestTSOCluster(ctx, 2, addr)
-		re.NoError(err)
+		as.NoError(err)
 		primary := tsoCluster.WaitForDefaultPrimaryServing(re)
-		re.NotNil(primary)
+		as.NotNil(primary)
 		clusterCh <- tsoCluster
 		ch <- struct{}{}
 	}()

--- a/tests/integrations/mcs/tso/keyspace_group_manager_test.go
+++ b/tests/integrations/mcs/tso/keyspace_group_manager_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
@@ -767,6 +768,7 @@ func (suite *tsoKeyspaceGroupManagerTestSuite) TestTSOKeyspaceGroupSplitClient()
 func (suite *tsoKeyspaceGroupManagerTestSuite) dispatchClient(
 	re *require.Assertions, keyspaceID, keyspaceGroupID uint32,
 ) context.CancelFunc {
+	as := assert.New(suite.T())
 	// Make sure the primary of the keyspace group is elected.
 	primary, err := suite.tsoCluster.
 		WaitForPrimaryServing(re, keyspaceID, keyspaceGroupID).
@@ -805,12 +807,17 @@ func (suite *tsoKeyspaceGroupManagerTestSuite) dispatchClient(
 					errors.Is(err, clierrs.ErrClientTSOStreamClosed) {
 					continue
 				}
-				re.FailNow(fmt.Sprintf("%+v", err))
+				as.Fail(fmt.Sprintf("%+v", err))
+				return
 			}
 			if physical == lastPhysical {
-				re.Greater(logical, lastLogical)
+				if !as.Greater(logical, lastLogical) {
+					return
+				}
 			} else {
-				re.Greater(physical, lastPhysical)
+				if !as.Greater(physical, lastPhysical) {
+					return
+				}
 			}
 			lastPhysical, lastLogical = physical, logical
 		}

--- a/tests/integrations/mcs/tso/keyspace_group_manager_test.go
+++ b/tests/integrations/mcs/tso/keyspace_group_manager_test.go
@@ -405,6 +405,7 @@ func (suite *tsoKeyspaceGroupManagerTestSuite) TestClientDoesNotFallbackToDefaul
 func (suite *tsoKeyspaceGroupManagerTestSuite) TestKeyspacesServedByDefaultKeyspaceGroup() {
 	// There is only default keyspace group. Any keyspace, which hasn't been assigned to
 	// a keyspace group before, will be served by the default keyspace group.
+	as := assert.New(suite.T())
 	re := suite.Require()
 	testutil.Eventually(re, func() bool {
 		for _, keyspaceID := range []uint32{0, 1, 2} {
@@ -453,7 +454,7 @@ func (suite *tsoKeyspaceGroupManagerTestSuite) TestKeyspacesServedByDefaultKeysp
 	clients := utils.WaitForMultiKeyspacesTSOAvailable(
 		suite.ctx, re, keyspaceIDs, []string{suite.pdLeaderServer.GetAddr()})
 	re.Len(keyspaceIDs, len(clients))
-	utils.CheckMultiKeyspacesTSO(suite.ctx, re, clients, func() {
+	utils.CheckMultiKeyspacesTSO(suite.ctx, as, clients, func() {
 		time.Sleep(3 * time.Second)
 	})
 	for _, client := range clients {
@@ -498,6 +499,7 @@ func (suite *tsoKeyspaceGroupManagerTestSuite) waitKeyspaceReady(groupIDs []uint
 func (suite *tsoKeyspaceGroupManagerTestSuite) TestKeyspacesServedByNonDefaultKeyspaceGroups() {
 	// Create multiple keyspace groups, and every keyspace should be served by one of them
 	// on a tso server.
+	as := assert.New(suite.T())
 	re := suite.Require()
 
 	// Create 3 keyspace groups with 2 keyspaces each.
@@ -561,7 +563,7 @@ func (suite *tsoKeyspaceGroupManagerTestSuite) TestKeyspacesServedByNonDefaultKe
 	clients := utils.WaitForMultiKeyspacesTSOAvailable(
 		suite.ctx, re, keyspaceIDs, []string{suite.pdLeaderServer.GetAddr()})
 	re.Len(keyspaceIDs, len(clients))
-	utils.CheckMultiKeyspacesTSO(suite.ctx, re, clients, func() {
+	utils.CheckMultiKeyspacesTSO(suite.ctx, as, clients, func() {
 		time.Sleep(3 * time.Second)
 	})
 	for _, client := range clients {

--- a/tests/integrations/mcs/tso/proxy_test.go
+++ b/tests/integrations/mcs/tso/proxy_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
@@ -116,14 +117,18 @@ func (s *tsoProxyTestSuite) TestTSOProxyWorksWithCancellation() {
 				streams, cleanupFuncs := createTSOStreams(s.ctx, re, s.backendEndpoints, 10)
 				for range 10 {
 					err := s.verifyTSOProxy(s.ctx, streams, cleanupFuncs, 10, true)
-					re.NoError(err)
+					if !s.NoError(err) {
+						return
+					}
 				}
 				cleanupGRPCStreams(cleanupFuncs)
 			}
 		}()
 		for range 10 {
 			err := s.verifyTSOProxy(s.ctx, s.streams, s.cleanupFuncs, 10, true)
-			re.NoError(err)
+			if !s.NoError(err) {
+				return
+			}
 		}
 	}()
 	wg.Wait()
@@ -315,7 +320,7 @@ func (s *tsoProxyTestSuite) verifyTSOProxy(
 	ctx context.Context, streams []pdpb.PD_TsoClient,
 	cleanupFuncs []testutil.CleanupFunc, requestsPerClient int, mustReliable bool,
 ) error {
-	re := s.Require()
+	as := assert.New(s.T())
 	reqs := s.generateRequests(requestsPerClient)
 
 	var respErr atomic.Value
@@ -344,20 +349,25 @@ func (s *tsoProxyTestSuite) verifyTSOProxy(
 					cleanupGRPCStream(streams, cleanupFuncs, i)
 					return
 				}
-				re.NoError(err)
+				if !as.NoError(err) {
+					return
+				}
 				resp, err := streams[i].Recv()
 				if err != nil && !mustReliable {
 					respErr.Store(err)
 					cleanupGRPCStream(streams, cleanupFuncs, i)
 					return
 				}
-				re.NoError(err)
-				re.Equal(req.GetCount(), resp.GetCount())
+				if !as.NoError(err) || !as.Equal(req.GetCount(), resp.GetCount()) {
+					return
+				}
 				ts := resp.GetTimestamp()
 				count := int64(resp.GetCount())
 				physical, largestLogic := ts.GetPhysical(), ts.GetLogical()
 				firstLogical := largestLogic - count + 1
-				re.False(tsoutil.TSLessEqual(physical, firstLogical, lastPhysical, lastLogical))
+				if !as.False(tsoutil.TSLessEqual(physical, firstLogical, lastPhysical, lastLogical)) {
+					return
+				}
 			}
 		}(i)
 	}

--- a/tests/integrations/mcs/tso/proxy_test.go
+++ b/tests/integrations/mcs/tso/proxy_test.go
@@ -58,6 +58,7 @@ func TestTSOProxyTestSuite(t *testing.T) {
 }
 
 func (s *tsoProxyTestSuite) SetupSuite() {
+	as := assert.New(s.T())
 	re := s.Require()
 
 	var err error
@@ -84,7 +85,8 @@ func (s *tsoProxyTestSuite) SetupSuite() {
 	}
 
 	// Create some TSO client streams with different context.
-	s.streams, s.cleanupFuncs = createTSOStreams(s.ctx, re, s.backendEndpoints, 200)
+	s.streams, s.cleanupFuncs, err = createTSOStreams(s.ctx, as, s.backendEndpoints, 200)
+	re.NoError(err)
 }
 
 func (s *tsoProxyTestSuite) TearDownSuite() {
@@ -106,7 +108,7 @@ func (s *tsoProxyTestSuite) TestTSOProxyBasic() {
 // TestTSOProxyWithLargeCount tests while some grpc streams being cancelled and the others are still
 // working, the TSO Proxy can still work correctly.
 func (s *tsoProxyTestSuite) TestTSOProxyWorksWithCancellation() {
-	re := s.Require()
+	as := assert.New(s.T())
 	wg := &sync.WaitGroup{}
 	wg.Add(2)
 	go func() {
@@ -114,9 +116,12 @@ func (s *tsoProxyTestSuite) TestTSOProxyWorksWithCancellation() {
 		go func() {
 			defer wg.Done()
 			for range 3 {
-				streams, cleanupFuncs := createTSOStreams(s.ctx, re, s.backendEndpoints, 10)
+				streams, cleanupFuncs, err := createTSOStreams(s.ctx, as, s.backendEndpoints, 10)
+				if !as.NoError(err) {
+					return
+				}
 				for range 10 {
-					err := s.verifyTSOProxy(s.ctx, streams, cleanupFuncs, 10, true)
+					err = s.verifyTSOProxy(s.ctx, streams, cleanupFuncs, 10, true)
 					if !s.NoError(err) {
 						return
 					}
@@ -141,6 +146,7 @@ func TestTSOProxyStress(_ *testing.T) {
 	s := new(tsoProxyTestSuite)
 	s.SetT(&testing.T{})
 	s.SetupSuite()
+	as := assert.New(s.T())
 	re := s.Require()
 
 	const (
@@ -160,11 +166,12 @@ func TestTSOProxyStress(_ *testing.T) {
 	for i := range totalRounds {
 		log.Info("start a new round of stress test",
 			zap.Int("round-id", i), zap.Int("clients-count", len(streams)+clientsIncr))
-		streamsTemp, cleanupFuncsTemp :=
-			createTSOStreams(s.ctx, re, s.backendEndpoints, clientsIncr)
+		streamsTemp, cleanupFuncsTemp, err :=
+			createTSOStreams(s.ctx, as, s.backendEndpoints, clientsIncr)
+		re.NoError(err)
 		streams = append(streams, streamsTemp...)
 		cleanupFuncs = append(cleanupFuncs, cleanupFuncsTemp...)
-		err := s.verifyTSOProxy(ctxTimeout, streams, cleanupFuncs, 50, false)
+		err = s.verifyTSOProxy(ctxTimeout, streams, cleanupFuncs, 50, false)
 		re.NoError(err)
 	}
 	cleanupGRPCStreams(cleanupFuncs)
@@ -182,6 +189,7 @@ func TestTSOProxyStress(_ *testing.T) {
 // TestTSOProxyClientsWithSameContext tests the TSO Proxy can work correctly while the grpc streams
 // are created with the same context.
 func (s *tsoProxyTestSuite) TestTSOProxyClientsWithSameContext() {
+	as := assert.New(s.T())
 	re := s.Require()
 	const clientCount = 1000
 	cleanupFuncs := make([]testutil.CleanupFunc, clientCount)
@@ -199,8 +207,8 @@ func (s *tsoProxyTestSuite) TestTSOProxyClientsWithSameContext() {
 		streams[i] = stream
 		cleanupFunc := func() {
 			err = stream.CloseSend()
-			re.NoError(err)
-			conn.Close()
+			as.NoError(err)          //nolint:testifylint // Cleanup can run in a worker goroutine, where require is unsafe.
+			as.NoError(conn.Close()) //nolint:testifylint // Cleanup can run in a worker goroutine, where require is unsafe.
 		}
 		cleanupFuncs[i] = cleanupFunc
 	}
@@ -213,14 +221,16 @@ func (s *tsoProxyTestSuite) TestTSOProxyClientsWithSameContext() {
 // TestTSOProxyRecvFromClientTimeout tests the TSO Proxy can properly close the grpc stream on the server side
 // when the client does not send any request to the server for a long time.
 func (s *tsoProxyTestSuite) TestTSOProxyRecvFromClientTimeout() {
+	as := assert.New(s.T())
 	re := s.Require()
 
 	// Enable the failpoint to make the TSO Proxy's grpc stream timeout on the server side to be 1 second.
 	re.NoError(failpoint.Enable("github.com/tikv/pd/server/tsoProxyRecvFromClientTimeout", `return(1)`))
-	streams, cleanupFuncs := createTSOStreams(s.ctx, re, s.backendEndpoints, 1)
+	streams, cleanupFuncs, err := createTSOStreams(s.ctx, as, s.backendEndpoints, 1)
+	re.NoError(err)
 	// Sleep 2 seconds to make the TSO Proxy's grpc stream timeout on the server side.
 	time.Sleep(2 * time.Second)
-	err := streams[0].Send(s.defaultReq)
+	err = streams[0].Send(s.defaultReq)
 	re.Error(err)
 	cleanupGRPCStreams(cleanupFuncs)
 	re.NoError(failpoint.Disable("github.com/tikv/pd/server/tsoProxyRecvFromClientTimeout"))
@@ -233,12 +243,14 @@ func (s *tsoProxyTestSuite) TestTSOProxyRecvFromClientTimeout() {
 // TestTSOProxyFailToSendToClient tests the TSO Proxy can properly close the grpc stream on the server side
 // when it fails to send the response to the client.
 func (s *tsoProxyTestSuite) TestTSOProxyFailToSendToClient() {
+	as := assert.New(s.T())
 	re := s.Require()
 
 	// Enable the failpoint to make the TSO Proxy's grpc stream timeout on the server side to be 1 second.
 	re.NoError(failpoint.Enable("github.com/tikv/pd/server/tsoProxyFailToSendToClient", `return(true)`))
-	streams, cleanupFuncs := createTSOStreams(s.ctx, re, s.backendEndpoints, 1)
-	err := streams[0].Send(s.defaultReq)
+	streams, cleanupFuncs, err := createTSOStreams(s.ctx, as, s.backendEndpoints, 1)
+	re.NoError(err)
+	err = streams[0].Send(s.defaultReq)
 	re.NoError(err)
 	_, err = streams[0].Recv()
 	re.Error(err)
@@ -252,12 +264,14 @@ func (s *tsoProxyTestSuite) TestTSOProxyFailToSendToClient() {
 // TestTSOProxySendToTSOTimeout tests the TSO Proxy can properly close the grpc stream on the server side
 // when it sends the request to the TSO service and encounters timeout.
 func (s *tsoProxyTestSuite) TestTSOProxySendToTSOTimeout() {
+	as := assert.New(s.T())
 	re := s.Require()
 
 	// Enable the failpoint to make the TSO Proxy's grpc stream timeout on the server side to be 1 second.
 	re.NoError(failpoint.Enable("github.com/tikv/pd/server/tsoProxySendToTSOTimeout", `return(true)`))
-	streams, cleanupFuncs := createTSOStreams(s.ctx, re, s.backendEndpoints, 1)
-	err := streams[0].Send(s.defaultReq)
+	streams, cleanupFuncs, err := createTSOStreams(s.ctx, as, s.backendEndpoints, 1)
+	re.NoError(err)
+	err = streams[0].Send(s.defaultReq)
 	re.NoError(err)
 	_, err = streams[0].Recv()
 	re.Error(err)
@@ -271,12 +285,14 @@ func (s *tsoProxyTestSuite) TestTSOProxySendToTSOTimeout() {
 // TestTSOProxyRecvFromTSOTimeout tests the TSO Proxy can properly close the grpc stream on the server side
 // when it receives the response from the TSO service and encounters timeout.
 func (s *tsoProxyTestSuite) TestTSOProxyRecvFromTSOTimeout() {
+	as := assert.New(s.T())
 	re := s.Require()
 
 	// Enable the failpoint to make the TSO Proxy's grpc stream timeout on the server side to be 1 second.
 	re.NoError(failpoint.Enable("github.com/tikv/pd/server/tsoProxyRecvFromTSOTimeout", `return(true)`))
-	streams, cleanupFuncs := createTSOStreams(s.ctx, re, s.backendEndpoints, 1)
-	err := streams[0].Send(s.defaultReq)
+	streams, cleanupFuncs, err := createTSOStreams(s.ctx, as, s.backendEndpoints, 1)
+	re.NoError(err)
+	err = streams[0].Send(s.defaultReq)
 	re.NoError(err)
 	_, err = streams[0].Recv()
 	re.Error(err)
@@ -393,30 +409,37 @@ func (s *tsoProxyTestSuite) generateRequests(requestsPerClient int) []*pdpb.TsoR
 // createTSOStreams creates multiple TSO client streams, and each stream uses a different gRPC connection
 // to simulate multiple clients.
 func createTSOStreams(
-	ctx context.Context, re *require.Assertions,
+	ctx context.Context, as *assert.Assertions,
 	backendEndpoints string, clientCount int,
-) ([]pdpb.PD_TsoClient, []testutil.CleanupFunc) {
+) ([]pdpb.PD_TsoClient, []testutil.CleanupFunc, error) {
 	cleanupFuncs := make([]testutil.CleanupFunc, clientCount)
 	streams := make([]pdpb.PD_TsoClient, clientCount)
 
 	for i := range clientCount {
 		conn, err := grpc.Dial(strings.TrimPrefix(backendEndpoints, "http://"), grpc.WithTransportCredentials(insecure.NewCredentials())) //nolint:staticcheck
-		re.NoError(err)
+		if err != nil {
+			cleanupGRPCStreams(cleanupFuncs)
+			return nil, nil, err
+		}
 		grpcPDClient := pdpb.NewPDClient(conn)
 		cctx, cancel := context.WithCancel(ctx)
 		stream, err := grpcPDClient.Tso(cctx)
-		re.NoError(err)
+		if err != nil {
+			cancel()
+			as.NoError(conn.Close()) //nolint:testifylint // Cleanup can run in a worker goroutine, where require is unsafe.
+			cleanupGRPCStreams(cleanupFuncs)
+			return nil, nil, err
+		}
 		streams[i] = stream
 		cleanupFunc := func() {
-			err = stream.CloseSend()
-			re.NoError(err)
+			as.NoError(stream.CloseSend()) //nolint:testifylint // Cleanup can run in a worker goroutine, where require is unsafe.
 			cancel()
-			conn.Close()
+			as.NoError(conn.Close()) //nolint:testifylint // Cleanup can run in a worker goroutine, where require is unsafe.
 		}
 		cleanupFuncs[i] = cleanupFunc
 	}
 
-	return streams, cleanupFuncs
+	return streams, cleanupFuncs, nil
 }
 
 func tsoProxy(
@@ -496,11 +519,13 @@ func benchmarkTSOProxyNClients(clientCount int, b *testing.B) {
 	suite.SetT(&testing.T{})
 	suite.SetupSuite()
 	re := suite.Require()
+	as := assert.New(b)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	streams, cleanupFuncs := createTSOStreams(ctx, re, suite.backendEndpoints, clientCount)
+	streams, cleanupFuncs, err := createTSOStreams(ctx, as, suite.backendEndpoints, clientCount)
+	require.NoError(b, err)
 
 	// Benchmark TSO proxy
 	b.ResetTimer()

--- a/tests/integrations/mcs/tso/server_test.go
+++ b/tests/integrations/mcs/tso/server_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -511,6 +512,7 @@ func (suite *PDServiceForward) checkAvailableTSO(re *require.Assertions) {
 }
 
 func TestForwardTsoConcurrently(t *testing.T) {
+	as := assert.New(t)
 	re := require.New(t)
 	suite := NewPDServiceForward(re)
 	defer suite.ShutDown()
@@ -530,8 +532,9 @@ func TestForwardTsoConcurrently(t *testing.T) {
 				caller.TestComponent,
 				[]string{suite.backendEndpoints},
 				pd.SecurityOption{})
-			re.NoError(err)
-			re.NotNil(pdClient)
+			if !as.NoError(err) || !as.NotNil(pdClient) {
+				return
+			}
 			defer pdClient.Close()
 			for range 10 {
 				testutil.Eventually(re, func() bool {
@@ -545,6 +548,7 @@ func TestForwardTsoConcurrently(t *testing.T) {
 }
 
 func BenchmarkForwardTsoConcurrently(b *testing.B) {
+	as := assert.New(b)
 	re := require.New(b)
 	suite := NewPDServiceForward(re)
 	defer suite.ShutDown()
@@ -580,8 +584,9 @@ func BenchmarkForwardTsoConcurrently(b *testing.B) {
 						defer wg.Done()
 						for range 1000 {
 							min, err := client.UpdateServiceGCSafePoint(context.Background(), fmt.Sprintf("service-%d", i), 1000, 1) //nolint:staticcheck
-							re.NoError(err)
-							re.Equal(uint64(0), min)
+							if !as.NoError(err) || !as.Equal(uint64(0), min) {
+								return
+							}
 						}
 					}()
 				}

--- a/tests/integrations/mcs/tso/server_test.go
+++ b/tests/integrations/mcs/tso/server_test.go
@@ -537,10 +537,12 @@ func TestForwardTsoConcurrently(t *testing.T) {
 			}
 			defer pdClient.Close()
 			for range 10 {
-				testutil.Eventually(re, func() bool {
+				if !testutil.EventuallyWithAssert(as, func() bool {
 					min, err := pdClient.UpdateServiceGCSafePoint(context.Background(), fmt.Sprintf("service-%d", i), 1000, 1) //nolint:staticcheck
 					return err == nil && min == 0
-				})
+				}) {
+					return
+				}
 			}
 		}()
 	}

--- a/tests/integrations/mcs/utils/testutil.go
+++ b/tests/integrations/mcs/utils/testutil.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	pd "github.com/tikv/pd/client"
@@ -72,12 +73,12 @@ func WaitForAllTSOServiceAvailable(
 
 // CheckMultiKeyspacesTSO checks the correctness of TSO for multiple keyspaces.
 func CheckMultiKeyspacesTSO(
-	ctx context.Context, re *require.Assertions,
+	ctx context.Context, as *assert.Assertions,
 	clients []pd.Client, parallelAct func(),
 ) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	wg := sync.WaitGroup{}
+	wg := &sync.WaitGroup{}
 	wg.Add(len(clients))
 	var readyClients atomic.Int64
 
@@ -90,7 +91,7 @@ func CheckMultiKeyspacesTSO(
 				select {
 				case <-ctx.Done():
 					// Make sure the lastTS is not empty
-					re.NotEmpty(lastTS)
+					as.NotEmpty(lastTS)
 					return
 				default:
 				}
@@ -100,7 +101,9 @@ func CheckMultiKeyspacesTSO(
 					continue
 				}
 				ts = tsoutil.ComposeTS(physical, logical)
-				re.Less(lastTS, ts)
+				if !as.Less(lastTS, ts) {
+					return
+				}
 				lastTS = ts
 				if !ready {
 					readyClients.Add(1)
@@ -110,15 +113,19 @@ func CheckMultiKeyspacesTSO(
 		}(client)
 	}
 
-	testutil.Eventually(re, func() bool {
+	if !testutil.EventuallyWithAssert(as, func() bool {
 		return readyClients.Load() == int64(len(clients))
-	})
+	}) {
+		cancel()
+		wg.Wait()
+		return
+	}
 
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		defer cancel()
 		parallelAct()
-		cancel()
 	}()
 
 	wg.Wait()

--- a/tests/integrations/tso/client_test.go
+++ b/tests/integrations/tso/client_test.go
@@ -436,12 +436,20 @@ func (suite *tsoClientTestSuite) TestRandomResignLeader() {
 				go func(keyspaceID uint32) {
 					defer wg.Done()
 					keyspaceGroupID := keyspaceGroups[keyspaceID]
-					suite.tsoCluster.WaitForPrimaryServing(re, keyspaceID, keyspaceGroupID)
+					if !testutil.EventuallyWithAssert(as, func() bool {
+						return suite.tsoCluster.GetPrimaryServer(keyspaceID, keyspaceGroupID) != nil
+					}, testutil.WithWaitFor(30*time.Second), testutil.WithTickInterval(100*time.Millisecond)) {
+						return
+					}
 					err := suite.tsoCluster.ResignPrimary(keyspaceID, keyspaceGroupID)
 					if !as.NoError(err) {
 						return
 					}
-					suite.tsoCluster.WaitForPrimaryServing(re, keyspaceID, keyspaceGroupID)
+					if !testutil.EventuallyWithAssert(as, func() bool {
+						return suite.tsoCluster.GetPrimaryServer(keyspaceID, keyspaceGroupID) != nil
+					}, testutil.WithWaitFor(30*time.Second), testutil.WithTickInterval(100*time.Millisecond)) {
+						return
+					}
 				}(keyspaceID)
 			}
 			wg.Wait()

--- a/tests/integrations/tso/client_test.go
+++ b/tests/integrations/tso/client_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/goleak"
@@ -223,7 +224,7 @@ func (suite *tsoClientTestSuite) TearDownSuite() {
 }
 
 func (suite *tsoClientTestSuite) TestGetTS() {
-	re := suite.Require()
+	as := assert.New(suite.T())
 	var wg sync.WaitGroup
 	wg.Add(tsoRequestConcurrencyNumber * len(suite.clients))
 	for range tsoRequestConcurrencyNumber {
@@ -233,9 +234,13 @@ func (suite *tsoClientTestSuite) TestGetTS() {
 				var lastTS uint64
 				for range tsoRequestRound {
 					physical, logical, err := client.GetTS(suite.ctx)
-					re.NoError(err)
+					if !as.NoError(err) {
+						return
+					}
 					ts := tsoutil.ComposeTS(physical, logical)
-					re.Less(lastTS, ts)
+					if !as.Less(lastTS, ts) {
+						return
+					}
 					lastTS = ts
 				}
 			}(client)
@@ -245,7 +250,7 @@ func (suite *tsoClientTestSuite) TestGetTS() {
 }
 
 func (suite *tsoClientTestSuite) TestGetTSAsync() {
-	re := suite.Require()
+	as := assert.New(suite.T())
 	var wg sync.WaitGroup
 	wg.Add(tsoRequestConcurrencyNumber * len(suite.clients))
 	for range tsoRequestConcurrencyNumber {
@@ -259,9 +264,13 @@ func (suite *tsoClientTestSuite) TestGetTSAsync() {
 				var lastTS uint64 = math.MaxUint64
 				for j := len(tsFutures) - 1; j >= 0; j-- {
 					physical, logical, err := tsFutures[j].Wait()
-					re.NoError(err)
+					if !as.NoError(err) {
+						return
+					}
 					ts := tsoutil.ComposeTS(physical, logical)
-					re.Greater(lastTS, ts)
+					if !as.Greater(lastTS, ts) {
+						return
+					}
 					lastTS = ts
 				}
 			}(client)
@@ -302,6 +311,7 @@ func (suite *tsoClientTestSuite) TestDiscoverTSOServiceWithLegacyPath() {
 
 // TestGetMinTS tests the correctness of GetMinTS.
 func (suite *tsoClientTestSuite) TestGetMinTS() {
+	as := assert.New(suite.T())
 	re := suite.Require()
 	var wg sync.WaitGroup
 	wg.Add(tsoRequestConcurrencyNumber * len(suite.clients))
@@ -312,9 +322,13 @@ func (suite *tsoClientTestSuite) TestGetMinTS() {
 				var lastMinTS uint64
 				for range tsoRequestRound {
 					physical, logical, err := client.GetMinTS(suite.ctx)
-					re.NoError(err)
+					if !as.NoError(err) {
+						return
+					}
 					minTS := tsoutil.ComposeTS(physical, logical)
-					re.Less(lastMinTS, minTS)
+					if !as.Less(lastMinTS, minTS) {
+						return
+					}
 					lastMinTS = minTS
 
 					// Now we check whether the returned ts is the minimum one
@@ -322,9 +336,13 @@ func (suite *tsoClientTestSuite) TestGetMinTS() {
 					// less than the new timestamps of all keyspace groups.
 					for _, client := range suite.clients {
 						physical, logical, err := client.GetTS(suite.ctx)
-						re.NoError(err)
+						if !as.NoError(err) {
+							return
+						}
 						ts := tsoutil.ComposeTS(physical, logical)
-						re.Less(minTS, ts)
+						if !as.Less(minTS, ts) {
+							return
+						}
 					}
 				}
 			}(client)
@@ -386,6 +404,7 @@ func (suite *tsoClientTestSuite) TestUpdateAfterResetTSO() {
 }
 
 func (suite *tsoClientTestSuite) TestRandomResignLeader() {
+	as := assert.New(suite.T())
 	re := suite.Require()
 	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/member/skipCampaignLeaderCheck", "return(true)"))
 	defer func() {
@@ -419,7 +438,9 @@ func (suite *tsoClientTestSuite) TestRandomResignLeader() {
 					keyspaceGroupID := keyspaceGroups[keyspaceID]
 					suite.tsoCluster.WaitForPrimaryServing(re, keyspaceID, keyspaceGroupID)
 					err := suite.tsoCluster.ResignPrimary(keyspaceID, keyspaceGroupID)
-					re.NoError(err)
+					if !as.NoError(err) {
+						return
+					}
 					suite.tsoCluster.WaitForPrimaryServing(re, keyspaceID, keyspaceGroupID)
 				}(keyspaceID)
 			}
@@ -475,6 +496,7 @@ func (suite *tsoClientTestSuite) TestRandomShutdown() {
 }
 
 func (suite *tsoClientTestSuite) TestGetTSWhileResettingTSOClient() {
+	as := assert.New(suite.T())
 	re := suite.Require()
 	re.NoError(failpoint.Enable("github.com/tikv/pd/client/clients/tso/delayDispatchTSORequest", "return(true)"))
 	var (
@@ -491,10 +513,14 @@ func (suite *tsoClientTestSuite) TestGetTSWhileResettingTSOClient() {
 				for !stopSignal.Load() {
 					physical, logical, err := client.GetTS(suite.ctx)
 					if err != nil {
-						re.ErrorContains(err, context.Canceled.Error())
+						if !as.ErrorContains(err, context.Canceled.Error()) {
+							return
+						}
 					} else {
 						ts := tsoutil.ComposeTS(physical, logical)
-						re.Less(lastTS, ts)
+						if !as.Less(lastTS, ts) {
+							return
+						}
 						lastTS = ts
 					}
 				}
@@ -591,6 +617,7 @@ func (suite *tsoClientTestSuite) TestTSONotLeaderWhenRebaseErr() {
 }
 
 func (suite *tsoClientTestSuite) TestRetryGetTSNotLeader() {
+	as := assert.New(suite.T())
 	re := suite.Require()
 	pdClient := suite.clients[0]
 	re.NoError(failpoint.Enable("github.com/tikv/pd/client/mockMaxTSORetryTimes", "return(2000)"))
@@ -614,11 +641,15 @@ func (suite *tsoClientTestSuite) TestRetryGetTSNotLeader() {
 			}
 			physical, logical, err := client.GetTS(ctx1)
 			if err != nil {
-				re.ErrorContains(err, context.Canceled.Error())
+				if !as.ErrorContains(err, context.Canceled.Error()) {
+					return
+				}
 				continue
 			}
 			ts := tsoutil.ComposeTS(physical, logical)
-			re.Less(lastTS, ts)
+			if !as.Less(lastTS, ts) {
+				return
+			}
 			lastTS = ts
 		}
 	}(pdClient)

--- a/tests/integrations/tso/client_test.go
+++ b/tests/integrations/tso/client_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/tikv/pd/client/pkg/caller"
 	sd "github.com/tikv/pd/client/servicediscovery"
 	bs "github.com/tikv/pd/pkg/basicserver"
+	"github.com/tikv/pd/pkg/keyspace"
 	"github.com/tikv/pd/pkg/keyspace/constant"
 	"github.com/tikv/pd/pkg/slice"
 	"github.com/tikv/pd/pkg/storage/endpoint"
@@ -418,7 +419,7 @@ func (suite *tsoClientTestSuite) TestRandomResignLeader() {
 		n := rand.IntN(2) + 3
 		time.Sleep(time.Duration(n) * time.Second)
 		if !suite.legacy {
-			wg := sync.WaitGroup{}
+			wg := &sync.WaitGroup{}
 			// Select the first keyspace from all keyspace groups. We need to make sure the selected
 			// keyspaces are from different keyspace groups, otherwise multiple goroutines below could
 			// try to resign the primary of the same keyspace group and cause race condition.
@@ -455,16 +456,19 @@ func (suite *tsoClientTestSuite) TestRandomResignLeader() {
 			wg.Wait()
 		} else {
 			err := suite.cluster.ResignLeader()
-			re.NoError(err)
+			if !as.NoError(err) { //nolint:testifylint // parallelAct runs in a worker goroutine, where require is unsafe.
+				return
+			}
 			suite.cluster.WaitLeader()
 		}
 		time.Sleep(time.Duration(n) * time.Second)
 	}
 
-	utils.CheckMultiKeyspacesTSO(suite.ctx, re, suite.clients, parallelAct)
+	utils.CheckMultiKeyspacesTSO(suite.ctx, as, suite.clients, parallelAct)
 }
 
 func (suite *tsoClientTestSuite) TestRandomShutdown() {
+	as := assert.New(suite.T())
 	re := suite.Require()
 	var closedTSOAddr string
 	if !suite.legacy {
@@ -478,11 +482,29 @@ func (suite *tsoClientTestSuite) TestRandomShutdown() {
 
 	parallelAct := func() {
 		if !suite.legacy {
-			primary := suite.tsoCluster.WaitForDefaultPrimaryServing(re)
+			keyspaceID := keyspace.GetBootstrapKeyspaceID()
+			primary := suite.tsoCluster.GetPrimaryServer(keyspaceID, constant.DefaultKeyspaceGroupID)
+			if !testutil.EventuallyWithAssert(as, func() bool {
+				primary = suite.tsoCluster.GetPrimaryServer(keyspaceID, constant.DefaultKeyspaceGroupID)
+				return primary != nil
+			}, testutil.WithWaitFor(30*time.Second), testutil.WithTickInterval(100*time.Millisecond)) {
+				return
+			}
 			closedTSOAddr = primary.GetAddr()
 			primary.Close()
-			suite.tsoCluster.WaitForDefaultPrimaryServing(re)
-			utils.WaitForAllTSOServiceAvailable(suite.ctx, re, suite.clients)
+			if !testutil.EventuallyWithAssert(as, func() bool {
+				return suite.tsoCluster.GetPrimaryServer(keyspaceID, constant.DefaultKeyspaceGroupID) != nil
+			}, testutil.WithWaitFor(30*time.Second), testutil.WithTickInterval(100*time.Millisecond)) {
+				return
+			}
+			for _, client := range suite.clients {
+				if !testutil.EventuallyWithAssert(as, func() bool {
+					_, _, err := client.GetTS(suite.ctx)
+					return err == nil
+				}) {
+					return
+				}
+			}
 		} else {
 			// After https://github.com/tikv/pd/issues/6376 is fixed, we can use a smaller number here.
 			// currently, the time to discover tso service is usually a little longer than 1s, compared
@@ -494,7 +516,7 @@ func (suite *tsoClientTestSuite) TestRandomShutdown() {
 		}
 	}
 
-	utils.CheckMultiKeyspacesTSO(suite.ctx, re, suite.clients, parallelAct)
+	utils.CheckMultiKeyspacesTSO(suite.ctx, as, suite.clients, parallelAct)
 	if !suite.legacy {
 		re.NotEmpty(closedTSOAddr)
 		return

--- a/tests/integrations/tso/consistency_test.go
+++ b/tests/integrations/tso/consistency_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
 
@@ -108,7 +109,13 @@ func (suite *tsoConsistencyTestSuite) TearDownSuite() {
 }
 
 func (suite *tsoConsistencyTestSuite) request(ctx context.Context, count uint32) *pdpb.Timestamp {
-	re := suite.Require()
+	as := assert.New(suite.T())
+	noError := func(err error) bool {
+		if err == nil {
+			return true
+		}
+		return as.Fail("Received unexpected error", "%+v", err)
+	}
 	clusterID := keypath.ClusterID()
 	if suite.legacy {
 		req := &pdpb.TsoRequest{
@@ -116,33 +123,43 @@ func (suite *tsoConsistencyTestSuite) request(ctx context.Context, count uint32)
 			Count:  count,
 		}
 		tsoClient, err := suite.pdClient.Tso(ctx)
-		re.NoError(err)
+		if !noError(err) {
+			return nil
+		}
 		defer func() {
 			err := tsoClient.CloseSend()
-			re.NoError(err)
+			noError(err)
 		}()
-		re.NoError(tsoClient.Send(req))
+		if !noError(tsoClient.Send(req)) {
+			return nil
+		}
 		resp, err := tsoClient.Recv()
-		re.NoError(err)
-		return checkAndReturnTimestampResponse(re, resp)
+		if !noError(err) {
+			return nil
+		}
+		return checkAndReturnTimestampResponse(as, resp)
 	}
 	req := &tsopb.TsoRequest{
 		Header: &tsopb.RequestHeader{ClusterId: clusterID},
 		Count:  count,
 	}
 	var resp *tsopb.TsoResponse
-	testutil.Eventually(re, func() bool {
+	as.Eventually(func() bool {
 		tsoClient, err := suite.tsoClient.Tso(ctx)
-		re.NoError(err)
+		if !noError(err) {
+			return false
+		}
 		defer func() {
 			err := tsoClient.CloseSend()
-			re.NoError(err)
+			noError(err)
 		}()
-		re.NoError(tsoClient.Send(req))
+		if !noError(tsoClient.Send(req)) {
+			return false
+		}
 		resp, err = tsoClient.Recv()
 		return err == nil && resp != nil
-	})
-	return checkAndReturnTimestampResponse(re, resp)
+	}, 20*time.Second, 100*time.Millisecond)
+	return checkAndReturnTimestampResponse(as, resp)
 }
 
 func (suite *tsoConsistencyTestSuite) TestRequestTSOConcurrently() {
@@ -154,7 +171,7 @@ func (suite *tsoConsistencyTestSuite) TestRequestTSOConcurrently() {
 }
 
 func (suite *tsoConsistencyTestSuite) requestTSOConcurrently() {
-	re := suite.Require()
+	as := assert.New(suite.T())
 	ctx, cancel := context.WithCancel(suite.ctx)
 	defer cancel()
 
@@ -170,8 +187,13 @@ func (suite *tsoConsistencyTestSuite) requestTSOConcurrently() {
 			var ts *pdpb.Timestamp
 			for range tsoRequestRound {
 				ts = suite.request(ctx, tsoCount)
+				if !as.NotNil(ts) {
+					return
+				}
 				// Check whether the TSO fallbacks
-				re.Equal(1, tsoutil.CompareTimestamp(ts, last))
+				if !as.Equal(1, tsoutil.CompareTimestamp(ts, last)) {
+					return
+				}
 				last = ts
 				time.Sleep(10 * time.Millisecond)
 			}
@@ -181,6 +203,7 @@ func (suite *tsoConsistencyTestSuite) requestTSOConcurrently() {
 }
 
 func (suite *tsoConsistencyTestSuite) TestFallbackTSOConsistency() {
+	as := assert.New(suite.T())
 	re := suite.Require()
 
 	// Re-create the cluster to enable the failpoints.
@@ -210,7 +233,9 @@ func (suite *tsoConsistencyTestSuite) TestFallbackTSOConsistency() {
 			var ts *pdpb.Timestamp
 			for range tsoRequestRound {
 				ts = suite.request(ctx, tsoCount)
-				re.Equal(1, tsoutil.CompareTimestamp(ts, last))
+				if !as.NotNil(ts) || !as.Equal(1, tsoutil.CompareTimestamp(ts, last)) {
+					return
+				}
 				last = ts
 				time.Sleep(10 * time.Millisecond)
 			}

--- a/tests/integrations/tso/consistency_test.go
+++ b/tests/integrations/tso/consistency_test.go
@@ -144,21 +144,21 @@ func (suite *tsoConsistencyTestSuite) request(ctx context.Context, count uint32)
 		Count:  count,
 	}
 	var resp *tsopb.TsoResponse
-	as.Eventually(func() bool {
+	if !as.Eventually(func() bool {
 		tsoClient, err := suite.tsoClient.Tso(ctx)
-		if !noError(err) {
+		if err != nil {
 			return false
 		}
-		defer func() {
-			err := tsoClient.CloseSend()
-			noError(err)
-		}()
-		if !noError(tsoClient.Send(req)) {
+		if err := tsoClient.Send(req); err != nil {
+			_ = tsoClient.CloseSend()
 			return false
 		}
 		resp, err = tsoClient.Recv()
-		return err == nil && resp != nil
-	}, 20*time.Second, 100*time.Millisecond)
+		closeErr := tsoClient.CloseSend()
+		return err == nil && closeErr == nil && resp != nil
+	}, 20*time.Second, 100*time.Millisecond) {
+		return nil
+	}
 	return checkAndReturnTimestampResponse(as, resp)
 }
 

--- a/tests/integrations/tso/server_test.go
+++ b/tests/integrations/tso/server_test.go
@@ -119,7 +119,7 @@ func (suite *tsoServerTestSuite) resetTS(ts uint64, ignoreSmaller, skipUpperBoun
 	}
 	// Only this error is acceptable.
 	if err != nil {
-		suite.Require().ErrorContains(err, "is smaller than now")
+		suite.ErrorContains(err, "is smaller than now")
 	}
 }
 

--- a/tests/integrations/tso/testutil.go
+++ b/tests/integrations/tso/testutil.go
@@ -33,8 +33,14 @@ type tsoResponse interface {
 }
 
 func checkAndReturnTimestampResponse[T tsoResponse](as *assert.Assertions, resp T) *pdpb.Timestamp {
+	if !as.NotNil(resp) {
+		return nil
+	}
 	as.Equal(uint32(tsoCount), resp.GetCount())
 	timestamp := resp.GetTimestamp()
+	if !as.NotNil(timestamp) {
+		return nil
+	}
 	as.Positive(timestamp.GetPhysical())
 	as.GreaterOrEqual(uint32(timestamp.GetLogical()), uint32(tsoCount))
 	return timestamp

--- a/tests/integrations/tso/testutil.go
+++ b/tests/integrations/tso/testutil.go
@@ -15,7 +15,7 @@
 package tso
 
 import (
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/pingcap/kvproto/pkg/pdpb"
 )
@@ -32,10 +32,10 @@ type tsoResponse interface {
 	GetTimestamp() *pdpb.Timestamp
 }
 
-func checkAndReturnTimestampResponse[T tsoResponse](re *require.Assertions, resp T) *pdpb.Timestamp {
-	re.Equal(uint32(tsoCount), resp.GetCount())
+func checkAndReturnTimestampResponse[T tsoResponse](as *assert.Assertions, resp T) *pdpb.Timestamp {
+	as.Equal(uint32(tsoCount), resp.GetCount())
 	timestamp := resp.GetTimestamp()
-	re.Positive(timestamp.GetPhysical())
-	re.GreaterOrEqual(uint32(timestamp.GetLogical()), uint32(tsoCount))
+	as.Positive(timestamp.GetPhysical())
+	as.GreaterOrEqual(uint32(timestamp.GetLogical()), uint32(tsoCount))
 	return timestamp
 }

--- a/tests/server/api/region_test.go
+++ b/tests/server/api/region_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/docker/go-units"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
@@ -598,6 +599,7 @@ func (suite *regionTestSuite) TestRegionsWithKillRequest() {
 }
 
 func (suite *regionTestSuite) checkRegionsWithKillRequest(cluster *tests.TestCluster) {
+	as := assert.New(suite.T())
 	re := suite.Require()
 	leader := cluster.GetLeaderServer()
 	urlPrefix := leader.GetAddr() + "/pd/api/v1"
@@ -624,9 +626,13 @@ func (suite *regionTestSuite) checkRegionsWithKillRequest(cluster *tests.TestClu
 				resp.Body.Close()
 			}
 		}()
-		re.Error(err)
-		re.Contains(err.Error(), "context canceled")
-		re.Nil(resp)
+		if err == nil {
+			as.Fail("An error is expected but got nil")
+			doneCh <- struct{}{}
+			return
+		}
+		as.Contains(err.Error(), "context canceled")
+		as.Nil(resp)
 		doneCh <- struct{}{}
 	}()
 	time.Sleep(100 * time.Millisecond) // wait for the request to be sent

--- a/tests/server/cluster/cluster_test.go
+++ b/tests/server/cluster/cluster_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/coreos/go-semver/semver"
 	"github.com/docker/go-units"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 	"google.golang.org/grpc/codes"
@@ -784,7 +785,7 @@ func TestRaftClusterStartTSOJob(t *testing.T) {
 			err := leaderServer.BootstrapCluster()
 			if err != nil {
 				// If the error is ErrEtcdTxnConflict, it means there is a temporary failure.
-				re.ErrorContains(err, errs.ErrEtcdTxnConflict.GetMsg())
+				assert.ErrorContains(t, err, errs.ErrEtcdTxnConflict.GetMsg())
 			}
 		}()
 	}
@@ -882,8 +883,10 @@ func TestStoreVersionChange(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		resp, err := putStore(grpcPDClient, clusterID, store)
-		re.NoError(err)
-		re.Equal(pdpb.ErrorType_OK, resp.GetHeader().GetError().GetType())
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.Equal(t, pdpb.ErrorType_OK, resp.GetHeader().GetError().GetType())
 	}()
 	time.Sleep(100 * time.Millisecond)
 	err = svr.SetClusterVersion("1.0.0")
@@ -964,7 +967,10 @@ func TestConcurrentHandleRegion(t *testing.T) {
 		go func(isReceiver bool) {
 			if isReceiver {
 				_, err := stream.Recv()
-				re.NoError(err)
+				if !assert.NoError(t, err) {
+					wg.Done()
+					return
+				}
 				wg.Done()
 			}
 			for {
@@ -974,7 +980,9 @@ func TestConcurrentHandleRegion(t *testing.T) {
 				default:
 					_, err = stream.Recv()
 					if err != nil {
-						re.ErrorContains(err, "code = Canceled")
+						if !assert.ErrorContains(t, err, "code = Canceled") {
+							return
+						}
 					}
 				}
 			}
@@ -1009,7 +1017,7 @@ func TestConcurrentHandleRegion(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			err := rc.HandleRegionHeartbeat(core.NewRegionInfo(region, region.Peers[0]))
-			re.NoError(err)
+			assert.NoError(t, err)
 		}()
 	}
 	wg.Wait()

--- a/tests/server/id/id_test.go
+++ b/tests/server/id/id_test.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/goleak"
@@ -63,6 +64,7 @@ func (s *idAllocatorTestSuite) TestID() {
 }
 
 func (s *idAllocatorTestSuite) checkID(cluster *tests.TestCluster) {
+	as := assert.New(s.T())
 	re := s.Require()
 	leaderServer := cluster.GetLeaderServer()
 	var last uint64
@@ -82,12 +84,16 @@ func (s *idAllocatorTestSuite) checkID(cluster *tests.TestCluster) {
 			defer wg.Done()
 			for range 200 {
 				id, _, err := leaderServer.GetAllocator().Alloc(1)
-				re.NoError(err)
+				if !as.NoError(err) {
+					return
+				}
 				m.Lock()
 				_, ok := ids[id]
 				ids[id] = struct{}{}
 				m.Unlock()
-				re.False(ok)
+				if !as.False(ok) {
+					return
+				}
 			}
 		}()
 	}
@@ -148,6 +154,7 @@ func (s *idAllocatorTestSuite) TestBatchAllocID() {
 }
 
 func (s *idAllocatorTestSuite) checkBatchAllocID(cluster *tests.TestCluster) {
+	as := assert.New(s.T())
 	re := s.Require()
 
 	leaderServer := cluster.GetLeaderServer()
@@ -169,13 +176,18 @@ func (s *idAllocatorTestSuite) checkBatchAllocID(cluster *tests.TestCluster) {
 			for range 200 {
 				id, count, err := leaderServer.GetAllocator().Alloc(10)
 				curID := id - uint64(count)
-				re.NoError(err)
+				if !as.NoError(err) {
+					return
+				}
 				m.Lock()
 				for range count {
 					_, ok := ids[curID]
 					ids[curID] = struct{}{}
 					curID++
-					re.False(ok, curID)
+					if !as.False(ok, curID) {
+						m.Unlock()
+						return
+					}
 				}
 				m.Unlock()
 			}

--- a/tests/server/server_test.go
+++ b/tests/server/server_test.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	etcdtypes "go.etcd.io/etcd/client/pkg/v3/types"
@@ -231,7 +232,7 @@ func TestGRPCRateLimit(t *testing.T) {
 			Header:    &pdpb.RequestHeader{ClusterId: leaderServer.GetClusterID()},
 			RegionKey: []byte(""),
 		})
-		re.Empty(resp.GetHeader().GetError())
+		assert.Empty(t, resp.GetHeader().GetError())
 		if err != nil {
 			errCh <- err.Error()
 		} else {
@@ -247,7 +248,7 @@ func TestGRPCRateLimit(t *testing.T) {
 			Header:    &pdpb.RequestHeader{ClusterId: leaderServer.GetClusterID()},
 			RegionKey: []byte(""),
 		})
-		re.Empty(resp.GetHeader().GetError())
+		assert.Empty(t, resp.GetHeader().GetError())
 		if err != nil {
 			errCh <- err.Error()
 		} else {
@@ -307,7 +308,7 @@ func (suite *leaderServerTestSuite) TestRegisterServerHandler() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	mockHandler := createMockHandler(re, "127.0.0.1")
+	mockHandler := createMockHandler(suite.Assert(), "127.0.0.1")
 	// Repeat registering the same handler should return error.
 	_, err := tests.NewTestClusterWithHandlers(ctx, 1, []server.HandlerBuilder{mockHandler, mockHandler})
 	re.Error(err)
@@ -337,7 +338,7 @@ func (suite *leaderServerTestSuite) TestSourceIpForHeaderForwarded() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	mockHandler := createMockHandler(re, "127.0.0.2")
+	mockHandler := createMockHandler(suite.Assert(), "127.0.0.2")
 	cluster, err := tests.NewTestClusterWithHandlers(ctx, 1, []server.HandlerBuilder{mockHandler})
 	re.NoError(err)
 	defer cluster.Destroy()
@@ -367,7 +368,7 @@ func (suite *leaderServerTestSuite) TestSourceIpForHeaderXReal() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	mockHandler := createMockHandler(re, "127.0.0.2")
+	mockHandler := createMockHandler(suite.Assert(), "127.0.0.2")
 	cluster, err := tests.NewTestClusterWithHandlers(ctx, 1, []server.HandlerBuilder{mockHandler})
 	re.NoError(err)
 	defer cluster.Destroy()
@@ -397,7 +398,7 @@ func (suite *leaderServerTestSuite) TestSourceIpForHeaderBoth() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	mockHandler := createMockHandler(re, "127.0.0.2")
+	mockHandler := createMockHandler(suite.Assert(), "127.0.0.2")
 	cluster, err := tests.NewTestClusterWithHandlers(ctx, 1, []server.HandlerBuilder{mockHandler})
 	re.NoError(err)
 	defer cluster.Destroy()
@@ -490,7 +491,7 @@ func TestCheckClusterID(t *testing.T) {
 	cfgA := clusterA.GetServer(leaderA).GetConfig()
 	cfgB := clusterB.GetServer(leaderB).GetConfig()
 
-	mockHandler := createMockHandler(re, "127.0.0.1")
+	mockHandler := createMockHandler(assert.New(t), "127.0.0.1")
 	svr, err := server.CreateServer(ctx, cfgA, nil, mockHandler)
 	re.NoError(err)
 
@@ -578,14 +579,14 @@ func TestSetPDServerConfigWithDashboard(t *testing.T) {
 }
 
 // createMockHandler creates a mock handler for test.
-func createMockHandler(re *require.Assertions, ip string) server.HandlerBuilder {
+func createMockHandler(as *assert.Assertions, ip string) server.HandlerBuilder {
 	return func(context.Context, *server.Server) (http.Handler, apiutil.APIServiceGroup, error) {
 		mux := http.NewServeMux()
 		mux.HandleFunc("/pd/apis/mock/v1/hello", func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprintln(w, "Hello World")
 			// test getting ip
 			clientIP, _ := apiutil.GetIPPortFromHTTPRequest(r)
-			re.Equal(ip, clientIP)
+			as.Equal(ip, clientIP)
 		})
 		info := apiutil.APIServiceGroup{
 			Name:    "mock",

--- a/tools/pd-api-bench/main.go
+++ b/tools/pd-api-bench/main.go
@@ -227,6 +227,15 @@ func parseCaseNameAndConfig(str string) (string, *cases.Config) {
 	return name, cfg
 }
 
+func validateCaseNames[T any](input map[string]cases.Config, registered map[string]T, caseType string) error {
+	for name := range input {
+		if _, ok := registered[name]; !ok {
+			return errors.Errorf("%s case %s not implemented", caseType, name)
+		}
+	}
+	return nil
+}
+
 func runHTTPServer(cfg *config.Config, co *cases.Coordinator) {
 	gin.SetMode(gin.ReleaseMode)
 	engine := gin.New()
@@ -263,6 +272,10 @@ func runHTTPServer(cfg *config.Config, co *cases.Coordinator) {
 			c.String(http.StatusBadRequest, err.Error())
 			return
 		}
+		if err := validateCaseNames(input, cases.HTTPCaseFnMap, "HTTP"); err != nil {
+			c.String(http.StatusBadRequest, err.Error())
+			return
+		}
 		for name, cfg := range input {
 			if err := co.SetHTTPCase(name, &cfg); err != nil {
 				c.String(http.StatusBadRequest, err.Error())
@@ -286,6 +299,10 @@ func runHTTPServer(cfg *config.Config, co *cases.Coordinator) {
 			c.String(http.StatusBadRequest, err.Error())
 			return
 		}
+		if err := validateCaseNames(input, cases.GRPCCaseFnMap, "gRPC"); err != nil {
+			c.String(http.StatusBadRequest, err.Error())
+			return
+		}
 		for name, cfg := range input {
 			if err := co.SetGRPCCase(name, &cfg); err != nil {
 				c.String(http.StatusBadRequest, err.Error())
@@ -306,6 +323,10 @@ func runHTTPServer(cfg *config.Config, co *cases.Coordinator) {
 	engine.POST("config/etcd/all", func(c *gin.Context) {
 		var input map[string]cases.Config
 		if err := c.ShouldBindJSON(&input); err != nil {
+			c.String(http.StatusBadRequest, err.Error())
+			return
+		}
+		if err := validateCaseNames(input, cases.EtcdCaseFnMap, "etcd"); err != nil {
 			c.String(http.StatusBadRequest, err.Error())
 			return
 		}

--- a/tools/pd-api-bench/main.go
+++ b/tools/pd-api-bench/main.go
@@ -122,9 +122,7 @@ func main() {
 	pdClis := make([]pd.Client, cfg.Client)
 	for i := range cfg.Client {
 		pdClis[i] = newPDClient(ctx, cfg)
-		if err := pdClis[i].UpdateOption(opt.EnableFollowerHandle, true); err != nil {
-			log.Fatal("enable follower handle failed", zap.Error(err))
-		}
+		_ = pdClis[i].UpdateOption(opt.EnableFollowerHandle, true)
 	}
 	etcdClis := make([]*clientv3.Client, cfg.Client)
 	for i := range cfg.Client {
@@ -148,9 +146,7 @@ func main() {
 		if len(name) == 0 {
 			continue
 		}
-		if err := coordinator.SetHTTPCase(name, cfg); err != nil {
-			log.Fatal("set HTTP case failed", zap.String("case", name), zap.Error(err))
-		}
+		_ = coordinator.SetHTTPCase(name, cfg)
 	}
 	gcaseStr := strings.Split(gRPCCases, ",")
 	for _, str := range gcaseStr {
@@ -158,9 +154,7 @@ func main() {
 		if len(name) == 0 {
 			continue
 		}
-		if err := coordinator.SetGRPCCase(name, cfg); err != nil {
-			log.Fatal("set gRPC case failed", zap.String("case", name), zap.Error(err))
-		}
+		_ = coordinator.SetGRPCCase(name, cfg)
 	}
 	cfg.InitCoordinator(coordinator)
 
@@ -387,9 +381,7 @@ func runHTTPServer(cfg *config.Config, co *cases.Coordinator) {
 		}
 		c.IndentedJSON(http.StatusOK, cfg)
 	})
-	if err := engine.Run(cfg.StatusAddr); err != nil {
-		log.Fatal("run status server failed", zap.Error(err))
-	}
+	_ = engine.Run(cfg.StatusAddr)
 }
 
 const (

--- a/tools/pd-api-bench/main.go
+++ b/tools/pd-api-bench/main.go
@@ -122,7 +122,9 @@ func main() {
 	pdClis := make([]pd.Client, cfg.Client)
 	for i := range cfg.Client {
 		pdClis[i] = newPDClient(ctx, cfg)
-		_ = pdClis[i].UpdateOption(opt.EnableFollowerHandle, true)
+		if err := pdClis[i].UpdateOption(opt.EnableFollowerHandle, true); err != nil {
+			log.Fatal("enable follower handle failed", zap.Error(err))
+		}
 	}
 	etcdClis := make([]*clientv3.Client, cfg.Client)
 	for i := range cfg.Client {
@@ -146,7 +148,9 @@ func main() {
 		if len(name) == 0 {
 			continue
 		}
-		_ = coordinator.SetHTTPCase(name, cfg)
+		if err := coordinator.SetHTTPCase(name, cfg); err != nil {
+			log.Fatal("set HTTP case failed", zap.String("case", name), zap.Error(err))
+		}
 	}
 	gcaseStr := strings.Split(gRPCCases, ",")
 	for _, str := range gcaseStr {
@@ -154,7 +158,9 @@ func main() {
 		if len(name) == 0 {
 			continue
 		}
-		_ = coordinator.SetGRPCCase(name, cfg)
+		if err := coordinator.SetGRPCCase(name, cfg); err != nil {
+			log.Fatal("set gRPC case failed", zap.String("case", name), zap.Error(err))
+		}
 	}
 	cfg.InitCoordinator(coordinator)
 
@@ -258,14 +264,20 @@ func runHTTPServer(cfg *config.Config, co *cases.Coordinator) {
 			return
 		}
 		for name, cfg := range input {
-			_ = co.SetHTTPCase(name, &cfg)
+			if err := co.SetHTTPCase(name, &cfg); err != nil {
+				c.String(http.StatusBadRequest, err.Error())
+				return
+			}
 		}
 		c.String(http.StatusOK, "")
 	})
 	engine.POST("config/http/:name", func(c *gin.Context) {
 		name := c.Param("name")
 		cfg := getCfg(c)
-		_ = co.SetHTTPCase(name, cfg)
+		if err := co.SetHTTPCase(name, cfg); err != nil {
+			c.String(http.StatusBadRequest, err.Error())
+			return
+		}
 		c.String(http.StatusOK, "")
 	})
 	engine.POST("config/grpc/all", func(c *gin.Context) {
@@ -275,14 +287,20 @@ func runHTTPServer(cfg *config.Config, co *cases.Coordinator) {
 			return
 		}
 		for name, cfg := range input {
-			_ = co.SetGRPCCase(name, &cfg)
+			if err := co.SetGRPCCase(name, &cfg); err != nil {
+				c.String(http.StatusBadRequest, err.Error())
+				return
+			}
 		}
 		c.String(http.StatusOK, "")
 	})
 	engine.POST("config/grpc/:name", func(c *gin.Context) {
 		name := c.Param("name")
 		cfg := getCfg(c)
-		_ = co.SetGRPCCase(name, cfg)
+		if err := co.SetGRPCCase(name, cfg); err != nil {
+			c.String(http.StatusBadRequest, err.Error())
+			return
+		}
 		c.String(http.StatusOK, "")
 	})
 	engine.POST("config/etcd/all", func(c *gin.Context) {
@@ -292,14 +310,20 @@ func runHTTPServer(cfg *config.Config, co *cases.Coordinator) {
 			return
 		}
 		for name, cfg := range input {
-			_ = co.SetEtcdCase(name, &cfg)
+			if err := co.SetEtcdCase(name, &cfg); err != nil {
+				c.String(http.StatusBadRequest, err.Error())
+				return
+			}
 		}
 		c.String(http.StatusOK, "")
 	})
 	engine.POST("config/etcd/:name", func(c *gin.Context) {
 		name := c.Param("name")
 		cfg := getCfg(c)
-		_ = co.SetEtcdCase(name, cfg)
+		if err := co.SetEtcdCase(name, cfg); err != nil {
+			c.String(http.StatusBadRequest, err.Error())
+			return
+		}
 		c.String(http.StatusOK, "")
 	})
 
@@ -342,7 +366,9 @@ func runHTTPServer(cfg *config.Config, co *cases.Coordinator) {
 		}
 		c.IndentedJSON(http.StatusOK, cfg)
 	})
-	_ = engine.Run(cfg.StatusAddr)
+	if err := engine.Run(cfg.StatusAddr); err != nil {
+		log.Fatal("run status server failed", zap.Error(err))
+	}
 }
 
 const (

--- a/tools/pd-api-bench/main.go
+++ b/tools/pd-api-bench/main.go
@@ -122,7 +122,7 @@ func main() {
 	pdClis := make([]pd.Client, cfg.Client)
 	for i := range cfg.Client {
 		pdClis[i] = newPDClient(ctx, cfg)
-		pdClis[i].UpdateOption(opt.EnableFollowerHandle, true)
+		_ = pdClis[i].UpdateOption(opt.EnableFollowerHandle, true)
 	}
 	etcdClis := make([]*clientv3.Client, cfg.Client)
 	for i := range cfg.Client {
@@ -146,7 +146,7 @@ func main() {
 		if len(name) == 0 {
 			continue
 		}
-		coordinator.SetHTTPCase(name, cfg)
+		_ = coordinator.SetHTTPCase(name, cfg)
 	}
 	gcaseStr := strings.Split(gRPCCases, ",")
 	for _, str := range gcaseStr {
@@ -154,7 +154,7 @@ func main() {
 		if len(name) == 0 {
 			continue
 		}
-		coordinator.SetGRPCCase(name, cfg)
+		_ = coordinator.SetGRPCCase(name, cfg)
 	}
 	cfg.InitCoordinator(coordinator)
 
@@ -186,11 +186,10 @@ func exit(code int) {
 func parseCaseNameAndConfig(str string) (string, *cases.Config) {
 	var err error
 	cfg := &cases.Config{}
-	name := ""
 	strs := strings.Split(str, "-")
 	// to get case name
 	strsa := strings.Split(strs[0], "+")
-	name = strsa[0]
+	name := strsa[0]
 	// to get case Burst
 	if len(strsa) > 1 {
 		cfg.Burst, err = strconv.ParseInt(strsa[1], 10, 64)
@@ -259,14 +258,14 @@ func runHTTPServer(cfg *config.Config, co *cases.Coordinator) {
 			return
 		}
 		for name, cfg := range input {
-			co.SetHTTPCase(name, &cfg)
+			_ = co.SetHTTPCase(name, &cfg)
 		}
 		c.String(http.StatusOK, "")
 	})
 	engine.POST("config/http/:name", func(c *gin.Context) {
 		name := c.Param("name")
 		cfg := getCfg(c)
-		co.SetHTTPCase(name, cfg)
+		_ = co.SetHTTPCase(name, cfg)
 		c.String(http.StatusOK, "")
 	})
 	engine.POST("config/grpc/all", func(c *gin.Context) {
@@ -276,14 +275,14 @@ func runHTTPServer(cfg *config.Config, co *cases.Coordinator) {
 			return
 		}
 		for name, cfg := range input {
-			co.SetGRPCCase(name, &cfg)
+			_ = co.SetGRPCCase(name, &cfg)
 		}
 		c.String(http.StatusOK, "")
 	})
 	engine.POST("config/grpc/:name", func(c *gin.Context) {
 		name := c.Param("name")
 		cfg := getCfg(c)
-		co.SetGRPCCase(name, cfg)
+		_ = co.SetGRPCCase(name, cfg)
 		c.String(http.StatusOK, "")
 	})
 	engine.POST("config/etcd/all", func(c *gin.Context) {
@@ -293,14 +292,14 @@ func runHTTPServer(cfg *config.Config, co *cases.Coordinator) {
 			return
 		}
 		for name, cfg := range input {
-			co.SetEtcdCase(name, &cfg)
+			_ = co.SetEtcdCase(name, &cfg)
 		}
 		c.String(http.StatusOK, "")
 	})
 	engine.POST("config/etcd/:name", func(c *gin.Context) {
 		name := c.Param("name")
 		cfg := getCfg(c)
-		co.SetEtcdCase(name, cfg)
+		_ = co.SetEtcdCase(name, cfg)
 		c.String(http.StatusOK, "")
 	})
 
@@ -343,7 +342,7 @@ func runHTTPServer(cfg *config.Config, co *cases.Coordinator) {
 		}
 		c.IndentedJSON(http.StatusOK, cfg)
 	})
-	engine.Run(cfg.StatusAddr)
+	_ = engine.Run(cfg.StatusAddr)
 }
 
 const (

--- a/tools/pd-api-bench/main_test.go
+++ b/tools/pd-api-bench/main_test.go
@@ -1,0 +1,31 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tikv/pd/tools/pd-api-bench/cases"
+)
+
+func TestValidateCaseNames(t *testing.T) {
+	registered := map[string]struct{}{"valid": {}}
+	require.NoError(t, validateCaseNames(map[string]cases.Config{"valid": {}}, registered, "test"))
+	require.EqualError(t,
+		validateCaseNames(map[string]cases.Config{"valid": {}, "invalid": {}}, registered, "test"),
+		"test case invalid not implemented")
+}

--- a/tools/pd-backup/main.go
+++ b/tools/pd-backup/main.go
@@ -68,7 +68,7 @@ func main() {
 
 	backInfo, err := pdbackup.GetBackupInfo(client, *pdAddr)
 	checkErr(err)
-	pdbackup.OutputToFile(backInfo, f)
+	_ = pdbackup.OutputToFile(backInfo, f)
 	fmt.Println("pd backup successful! dump file is:", *filePath)
 }
 

--- a/tools/pd-backup/main.go
+++ b/tools/pd-backup/main.go
@@ -68,7 +68,7 @@ func main() {
 
 	backInfo, err := pdbackup.GetBackupInfo(client, *pdAddr)
 	checkErr(err)
-	_ = pdbackup.OutputToFile(backInfo, f)
+	checkErr(pdbackup.OutputToFile(backInfo, f))
 	fmt.Println("pd backup successful! dump file is:", *filePath)
 }
 

--- a/tools/pd-backup/pdbackup/backup.go
+++ b/tools/pd-backup/pdbackup/backup.go
@@ -97,7 +97,6 @@ func GetBackupInfo(client *clientv3.Client, pdAddr string) (*BackupInfo, error) 
 // OutputToFile output the backupInfo to the file.
 func OutputToFile(backInfo *BackupInfo, f *os.File) error {
 	w := bufio.NewWriter(f)
-	defer w.Flush()
 	backBytes, err := json.Marshal(backInfo)
 	if err != nil {
 		return err
@@ -107,8 +106,10 @@ func OutputToFile(backInfo *BackupInfo, f *os.File) error {
 	if err != nil {
 		return err
 	}
-	fmt.Fprintln(w, formatBuffer.String())
-	return nil
+	if _, err := fmt.Fprintln(w, formatBuffer.String()); err != nil {
+		return err
+	}
+	return w.Flush()
 }
 
 func getConfig(pdAddr string) (*config.Config, error) {

--- a/tools/pd-backup/pdbackup/backup_test.go
+++ b/tools/pd-backup/pdbackup/backup_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/server/v3/embed"
@@ -76,6 +77,15 @@ func TestBackupTestSuite(t *testing.T) {
 	}
 
 	suite.Run(t, testSuite)
+}
+
+func TestOutputToFileReturnsFlushError(t *testing.T) {
+	tmpFile, err := os.CreateTemp(t.TempDir(), "pd-backup")
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+
+	err = OutputToFile(&BackupInfo{}, tmpFile)
+	require.Error(t, err)
 }
 
 func setupServer() (*httptest.Server, *config.Config) {

--- a/tools/pd-backup/tests/backup_test.go
+++ b/tools/pd-backup/tests/backup_test.go
@@ -40,7 +40,7 @@ func TestBackup(t *testing.T) {
 	re.NoError(err)
 	re.NotEmpty(cluster.WaitLeader())
 	leaderServer := cluster.GetLeaderServer()
-	leaderServer.BootstrapCluster()
+	re.NoError(leaderServer.BootstrapCluster())
 	pdAddr := cluster.GetConfig().GetClientURL()
 	urls := strings.Split(pdAddr, ",")
 	client, err := clientv3.New(clientv3.Config{

--- a/tools/pd-ctl/pdctl/command/completion_command.go
+++ b/tools/pd-ctl/pdctl/command/completion_command.go
@@ -93,22 +93,22 @@ func NewCompletionCommand() *cobra.Command {
 func RunCompletion(cmd *cobra.Command, args []string) {
 	if len(args) == 0 {
 		cmd.Println("Shell not specified.")
-		cmd.Usage()
+		_ = cmd.Usage()
 		return
 	}
 	if len(args) > 1 {
 		cmd.Println("Too many arguments. Expected only the shell type.")
-		cmd.Usage()
+		_ = cmd.Usage()
 		return
 	}
 	run, found := completionShells[args[0]]
 	if !found {
 		cmd.Printf("Unsupported shell type %q.\n", args[0])
-		cmd.Usage()
+		_ = cmd.Usage()
 		return
 	}
 
-	run(os.Stdout, cmd.Root())
+	_ = run(os.Stdout, cmd.Root())
 }
 
 func runCompletionBash(out io.Writer, cmd *cobra.Command) error {

--- a/tools/pd-ctl/pdctl/command/completion_command.go
+++ b/tools/pd-ctl/pdctl/command/completion_command.go
@@ -82,33 +82,30 @@ func NewCompletionCommand() *cobra.Command {
 		Short:                 "Output shell completion code for the specified shell (bash)",
 		Long:                  completionLongDesc,
 		Example:               completionExample,
-		Run:                   RunCompletion,
+		RunE:                  RunCompletion,
 		ValidArgs:             shells,
 	}
 
 	return cmd
 }
 
-// RunCompletion wrapped the bash and zsh completion scripts
-func RunCompletion(cmd *cobra.Command, args []string) {
+// RunCompletion wraps the bash and zsh completion scripts.
+func RunCompletion(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
 		cmd.Println("Shell not specified.")
-		_ = cmd.Usage()
-		return
+		return cmd.Usage()
 	}
 	if len(args) > 1 {
 		cmd.Println("Too many arguments. Expected only the shell type.")
-		_ = cmd.Usage()
-		return
+		return cmd.Usage()
 	}
 	run, found := completionShells[args[0]]
 	if !found {
 		cmd.Printf("Unsupported shell type %q.\n", args[0])
-		_ = cmd.Usage()
-		return
+		return cmd.Usage()
 	}
 
-	_ = run(os.Stdout, cmd.Root())
+	return run(os.Stdout, cmd.Root())
 }
 
 func runCompletionBash(out io.Writer, cmd *cobra.Command) error {

--- a/tools/pd-ctl/pdctl/command/gc_safepoint_command.go
+++ b/tools/pd-ctl/pdctl/command/gc_safepoint_command.go
@@ -57,7 +57,7 @@ func showSSPs(cmd *cobra.Command, _ []string) {
 
 func deleteSSP(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
-		cmd.Usage()
+		_ = cmd.Usage()
 		return
 	}
 	r, err := PDCli.DeleteGCSafePoint(cmd.Context(), args[0])

--- a/tools/pd-ctl/pdctl/command/keyspace_command.go
+++ b/tools/pd-ctl/pdctl/command/keyspace_command.go
@@ -86,7 +86,7 @@ func newShowKeyspaceCommand() *cobra.Command {
 
 func showKeyspaceIDCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
-		cmd.Usage()
+		_ = cmd.Usage()
 		return
 	}
 	resp, err := doRequest(cmd, fmt.Sprintf("%s/id/%s", keyspacePrefix, args[0]), http.MethodGet, http.Header{})
@@ -99,7 +99,7 @@ func showKeyspaceIDCommandFunc(cmd *cobra.Command, args []string) {
 
 func showKeyspaceNameCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
-		cmd.Usage()
+		_ = cmd.Usage()
 		return
 	}
 	refreshGroupID, err := cmd.Flags().GetBool(nmForceRefreshGroupID)
@@ -137,7 +137,7 @@ func newCreateKeyspaceCommand() *cobra.Command {
 
 func createKeyspaceCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
-		cmd.Usage()
+		_ = cmd.Usage()
 		return
 	}
 
@@ -198,7 +198,7 @@ func newUpdateKeyspaceConfigCommand() *cobra.Command {
 
 func updateKeyspaceConfigCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
-		cmd.Usage()
+		_ = cmd.Usage()
 		return
 	}
 	configPatch := map[string]*string{}
@@ -301,7 +301,7 @@ func newUpdateKeyspaceStateCommand() *cobra.Command {
 
 func updateKeyspaceStateCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 2 {
-		cmd.Usage()
+		_ = cmd.Usage()
 		return
 	}
 	params := handlers.UpdateStateParam{
@@ -334,7 +334,7 @@ func newListKeyspaceCommand() *cobra.Command {
 
 func listKeyspaceCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 0 {
-		cmd.Usage()
+		_ = cmd.Usage()
 		return
 	}
 
@@ -395,7 +395,7 @@ func newShowKeyspaceRangeCommand() *cobra.Command {
 
 func showKeyspaceRangeByIDCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
-		cmd.Usage()
+		_ = cmd.Usage()
 		return
 	}
 
@@ -444,7 +444,7 @@ func showKeyspaceRangeByIDCommandFunc(cmd *cobra.Command, args []string) {
 
 func showKeyspaceRangeByNameCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
-		cmd.Usage()
+		_ = cmd.Usage()
 		return
 	}
 
@@ -512,7 +512,7 @@ func newSetPlacementCommand() *cobra.Command {
 
 func setPlacementCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) < 2 {
-		cmd.Usage()
+		_ = cmd.Usage()
 		return
 	}
 
@@ -614,7 +614,7 @@ func newRevertPlacementCommand() *cobra.Command {
 
 func revertPlacementCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
-		cmd.Usage()
+		_ = cmd.Usage()
 		return
 	}
 

--- a/tools/pd-ctl/pdctl/command/keyspace_group_command.go
+++ b/tools/pd-ctl/pdctl/command/keyspace_group_command.go
@@ -127,7 +127,7 @@ func newShowKeyspaceGroupPrimaryCommand() *cobra.Command {
 func showKeyspaceGroupsCommandFunc(cmd *cobra.Command, args []string) {
 	prefix := keyspaceGroupsPrefix
 	if len(args) > 1 {
-		cmd.Usage()
+		_ = cmd.Usage()
 		return
 	}
 	cFunc := convertToKeyspaceGroups
@@ -171,7 +171,7 @@ func showKeyspaceGroupsCommandFunc(cmd *cobra.Command, args []string) {
 
 func splitKeyspaceGroupCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) < 3 {
-		cmd.Usage()
+		_ = cmd.Usage()
 		return
 	}
 	_, err := strconv.ParseUint(args[0], 10, 32)
@@ -201,7 +201,7 @@ func splitKeyspaceGroupCommandFunc(cmd *cobra.Command, args []string) {
 
 func splitRangeKeyspaceGroupCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) < 4 {
-		cmd.Usage()
+		_ = cmd.Usage()
 		return
 	}
 	_, err := strconv.ParseUint(args[0], 10, 32)
@@ -233,7 +233,7 @@ func splitRangeKeyspaceGroupCommandFunc(cmd *cobra.Command, args []string) {
 
 func finishSplitKeyspaceGroupCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) < 1 {
-		cmd.Usage()
+		_ = cmd.Usage()
 		return
 	}
 	_, err := strconv.ParseUint(args[0], 10, 32)
@@ -291,7 +291,7 @@ func mergeKeyspaceGroupCommandFunc(cmd *cobra.Command, args []string) {
 		params["merge-list"] = groups
 	} else {
 		cmd.Println("Must specify the source keyspace group ID(s) or the merge all flag")
-		cmd.Usage()
+		_ = cmd.Usage()
 		return
 	}
 	// TODO: implement the retry mechanism under merge all flag.
@@ -300,7 +300,7 @@ func mergeKeyspaceGroupCommandFunc(cmd *cobra.Command, args []string) {
 
 func finishMergeKeyspaceGroupCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) < 1 {
-		cmd.Usage()
+		_ = cmd.Usage()
 		return
 	}
 	_, err := strconv.ParseUint(args[0], 10, 32)
@@ -318,7 +318,7 @@ func finishMergeKeyspaceGroupCommandFunc(cmd *cobra.Command, args []string) {
 
 func setNodesKeyspaceGroupCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) < 2 {
-		cmd.Usage()
+		_ = cmd.Usage()
 		return
 	}
 	_, err := strconv.ParseUint(args[0], 10, 32)
@@ -342,7 +342,7 @@ func setNodesKeyspaceGroupCommandFunc(cmd *cobra.Command, args []string) {
 
 func setPriorityKeyspaceGroupCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) < 3 {
-		cmd.Usage()
+		_ = cmd.Usage()
 		return
 	}
 	_, err := strconv.ParseUint(args[0], 10, 32)
@@ -377,7 +377,7 @@ func setPriorityKeyspaceGroupCommandFunc(cmd *cobra.Command, args []string) {
 
 func showKeyspaceGroupPrimaryCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) < 1 {
-		cmd.Usage()
+		_ = cmd.Usage()
 		return
 	}
 	_, err := strconv.ParseUint(args[0], 10, 32)

--- a/tools/pd-ctl/pdctl/command/maintenance_command_test.go
+++ b/tools/pd-ctl/pdctl/command/maintenance_command_test.go
@@ -54,7 +54,7 @@ func TestMaintenanceSetCommand_Success(t *testing.T) {
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.Execute()
+	re.NoError(cmd.Execute())
 	result := out.String()
 	re.Contains(result, "Maintenance task started successfully")
 }
@@ -72,7 +72,7 @@ func TestMaintenanceSetCommand_Error(t *testing.T) {
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.Execute()
+	re.NoError(cmd.Execute())
 	result := out.String()
 	re.Contains(result, "Failed to start maintenance task:")
 	re.Contains(result, "mock error")
@@ -94,7 +94,7 @@ func TestMaintenanceDeleteCommand_Success(t *testing.T) {
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.Execute()
+	re.NoError(cmd.Execute())
 	result := out.String()
 	re.Contains(result, "Maintenance task deleted successfully")
 }
@@ -111,7 +111,7 @@ func TestMaintenanceDeleteCommand_Error(t *testing.T) {
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.Execute()
+	re.NoError(cmd.Execute())
 	result := out.String()
 	re.Contains(result, "Failed to delete maintenance task:")
 	re.Contains(result, "mock error")
@@ -134,7 +134,7 @@ func TestMaintenanceShowCommand_Success(t *testing.T) {
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.Execute()
+	re.NoError(cmd.Execute())
 	result := out.String()
 
 	// Check that the raw JSON response is printed
@@ -153,7 +153,7 @@ func TestMaintenanceShowCommand_Error(t *testing.T) {
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.Execute()
+	re.NoError(cmd.Execute())
 	result := out.String()
 	re.Contains(result, "Failed to get maintenance task:")
 	re.Contains(result, "mock error")
@@ -176,7 +176,7 @@ func TestMaintenanceShowCommand_AllTasks(t *testing.T) {
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.Execute()
+	re.NoError(cmd.Execute())
 	result := out.String()
 	re.Contains(result, `{"type":"tikv","id":"task1","start_timestamp":1234567890,"description":"rolling restart for TiKV store-1"}`)
 }
@@ -198,7 +198,7 @@ func TestMaintenanceShowCommand_SpecificTaskType(t *testing.T) {
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.Execute()
+	re.NoError(cmd.Execute())
 	result := out.String()
 	re.Contains(result, `{"type":"tikv","id":"task1","start_timestamp":1234567890,"description":"specific task"}`)
 }
@@ -220,7 +220,7 @@ func TestMaintenanceShowCommand_NotFound_AllTasks(t *testing.T) {
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.Execute()
+	re.NoError(cmd.Execute())
 	result := out.String()
 	re.Contains(result, "No maintenance tasks are currently running.")
 }
@@ -242,7 +242,7 @@ func TestMaintenanceShowCommand_NotFound_SpecificType(t *testing.T) {
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.Execute()
+	re.NoError(cmd.Execute())
 	result := out.String()
 	re.Contains(result, "No maintenance task found for type: tikv")
 }
@@ -264,7 +264,7 @@ func TestMaintenanceShowCommand_InvalidJSON(t *testing.T) {
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.Execute()
+	re.NoError(cmd.Execute())
 	result := out.String()
 	re.Contains(result, "invalid json response")
 }
@@ -281,7 +281,7 @@ func TestMaintenanceShowCommand_NetworkError(t *testing.T) {
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.Execute()
+	re.NoError(cmd.Execute())
 	result := out.String()
 	re.Contains(result, "Failed to get maintenance task:")
 	re.Contains(result, "network error")
@@ -311,7 +311,7 @@ func TestMaintenanceShowCommand_ReadBodyError(t *testing.T) {
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.Execute()
+	re.NoError(cmd.Execute())
 	result := out.String()
 	re.Contains(result, "Failed to get maintenance task:")
 	re.Contains(result, "read error")
@@ -334,7 +334,7 @@ func TestMaintenanceSetCommand_Conflict(t *testing.T) {
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.Execute()
+	re.NoError(cmd.Execute())
 	result := out.String()
 	re.Contains(result, "Failed to start maintenance task:")
 	re.Contains(result, "[409]")
@@ -357,7 +357,7 @@ func TestMaintenanceDeleteCommand_NotFound(t *testing.T) {
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.Execute()
+	re.NoError(cmd.Execute())
 	result := out.String()
 	re.Contains(result, "Failed to delete maintenance task:")
 	re.Contains(result, "[404]")
@@ -380,7 +380,7 @@ func TestMaintenanceDeleteCommand_Conflict(t *testing.T) {
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.Execute()
+	re.NoError(cmd.Execute())
 	result := out.String()
 	re.Contains(result, "Failed to delete maintenance task:")
 	re.Contains(result, "[409]")

--- a/tools/pd-ctl/pdctl/command/meta_service_group_command.go
+++ b/tools/pd-ctl/pdctl/command/meta_service_group_command.go
@@ -57,7 +57,7 @@ func newListMetaServiceGroupCommand() *cobra.Command {
 
 func listMetaServiceGroupFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 0 {
-		cmd.Usage()
+		_ = cmd.Usage()
 		return
 	}
 	resp, err := doRequest(cmd, metaServiceGroupPrefix, http.MethodGet, http.Header{})
@@ -87,7 +87,7 @@ func newUpsertMetaServiceGroupFunc(cmd *cobra.Command, _ []string) {
 	}
 	if len(metaServiceGroups) == 0 {
 		cmd.PrintErrln("At least one --group must be specified")
-		cmd.Usage()
+		_ = cmd.Usage()
 		return
 	}
 	patch := make(map[string]*string)

--- a/tools/pd-ctl/pdctl/command/region_command.go
+++ b/tools/pd-ctl/pdctl/command/region_command.go
@@ -354,15 +354,9 @@ func decodeKey(text string) (string, error) {
 
 		switch n[0] {
 		case 'x':
-			n = r.Next(2)
-			if len(n) != 2 {
-				return "", io.ErrUnexpectedEOF
-			}
-			decoded, err := hex.DecodeString(string(n))
-			if err != nil {
-				return "", errors.WithStack(err)
-			}
-			buf = append(buf, decoded[0])
+			// Keep accepting partial and malformed hexadecimal escapes for compatibility.
+			_, _ = fmt.Sscanf(string(r.Next(2)), "%02x", &c)
+			buf = append(buf, c)
 		default:
 			n = append(n, r.Next(2)...)
 			_, err := fmt.Sscanf(string(n), "%03o", &c)

--- a/tools/pd-ctl/pdctl/command/region_command.go
+++ b/tools/pd-ctl/pdctl/command/region_command.go
@@ -354,8 +354,15 @@ func decodeKey(text string) (string, error) {
 
 		switch n[0] {
 		case 'x':
-			_, _ = fmt.Sscanf(string(r.Next(2)), "%02x", &c)
-			buf = append(buf, c)
+			n = r.Next(2)
+			if len(n) != 2 {
+				return "", io.ErrUnexpectedEOF
+			}
+			decoded, err := hex.DecodeString(string(n))
+			if err != nil {
+				return "", errors.WithStack(err)
+			}
+			buf = append(buf, decoded[0])
 		default:
 			n = append(n, r.Next(2)...)
 			_, err := fmt.Sscanf(string(n), "%03o", &c)

--- a/tools/pd-ctl/pdctl/command/region_command.go
+++ b/tools/pd-ctl/pdctl/command/region_command.go
@@ -354,7 +354,7 @@ func decodeKey(text string) (string, error) {
 
 		switch n[0] {
 		case 'x':
-			fmt.Sscanf(string(r.Next(2)), "%02x", &c)
+			_, _ = fmt.Sscanf(string(r.Next(2)), "%02x", &c)
 			buf = append(buf, c)
 		default:
 			n = append(n, r.Next(2)...)

--- a/tools/pd-ctl/pdctl/command/region_test.go
+++ b/tools/pd-ctl/pdctl/command/region_test.go
@@ -57,6 +57,35 @@ func TestCheckKey(t *testing.T) {
 	}
 }
 
+func TestDecodeKey(t *testing.T) {
+	testCases := []struct {
+		name    string
+		input   string
+		expect  string
+		wantErr bool
+	}{
+		{name: "hex", input: `\x61`, expect: "a"},
+		{name: "octal", input: `\141`, expect: "a"},
+		{name: "escaped newline", input: `\n`, expect: "\n"},
+		{name: "plain", input: "abc", expect: "abc"},
+		{name: "missing hex digits", input: `\x`, wantErr: true},
+		{name: "short hex escape", input: `\x1`, wantErr: true},
+		{name: "invalid hex digit", input: `\x1g`, wantErr: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := decodeKey(tc.input)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expect, actual)
+		})
+	}
+}
+
 func TestExpandHexStackOverflow(t *testing.T) {
 	// This is a valid hex string
 	hexStr := "616263646566" // "abcdef" in hex

--- a/tools/pd-ctl/pdctl/command/region_test.go
+++ b/tools/pd-ctl/pdctl/command/region_test.go
@@ -68,9 +68,11 @@ func TestDecodeKey(t *testing.T) {
 		{name: "octal", input: `\141`, expect: "a"},
 		{name: "escaped newline", input: `\n`, expect: "\n"},
 		{name: "plain", input: "abc", expect: "abc"},
-		{name: "missing hex digits", input: `\x`, wantErr: true},
-		{name: "short hex escape", input: `\x1`, wantErr: true},
-		{name: "invalid hex digit", input: `\x1g`, wantErr: true},
+		{name: "missing hex digits", input: `\x`, expect: `\`},
+		{name: "short hex escape", input: `\x1`, expect: string([]byte{1})},
+		{name: "partially invalid hex escape", input: `\x1g`, expect: string([]byte{1})},
+		{name: "invalid hex escape", input: `\xg1`, expect: `\`},
+		{name: "trailing escape", input: `abc\`, wantErr: true},
 	}
 
 	for _, tc := range testCases {

--- a/tools/pd-ctl/pdctl/command/scheduler_command.go
+++ b/tools/pd-ctl/pdctl/command/scheduler_command.go
@@ -65,12 +65,12 @@ func NewPauseSchedulerCommand() *cobra.Command {
 
 func pauseSchedulerCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 2 {
-		cmd.Usage()
+		_ = cmd.Usage()
 		return
 	}
 	delay, err := strconv.ParseInt(args[1], 10, 64)
 	if err != nil || delay <= 0 {
-		cmd.Usage()
+		_ = cmd.Usage()
 		return
 	}
 	path := schedulersPrefix + "/" + getEscapedSchedulerName(args[0])
@@ -97,7 +97,7 @@ func NewResumeSchedulerCommand() *cobra.Command {
 
 func resumeSchedulerCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
-		cmd.Usage()
+		_ = cmd.Usage()
 		return
 	}
 	path := schedulersPrefix + "/" + getEscapedSchedulerName(args[0])
@@ -193,7 +193,7 @@ func checkSchedulerExist(cmd *cobra.Command, schedulerName string) (bool, error)
 		return false, err
 	}
 	var schedulerList []string
-	json.Unmarshal([]byte(r), &schedulerList)
+	_ = json.Unmarshal([]byte(r), &schedulerList)
 	for idx := range schedulerList {
 		if strings.Contains(schedulerList[idx], schedulerName) {
 			return true, nil

--- a/tools/pd-ctl/pdctl/command/scheduler_command.go
+++ b/tools/pd-ctl/pdctl/command/scheduler_command.go
@@ -193,7 +193,9 @@ func checkSchedulerExist(cmd *cobra.Command, schedulerName string) (bool, error)
 		return false, err
 	}
 	var schedulerList []string
-	_ = json.Unmarshal([]byte(r), &schedulerList)
+	if err := json.Unmarshal([]byte(r), &schedulerList); err != nil {
+		return false, errors.WithStack(err)
+	}
 	for idx := range schedulerList {
 		if strings.Contains(schedulerList[idx], schedulerName) {
 			return true, nil

--- a/tools/pd-ctl/pdctl/command/store_command.go
+++ b/tools/pd-ctl/pdctl/command/store_command.go
@@ -268,7 +268,7 @@ func convertToStoresInfo(content string) string {
 func showStoreCommandFunc(cmd *cobra.Command, args []string) {
 	prefix := storesPrefix
 	if len(args) > 1 {
-		cmd.Usage()
+		_ = cmd.Usage()
 		return
 	}
 	cFunc := convertToStoresInfo
@@ -313,7 +313,7 @@ func showStoreCommandFunc(cmd *cobra.Command, args []string) {
 
 func deleteStoreCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
-		cmd.Usage()
+		_ = cmd.Usage()
 		return
 	}
 	if _, err := strconv.Atoi(args[0]); err != nil {
@@ -346,7 +346,7 @@ func deleteStoreCommandByAddrFunc(cmd *cobra.Command, args []string) error {
 
 func cancelDeleteStoreCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
-		cmd.Usage()
+		_ = cmd.Usage()
 		return
 	}
 	if _, err := strconv.Atoi(args[0]); err != nil {
@@ -407,7 +407,7 @@ func cancelDeleteStoreCommandByAddrFunc(cmd *cobra.Command, args []string) {
 func getStoreID(cmd *cobra.Command, args []string, isCancel bool) (id int) {
 	id = -1
 	if len(args) != 1 {
-		cmd.Usage()
+		_ = cmd.Usage()
 		return
 	}
 	addr := args[0]
@@ -458,7 +458,7 @@ func labelStoreCommandFunc(cmd *cobra.Command, args []string) {
 		return
 	}
 	if len(args) <= 1 {
-		cmd.Usage()
+		_ = cmd.Usage()
 		return
 	}
 	if _, err := strconv.Atoi(args[0]); err != nil {
@@ -522,7 +522,7 @@ func labelStoreCommandFunc(cmd *cobra.Command, args []string) {
 
 func setStoreWeightCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 3 {
-		cmd.Usage()
+		_ = cmd.Usage()
 		return
 	}
 	leader, err := strconv.ParseFloat(args[1], 64)
@@ -612,7 +612,7 @@ func storeLimitCommandFunc(cmd *cobra.Command, args []string) {
 
 func storeCheckCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
-		cmd.Usage()
+		_ = cmd.Usage()
 		return
 	}
 
@@ -643,7 +643,7 @@ func showStoresCommandFunc(cmd *cobra.Command, _ []string) {
 
 func showAllStoresLimitCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) > 1 {
-		cmd.Usage()
+		_ = cmd.Usage()
 		return
 	}
 	prefix := storesLimitPrefix
@@ -660,7 +660,7 @@ func showAllStoresLimitCommandFunc(cmd *cobra.Command, args []string) {
 
 func removeTombStoneCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 0 {
-		cmd.Usage()
+		_ = cmd.Usage()
 		return
 	}
 	prefix := path.Join(storesPrefix, "remove-tombstone")
@@ -675,7 +675,7 @@ func removeTombStoneCommandFunc(cmd *cobra.Command, args []string) {
 func setAllLimitCommandFunc(cmd *cobra.Command, args []string) {
 	argsCount := len(args)
 	if argsCount != 1 && argsCount != 2 {
-		cmd.Usage()
+		_ = cmd.Usage()
 		return
 	}
 	rate, err := strconv.ParseFloat(args[0], 64)

--- a/tools/pd-ctl/pdctl/command/unsafe_command.go
+++ b/tools/pd-ctl/pdctl/command/unsafe_command.go
@@ -94,7 +94,7 @@ func removeFailedStoresCommandFunc(cmd *cobra.Command, args []string) {
 	} else {
 		if len(args) < 1 {
 			cmd.Println("Failed store ids are not specified")
-			cmd.Usage()
+			_ = cmd.Usage()
 			return
 		}
 

--- a/tools/pd-ctl/pdctl/ctl.go
+++ b/tools/pd-ctl/pdctl/ctl.go
@@ -102,7 +102,7 @@ func MainStart(args []string) {
 	}
 
 	rootCmd.SetArgs(args)
-	rootCmd.ParseFlags(args)
+	_ = rootCmd.ParseFlags(args)
 	rootCmd.SetOut(os.Stdout)
 	rootCmd.SetErr(os.Stderr)
 
@@ -130,13 +130,13 @@ func loop(persistentFlags *pflag.FlagSet, readlineCompleter readline.AutoComplet
 		rootCmd := GetRootCmd()
 		persistentFlags.VisitAll(func(flag *pflag.Flag) {
 			if flag.Changed {
-				rootCmd.PersistentFlags().Set(flag.Name, flag.Value.String())
+				_ = rootCmd.PersistentFlags().Set(flag.Name, flag.Value.String())
 			}
 		})
-		rootCmd.LocalFlags().MarkHidden("pd")
-		rootCmd.LocalFlags().MarkHidden("cacert")
-		rootCmd.LocalFlags().MarkHidden("cert")
-		rootCmd.LocalFlags().MarkHidden("key")
+		_ = rootCmd.LocalFlags().MarkHidden("pd")
+		_ = rootCmd.LocalFlags().MarkHidden("cacert")
+		_ = rootCmd.LocalFlags().MarkHidden("cert")
+		_ = rootCmd.LocalFlags().MarkHidden("key")
 		rootCmd.SetOut(os.Stdout)
 		return rootCmd
 	}
@@ -162,7 +162,7 @@ func loop(persistentFlags *pflag.FlagSet, readlineCompleter readline.AutoComplet
 
 		rootCmd := getREPLCmd()
 		rootCmd.SetArgs(args)
-		rootCmd.ParseFlags(args)
+		_ = rootCmd.ParseFlags(args)
 		if err := rootCmd.Execute(); err != nil {
 			rootCmd.Println(err)
 		}

--- a/tools/pd-ctl/tests/global_test.go
+++ b/tools/pd-ctl/tests/global_test.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/pingcap/kvproto/pkg/metapb"
@@ -34,23 +35,30 @@ import (
 )
 
 func TestSendAndGetComponent(t *testing.T) {
+	as := assert.New(t)
 	re := require.New(t)
 	handler := func(context.Context, *server.Server) (http.Handler, apiutil.APIServiceGroup, error) {
 		mux := http.NewServeMux()
 		// check pd http sdk api
 		mux.HandleFunc("/pd/api/v1/cluster", func(w http.ResponseWriter, r *http.Request) {
 			callerID := apiutil.GetCallerIDOnHTTP(r)
-			re.Equal(command.PDControlCallerID, callerID)
+			if !as.Equal(command.PDControlCallerID, callerID) {
+				return
+			}
 			cluster := &metapb.Cluster{Id: 1}
 			clusterBytes, err := json.Marshal(cluster)
-			re.NoError(err)
+			if !as.NoError(err) {
+				return
+			}
 			w.Write(clusterBytes)
 		})
 		// check http client api
 		// TODO: remove this comment after replacing dialClient with the PD HTTP client completely.
 		mux.HandleFunc("/pd/api/v1/stores", func(w http.ResponseWriter, r *http.Request) {
 			callerID := apiutil.GetCallerIDOnHTTP(r)
-			re.Equal(command.PDControlCallerID, callerID)
+			if !as.Equal(command.PDControlCallerID, callerID) {
+				return
+			}
 			fmt.Fprint(w, callerID)
 		})
 		info := apiutil.APIServiceGroup{

--- a/tools/pd-ctl/tests/keyspace/keyspace_group_test.go
+++ b/tools/pd-ctl/tests/keyspace/keyspace_group_test.go
@@ -86,7 +86,8 @@ func (suite *keyspaceGroupTestSuite) SetupTest() {
 	re.NoError(err)
 	suite.tsoAddrs = suite.tsoCluster.GetAddrs()
 
-	suite.idAllocator.Alloc(1) // keyspace group 0 is reserved
+	_, _, err = suite.idAllocator.Alloc(1) // keyspace group 0 is reserved
+	re.NoError(err)
 }
 
 func (suite *keyspaceGroupTestSuite) TearDownTest() {
@@ -440,7 +441,9 @@ func (suite *keyspaceGroupTestSuite) TestShowKeyspaceGroupPrimary() {
 		output, err := tests.ExecuteCommand(cmd, args...)
 		re.NoError(err)
 		var resp handlers.GetKeyspaceGroupPrimaryResponse
-		json.Unmarshal(output, &resp)
+		if err := json.Unmarshal(output, &resp); err != nil {
+			return false
+		}
 		return suite.tsoAddrs[0] == resp.Primary || suite.tsoAddrs[1] == resp.Primary
 	})
 
@@ -476,7 +479,9 @@ func (suite *keyspaceGroupTestSuite) TestShowKeyspaceGroupPrimary() {
 		output, err := tests.ExecuteCommand(cmd, args...)
 		re.NoError(err)
 		var resp handlers.GetKeyspaceGroupPrimaryResponse
-		json.Unmarshal(output, &resp)
+		if err := json.Unmarshal(output, &resp); err != nil {
+			return false
+		}
 		return suite.tsoAddrs[0] == resp.Primary || suite.tsoAddrs[1] == resp.Primary
 	})
 

--- a/tools/pd-ctl/tests/keyspace/keyspace_test.go
+++ b/tools/pd-ctl/tests/keyspace/keyspace_test.go
@@ -666,7 +666,7 @@ func (suite *keyspaceTestSuite) TestSetPlacementWithTiFlash() {
 		},
 		peers[0],
 	)
-	leaderServer.GetRaftCluster().HandleRegionHeartbeat(region)
+	re.NoError(leaderServer.GetRaftCluster().HandleRegionHeartbeat(region))
 
 	// Wait for bundles to apply and ensure both rules match the region
 	testutil.Eventually(re, func() bool {

--- a/tools/pd-ctl/tests/resourcemanager/resource_manager_command_test.go
+++ b/tools/pd-ctl/tests/resourcemanager/resource_manager_command_test.go
@@ -47,7 +47,7 @@ func (s *testResourceManagerSuite) SetupSuite() {
 	cluster, err := pdTests.NewTestCluster(s.ctx, 1)
 	re.NoError(err)
 	s.cluster = cluster
-	s.cluster.RunInitialServers()
+	re.NoError(s.cluster.RunInitialServers())
 	re.NotEmpty(cluster.WaitLeader())
 	s.pdAddr = cluster.GetConfig().GetClientURL()
 }
@@ -60,7 +60,7 @@ func (s *testResourceManagerSuite) TearDownSuite() {
 func (s *testResourceManagerSuite) TestConfigController() {
 	re := s.Require()
 	expectCfg := server.Config{}
-	expectCfg.Adjust(nil)
+	re.NoError(expectCfg.Adjust(nil))
 	// Show controller config
 	checkShow := func() {
 		args := []string{"-u", s.pdAddr, "resource-manager", "config", "controller", "show"}

--- a/tools/pd-ctl/tests/scheduler/scheduler_test.go
+++ b/tools/pd-ctl/tests/scheduler/scheduler_test.go
@@ -903,7 +903,7 @@ func mightExec(re *require.Assertions, cmd *cobra.Command, args []string, v any)
 	if v == nil {
 		return
 	}
-	json.Unmarshal(output, v)
+	re.NoError(json.Unmarshal(output, v))
 }
 
 func checkSchedulerCommand(re *require.Assertions, cmd *cobra.Command, pdAddr string, args []string, expected map[string]bool) {

--- a/tools/pd-ctl/tests/store/store_test.go
+++ b/tools/pd-ctl/tests/store/store_test.go
@@ -322,7 +322,7 @@ func (s *storeTestSuite) checkStore(cluster *pdTests.TestCluster) {
 	re.NoError(err)
 
 	allAddPeerLimit := make(map[string]map[string]any)
-	json.Unmarshal(output, &allAddPeerLimit)
+	re.NoError(json.Unmarshal(output, &allAddPeerLimit))
 	re.Equal(float64(20), allAddPeerLimit["1"]["add-peer"].(float64))
 	re.Equal(float64(20), allAddPeerLimit["3"]["add-peer"].(float64))
 	_, ok := allAddPeerLimit["2"]["add-peer"]
@@ -333,7 +333,7 @@ func (s *storeTestSuite) checkStore(cluster *pdTests.TestCluster) {
 	re.NoError(err)
 
 	allRemovePeerLimit := make(map[string]map[string]any)
-	json.Unmarshal(output, &allRemovePeerLimit)
+	re.NoError(json.Unmarshal(output, &allRemovePeerLimit))
 	re.Equal(float64(20), allRemovePeerLimit["1"]["remove-peer"].(float64))
 	re.Equal(float64(25), allRemovePeerLimit["3"]["remove-peer"].(float64))
 	_, ok = allRemovePeerLimit["2"]["add-peer"]
@@ -512,7 +512,7 @@ func (s *storeTestSuite) checkStore(cluster *pdTests.TestCluster) {
 	output, err = tests.ExecuteCommand(cmd, args...)
 	re.NoError(err)
 	allRemovePeerLimit = make(map[string]map[string]any)
-	json.Unmarshal(output, &allRemovePeerLimit)
+	re.NoError(json.Unmarshal(output, &allRemovePeerLimit))
 	re.Equal(float64(21), allRemovePeerLimit["1"]["remove-peer"].(float64))
 	re.Equal(float64(21), allRemovePeerLimit["3"]["remove-peer"].(float64))
 }

--- a/tools/pd-heartbeat-bench/main.go
+++ b/tools/pd-heartbeat-bench/main.go
@@ -145,8 +145,12 @@ func bootstrap(ctx context.Context, cli pdpb.PDClient) {
 	log.Info("bootstrapped")
 }
 
-func putStores(ctx context.Context, cfg *config.Config, cli pdpb.PDClient, stores *Stores) {
-	go stores.reportStoreHeartbeatFailures(ctx)
+func putStores(ctx context.Context, cfg *config.Config, cli pdpb.PDClient, stores *Stores) <-chan struct{} {
+	reporterDone := make(chan struct{})
+	go func() {
+		defer close(reporterDone)
+		stores.reportStoreHeartbeatFailures(ctx)
+	}()
 	for i := uint64(1); i <= uint64(cfg.StoreCount); i++ {
 		store := &metapb.Store{
 			Id:      i,
@@ -175,6 +179,7 @@ func putStores(ctx context.Context, cfg *config.Config, cli pdpb.PDClient, store
 			}
 		}(ctx, i)
 	}
+	return reporterDone
 }
 
 func createHeartbeatStream(ctx context.Context, cfg *config.Config) (pdpb.PDClient, pdpb.PD_RegionHeartbeatClient) {
@@ -373,7 +378,7 @@ func main() {
 	stores := newStores(cfg.StoreCount)
 	stores.update(regions)
 	bootstrap(ctx, cli)
-	putStores(ctx, cfg, cli, stores)
+	heartbeatReporterDone := putStores(ctx, cfg, cli, stores)
 	log.Info("finish put stores")
 	clis := make(map[uint64]pdpb.PDClient, cfg.StoreCount)
 	httpCli := pdHttp.NewClient("tools-heartbeat-bench", []string{cfg.PDAddr}, pdHttp.WithTLSConfig(loadTLSConfig(cfg)))
@@ -394,6 +399,8 @@ func main() {
 		select {
 		case <-heartbeatTicker.C:
 			if cfg.Round != 0 && regions.UpdateRound > cfg.Round {
+				cancel()
+				<-heartbeatReporterDone
 				exit(0)
 			}
 			rep := newReport(cfg)
@@ -443,6 +450,7 @@ func main() {
 			wg.Wait()
 		case <-ctx.Done():
 			log.Info("got signal to exit")
+			<-heartbeatReporterDone
 			switch sig {
 			case syscall.SIGTERM:
 				exit(0)

--- a/tools/pd-heartbeat-bench/main.go
+++ b/tools/pd-heartbeat-bench/main.go
@@ -217,7 +217,7 @@ func newStores(storeCount int) *Stores {
 func (s *Stores) heartbeat(ctx context.Context, cli pdpb.PDClient, storeID uint64) {
 	cctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	cli.StoreHeartbeat(cctx, &pdpb.StoreHeartbeatRequest{Header: header(), Stats: s.stat[storeID].Load().(*pdpb.StoreStats)})
+	_, _ = cli.StoreHeartbeat(cctx, &pdpb.StoreHeartbeatRequest{Header: header(), Stats: s.stat[storeID].Load().(*pdpb.StoreStats)})
 }
 
 func (s *Stores) update(rs *utils.Regions) {
@@ -488,7 +488,7 @@ func runHTTPServer(cfg *config.Config, options *config.Options) {
 		c.IndentedJSON(http.StatusOK, "Successfully collect metrics")
 	})
 
-	engine.Run(cfg.StatusAddr)
+	_ = engine.Run(cfg.StatusAddr)
 }
 
 func loadTLSConfig(cfg *config.Config) *tls.Config {

--- a/tools/pd-heartbeat-bench/main.go
+++ b/tools/pd-heartbeat-bench/main.go
@@ -217,7 +217,10 @@ func newStores(storeCount int) *Stores {
 func (s *Stores) heartbeat(ctx context.Context, cli pdpb.PDClient, storeID uint64) {
 	cctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	_, _ = cli.StoreHeartbeat(cctx, &pdpb.StoreHeartbeatRequest{Header: header(), Stats: s.stat[storeID].Load().(*pdpb.StoreStats)})
+	_, err := cli.StoreHeartbeat(cctx, &pdpb.StoreHeartbeatRequest{Header: header(), Stats: s.stat[storeID].Load().(*pdpb.StoreStats)})
+	if err != nil {
+		log.Error("store heartbeat failed", zap.Uint64("store-id", storeID), zap.Error(err))
+	}
 }
 
 func (s *Stores) update(rs *utils.Regions) {
@@ -488,7 +491,9 @@ func runHTTPServer(cfg *config.Config, options *config.Options) {
 		c.IndentedJSON(http.StatusOK, "Successfully collect metrics")
 	})
 
-	_ = engine.Run(cfg.StatusAddr)
+	if err := engine.Run(cfg.StatusAddr); err != nil {
+		log.Fatal("run status server failed", zap.Error(err))
+	}
 }
 
 func loadTLSConfig(cfg *config.Config) *tls.Config {

--- a/tools/pd-heartbeat-bench/main.go
+++ b/tools/pd-heartbeat-bench/main.go
@@ -146,6 +146,7 @@ func bootstrap(ctx context.Context, cli pdpb.PDClient) {
 }
 
 func putStores(ctx context.Context, cfg *config.Config, cli pdpb.PDClient, stores *Stores) {
+	go stores.reportStoreHeartbeatFailures(ctx)
 	for i := uint64(1); i <= uint64(cfg.StoreCount); i++ {
 		store := &metapb.Store{
 			Id:      i,
@@ -206,6 +207,11 @@ func createHeartbeatStream(ctx context.Context, cfg *config.Config) (pdpb.PDClie
 // Stores contains store stats with lock.
 type Stores struct {
 	stat []atomic.Value
+
+	heartbeatFailureMu        sync.Mutex
+	failedStoreHeartbeatCount uint64
+	lastFailedStoreID         uint64
+	lastStoreHeartbeatError   string
 }
 
 func newStores(storeCount int) *Stores {
@@ -217,9 +223,48 @@ func newStores(storeCount int) *Stores {
 func (s *Stores) heartbeat(ctx context.Context, cli pdpb.PDClient, storeID uint64) {
 	cctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	_, err := cli.StoreHeartbeat(cctx, &pdpb.StoreHeartbeatRequest{Header: header(), Stats: s.stat[storeID].Load().(*pdpb.StoreStats)})
+	resp, err := cli.StoreHeartbeat(cctx, &pdpb.StoreHeartbeatRequest{Header: header(), Stats: s.stat[storeID].Load().(*pdpb.StoreStats)})
+	if err == nil && resp.GetHeader().GetError() != nil {
+		err = errors.New(resp.GetHeader().GetError().String())
+	}
 	if err != nil {
-		log.Error("store heartbeat failed", zap.Uint64("store-id", storeID), zap.Error(err))
+		s.heartbeatFailureMu.Lock()
+		s.failedStoreHeartbeatCount++
+		s.lastFailedStoreID = storeID
+		s.lastStoreHeartbeatError = err.Error()
+		s.heartbeatFailureMu.Unlock()
+	}
+}
+
+func (s *Stores) takeStoreHeartbeatFailures() (count, storeID uint64, err string) {
+	s.heartbeatFailureMu.Lock()
+	defer s.heartbeatFailureMu.Unlock()
+	count = s.failedStoreHeartbeatCount
+	s.failedStoreHeartbeatCount = 0
+	return count, s.lastFailedStoreID, s.lastStoreHeartbeatError
+}
+
+func (s *Stores) reportStoreHeartbeatFailures(ctx context.Context) {
+	reportTicker := time.NewTicker(time.Duration(storeReportInterval) * time.Second)
+	defer reportTicker.Stop()
+	report := func() {
+		count, storeID, err := s.takeStoreHeartbeatFailures()
+		if count == 0 {
+			return
+		}
+		log.Error("store heartbeats failed",
+			zap.Uint64("count", count),
+			zap.Uint64("last-store-id", storeID),
+			zap.String("last-error", err))
+	}
+	for {
+		select {
+		case <-reportTicker.C:
+			report()
+		case <-ctx.Done():
+			report()
+			return
+		}
 	}
 }
 

--- a/tools/pd-heartbeat-bench/main.go
+++ b/tools/pd-heartbeat-bench/main.go
@@ -146,11 +146,7 @@ func bootstrap(ctx context.Context, cli pdpb.PDClient) {
 }
 
 func putStores(ctx context.Context, cfg *config.Config, cli pdpb.PDClient, stores *Stores) <-chan struct{} {
-	reporterDone := make(chan struct{})
-	go func() {
-		defer close(reporterDone)
-		stores.reportStoreHeartbeatFailures(ctx)
-	}()
+	heartbeatWorkers := &sync.WaitGroup{}
 	for i := uint64(1); i <= uint64(cfg.StoreCount); i++ {
 		store := &metapb.Store{
 			Id:      i,
@@ -166,7 +162,9 @@ func putStores(ctx context.Context, cfg *config.Config, cli pdpb.PDClient, store
 		if resp.GetHeader().GetError() != nil {
 			log.Fatal("failed to put store", zap.Uint64("store-id", i), zap.String("err", resp.GetHeader().GetError().String()))
 		}
+		heartbeatWorkers.Add(1)
 		go func(ctx context.Context, storeID uint64) {
+			defer heartbeatWorkers.Done()
 			heartbeatTicker := time.NewTicker(10 * time.Second)
 			defer heartbeatTicker.Stop()
 			for {
@@ -179,6 +177,11 @@ func putStores(ctx context.Context, cfg *config.Config, cli pdpb.PDClient, store
 			}
 		}(ctx, i)
 	}
+	reporterDone := make(chan struct{})
+	go func() {
+		defer close(reporterDone)
+		stores.reportStoreHeartbeatFailures(ctx, heartbeatWorkers)
+	}()
 	return reporterDone
 }
 
@@ -249,7 +252,7 @@ func (s *Stores) takeStoreHeartbeatFailures() (count, storeID uint64, err string
 	return count, s.lastFailedStoreID, s.lastStoreHeartbeatError
 }
 
-func (s *Stores) reportStoreHeartbeatFailures(ctx context.Context) {
+func (s *Stores) reportStoreHeartbeatFailures(ctx context.Context, heartbeatWorkers *sync.WaitGroup) {
 	reportTicker := time.NewTicker(time.Duration(storeReportInterval) * time.Second)
 	defer reportTicker.Stop()
 	report := func() {
@@ -267,6 +270,7 @@ func (s *Stores) reportStoreHeartbeatFailures(ctx context.Context) {
 		case <-reportTicker.C:
 			report()
 		case <-ctx.Done():
+			heartbeatWorkers.Wait()
 			report()
 			return
 		}

--- a/tools/pd-heartbeat-bench/main.go
+++ b/tools/pd-heartbeat-bench/main.go
@@ -548,9 +548,7 @@ func runHTTPServer(cfg *config.Config, options *config.Options) {
 		c.IndentedJSON(http.StatusOK, "Successfully collect metrics")
 	})
 
-	if err := engine.Run(cfg.StatusAddr); err != nil {
-		log.Fatal("run status server failed", zap.Error(err))
-	}
+	_ = engine.Run(cfg.StatusAddr)
 }
 
 func loadTLSConfig(cfg *config.Config) *tls.Config {

--- a/tools/pd-heartbeat-bench/main_test.go
+++ b/tools/pd-heartbeat-bench/main_test.go
@@ -17,12 +17,15 @@ package main
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/pdpb"
+
+	"github.com/tikv/pd/tools/pd-heartbeat-bench/config"
 )
 
 type storeHeartbeatClient struct {
@@ -85,4 +88,22 @@ func TestStoreHeartbeatFailuresAreRecorded(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestStoreHeartbeatReporterFlushesBeforeDone(t *testing.T) {
+	stores := newStores(1)
+	stores.stat[1].Store(&pdpb.StoreStats{StoreId: 1})
+	stores.heartbeat(context.Background(), &storeHeartbeatClient{err: errors.New("transport failure")}, 1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	reporterDone := putStores(ctx, &config.Config{}, nil, stores)
+	cancel()
+	select {
+	case <-reporterDone:
+	case <-time.After(time.Second):
+		t.Fatal("store heartbeat reporter did not stop")
+	}
+
+	count, _, _ := stores.takeStoreHeartbeatFailures()
+	require.Zero(t, count)
 }

--- a/tools/pd-heartbeat-bench/main_test.go
+++ b/tools/pd-heartbeat-bench/main_test.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -24,8 +25,6 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/pdpb"
-
-	"github.com/tikv/pd/tools/pd-heartbeat-bench/config"
 )
 
 type storeHeartbeatClient struct {
@@ -93,11 +92,18 @@ func TestStoreHeartbeatFailuresAreRecorded(t *testing.T) {
 func TestStoreHeartbeatReporterFlushesBeforeDone(t *testing.T) {
 	stores := newStores(1)
 	stores.stat[1].Store(&pdpb.StoreStats{StoreId: 1})
-	stores.heartbeat(context.Background(), &storeHeartbeatClient{err: errors.New("transport failure")}, 1)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	reporterDone := putStores(ctx, &config.Config{}, nil, stores)
+	heartbeatWorkers := &sync.WaitGroup{}
+	heartbeatWorkers.Add(1)
+	reporterDone := make(chan struct{})
+	go func() {
+		defer close(reporterDone)
+		stores.reportStoreHeartbeatFailures(ctx, heartbeatWorkers)
+	}()
 	cancel()
+	stores.heartbeat(context.Background(), &storeHeartbeatClient{err: errors.New("transport failure")}, 1)
+	heartbeatWorkers.Done()
 	select {
 	case <-reporterDone:
 	case <-time.After(time.Second):

--- a/tools/pd-heartbeat-bench/main_test.go
+++ b/tools/pd-heartbeat-bench/main_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/kvproto/pkg/pdpb"
+)
+
+type storeHeartbeatClient struct {
+	pdpb.PDClient
+	resp *pdpb.StoreHeartbeatResponse
+	err  error
+}
+
+func (c *storeHeartbeatClient) StoreHeartbeat(
+	context.Context, *pdpb.StoreHeartbeatRequest, ...grpc.CallOption,
+) (*pdpb.StoreHeartbeatResponse, error) {
+	return c.resp, c.err
+}
+
+func TestStoreHeartbeatFailuresAreRecorded(t *testing.T) {
+	testCases := []struct {
+		name      string
+		client    pdpb.PDClient
+		wantCount uint64
+		wantError string
+	}{
+		{
+			name: "success",
+			client: &storeHeartbeatClient{
+				resp: &pdpb.StoreHeartbeatResponse{},
+			},
+		},
+		{
+			name: "transport error",
+			client: &storeHeartbeatClient{
+				err: errors.New("transport failure"),
+			},
+			wantCount: 1,
+			wantError: "transport failure",
+		},
+		{
+			name: "response error",
+			client: &storeHeartbeatClient{
+				resp: &pdpb.StoreHeartbeatResponse{
+					Header: &pdpb.ResponseHeader{
+						Error: &pdpb.Error{Type: pdpb.ErrorType_UNKNOWN, Message: "store rejected"},
+					},
+				},
+			},
+			wantCount: 1,
+			wantError: "store rejected",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			stores := newStores(1)
+			stores.stat[1].Store(&pdpb.StoreStats{StoreId: 1})
+			stores.heartbeat(context.Background(), tc.client, 1)
+			count, storeID, err := stores.takeStoreHeartbeatFailures()
+			require.Equal(t, tc.wantCount, count)
+			if tc.wantError != "" {
+				require.Equal(t, uint64(1), storeID)
+				require.Contains(t, err, tc.wantError)
+			}
+		})
+	}
+}

--- a/tools/pd-simulator/main.go
+++ b/tools/pd-simulator/main.go
@@ -153,7 +153,9 @@ func simStart(pdAddr, statusAddress string, simCase string, simConfig *sc.SimCon
 	defer tick.Stop()
 	sc := make(chan os.Signal, 1)
 	// halt scheduling
-	simulator.ChooseToHaltPDSchedule(true)
+	if err := simulator.ChooseToHaltPDSchedule(true); err != nil {
+		simutil.Logger.Fatal("halt PD scheduling failed", zap.Error(err))
+	}
 	signal.Notify(sc,
 		syscall.SIGHUP,
 		syscall.SIGINT,

--- a/tools/pd-simulator/simulator/client.go
+++ b/tools/pd-simulator/simulator/client.go
@@ -348,7 +348,7 @@ func newRetryClient(node *Node) (*retryClient, error) {
 		client:     client,
 		retryCount: retryTimes,
 	}
-	if err := retryClient.updateLeaderConnection(); err != nil {
+	if err := retryClient.updateLeaderConnection(node.ctx); err != nil {
 		client.Close()
 		return nil, errors.Annotate(err, "connect to PD leader failed")
 	}
@@ -359,23 +359,32 @@ func newRetryClient(node *Node) (*retryClient, error) {
 	return retryClient, nil
 }
 
-func (rc *retryClient) requestWithRetry(f func() (any, error)) (any, error) {
+func (rc *retryClient) requestWithRetry(ctx context.Context, f func() (any, error)) (any, error) {
 	// execute the function directly
 	if res, err := f(); err == nil {
 		return res, nil
 	}
-	if err := rc.updateLeaderConnection(); err != nil {
+	if err := rc.updateLeaderConnection(ctx); err != nil {
 		return nil, err
 	}
 	return f()
 }
 
-func (rc *retryClient) updateLeaderConnection() error {
+func (rc *retryClient) updateLeaderConnection(ctx context.Context) error {
+	retryTimer := time.NewTimer(100 * time.Millisecond)
+	defer retryTimer.Stop()
 	for range rc.retryCount {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		SD.ScheduleCheckMemberChanged()
-		time.Sleep(100 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-retryTimer.C:
+		}
 		if client := SD.GetServiceClient(); client != nil {
-			_, conn, err := getLeaderURL(context.Background(), client.GetClientConn())
+			_, conn, err := getLeaderURL(ctx, client.GetClientConn())
 			if err != nil {
 				simutil.Logger.Error("[retry] failed to get leader URL", zap.Error(err))
 				return err
@@ -386,6 +395,7 @@ func (rc *retryClient) updateLeaderConnection() error {
 			}
 			return nil
 		}
+		retryTimer.Reset(100 * time.Millisecond)
 	}
 	return errors.New("failed to retry")
 }
@@ -412,7 +422,7 @@ func getLeaderURL(ctx context.Context, conn *grpc.ClientConn) (string, *grpc.Cli
 }
 
 func (rc *retryClient) allocID(ctx context.Context) (uint64, error) {
-	res, err := rc.requestWithRetry(func() (any, error) {
+	res, err := rc.requestWithRetry(ctx, func() (any, error) {
 		id, err := rc.client.allocID(ctx)
 		return id, err
 	})
@@ -424,7 +434,7 @@ func (rc *retryClient) allocID(ctx context.Context) (uint64, error) {
 
 // PutStore sends PutStore to PD.
 func (rc *retryClient) PutStore(ctx context.Context, store *metapb.Store) error {
-	_, err := rc.requestWithRetry(func() (any, error) {
+	_, err := rc.requestWithRetry(ctx, func() (any, error) {
 		err := rc.client.PutStore(ctx, store)
 		return nil, err
 	})
@@ -433,7 +443,7 @@ func (rc *retryClient) PutStore(ctx context.Context, store *metapb.Store) error 
 
 // StoreHeartbeat sends a StoreHeartbeat to PD.
 func (rc *retryClient) StoreHeartbeat(ctx context.Context, newStats *pdpb.StoreStats) error {
-	_, err := rc.requestWithRetry(func() (any, error) {
+	_, err := rc.requestWithRetry(ctx, func() (any, error) {
 		err := rc.client.StoreHeartbeat(ctx, newStats)
 		return nil, err
 	})
@@ -442,7 +452,7 @@ func (rc *retryClient) StoreHeartbeat(ctx context.Context, newStats *pdpb.StoreS
 
 // RegionHeartbeat sends a RegionHeartbeat to PD.
 func (rc *retryClient) RegionHeartbeat(ctx context.Context, region *core.RegionInfo) error {
-	_, err := rc.requestWithRetry(func() (any, error) {
+	_, err := rc.requestWithRetry(ctx, func() (any, error) {
 		err := rc.client.RegionHeartbeat(ctx, region)
 		return nil, err
 	})

--- a/tools/pd-simulator/simulator/client.go
+++ b/tools/pd-simulator/simulator/client.go
@@ -318,7 +318,7 @@ type retryClient struct {
 	retryCount int
 }
 
-func newRetryClient(node *Node) *retryClient {
+func newRetryClient(node *Node) (*retryClient, error) {
 	// Init PD client and putting it into node.
 	tag := fmt.Sprintf("store %d", node.Id)
 	var (
@@ -337,24 +337,23 @@ func newRetryClient(node *Node) *retryClient {
 	}
 
 	if err != nil {
-		simutil.Logger.Fatal("create client failed", zap.Error(err))
+		return nil, errors.Annotate(err, "create client failed")
 	}
-	node.client = client
 
 	// Init retryClient
 	retryClient := &retryClient{
 		client:     client,
 		retryCount: retryTimes,
 	}
-	// check leader url firstly
-	_, _ = retryClient.requestWithRetry(func() (any, error) {
-		return nil, errors.New("retry to create client")
-	})
+	if err := retryClient.updateLeaderConnection(); err != nil {
+		client.Close()
+		return nil, errors.Annotate(err, "connect to PD leader failed")
+	}
 	// start heartbeat stream
 	node.receiveRegionHeartbeatCh = receiveRegionHeartbeatCh
 	go client.heartbeatStreamLoop()
 
-	return retryClient
+	return retryClient, nil
 }
 
 func (rc *retryClient) requestWithRetry(f func() (any, error)) (any, error) {
@@ -362,7 +361,13 @@ func (rc *retryClient) requestWithRetry(f func() (any, error)) (any, error) {
 	if res, err := f(); err == nil {
 		return res, nil
 	}
-	// retry to get leader URL
+	if err := rc.updateLeaderConnection(); err != nil {
+		return nil, err
+	}
+	return f()
+}
+
+func (rc *retryClient) updateLeaderConnection() error {
 	for range rc.retryCount {
 		SD.ScheduleCheckMemberChanged()
 		time.Sleep(100 * time.Millisecond)
@@ -370,16 +375,16 @@ func (rc *retryClient) requestWithRetry(f func() (any, error)) (any, error) {
 			_, conn, err := getLeaderURL(context.Background(), client.GetClientConn())
 			if err != nil {
 				simutil.Logger.Error("[retry] failed to get leader URL", zap.Error(err))
-				return nil, err
+				return err
 			}
 			if err = rc.client.changeConn(conn); err != nil {
 				simutil.Logger.Error("failed to change connection", zap.Error(err))
-				return nil, err
+				return err
 			}
-			return f()
+			return nil
 		}
 	}
-	return nil, errors.New("failed to retry")
+	return errors.New("failed to retry")
 }
 
 func getLeaderURL(ctx context.Context, conn *grpc.ClientConn) (string, *grpc.ClientConn, error) {
@@ -554,10 +559,13 @@ func PutPDConfig(config *sc.PDConfig) error {
 	return nil
 }
 
-// ChooseToHaltPDSchedule is used to choose whether to halt the PD schedule
-func ChooseToHaltPDSchedule(halt bool) {
-	haltSchedule.Store(halt)
-	_ = PDHTTPClient.SetConfig(context.Background(), map[string]any{
+// ChooseToHaltPDSchedule is used to choose whether to halt the PD schedule.
+func ChooseToHaltPDSchedule(halt bool) error {
+	if err := PDHTTPClient.SetConfig(context.Background(), map[string]any{
 		"schedule.halt-scheduling": strconv.FormatBool(halt),
-	})
+	}); err != nil {
+		return err
+	}
+	haltSchedule.Store(halt)
+	return nil
 }

--- a/tools/pd-simulator/simulator/client.go
+++ b/tools/pd-simulator/simulator/client.go
@@ -250,6 +250,9 @@ func (c *client) Close() {
 	c.cancel()
 	c.wg.Wait()
 
+	if c.clientConn == nil {
+		return
+	}
 	if err := c.clientConn.Close(); err != nil {
 		simutil.Logger.Error("failed to close grpc client connection", zap.String("tag", c.tag), zap.Error(err))
 	}

--- a/tools/pd-simulator/simulator/client.go
+++ b/tools/pd-simulator/simulator/client.go
@@ -347,7 +347,7 @@ func newRetryClient(node *Node) *retryClient {
 		retryCount: retryTimes,
 	}
 	// check leader url firstly
-	retryClient.requestWithRetry(func() (any, error) {
+	_, _ = retryClient.requestWithRetry(func() (any, error) {
 		return nil, errors.New("retry to create client")
 	})
 	// start heartbeat stream
@@ -557,7 +557,7 @@ func PutPDConfig(config *sc.PDConfig) error {
 // ChooseToHaltPDSchedule is used to choose whether to halt the PD schedule
 func ChooseToHaltPDSchedule(halt bool) {
 	haltSchedule.Store(halt)
-	PDHTTPClient.SetConfig(context.Background(), map[string]any{
+	_ = PDHTTPClient.SetConfig(context.Background(), map[string]any{
 		"schedule.halt-scheduling": strconv.FormatBool(halt),
 	})
 }

--- a/tools/pd-simulator/simulator/client_test.go
+++ b/tools/pd-simulator/simulator/client_test.go
@@ -15,6 +15,7 @@
 package simulator
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -33,4 +34,12 @@ func TestCloseBeforeConnectionInitialized(t *testing.T) {
 	client, _, err := NewClient("test")
 	require.NoError(t, err)
 	require.NotPanics(t, client.Close)
+}
+
+func TestUpdateLeaderConnectionRespectsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := (&retryClient{retryCount: 1}).updateLeaderConnection(ctx)
+	require.ErrorIs(t, err, context.Canceled)
 }

--- a/tools/pd-simulator/simulator/client_test.go
+++ b/tools/pd-simulator/simulator/client_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package simulator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/tikv/pd/tools/pd-simulator/simulator/simutil"
+)
+
+func TestCloseBeforeConnectionInitialized(t *testing.T) {
+	previousLogger := simutil.Logger
+	simutil.Logger = zap.NewNop()
+	t.Cleanup(func() {
+		simutil.Logger = previousLogger
+	})
+
+	client, _, err := NewClient("test")
+	require.NoError(t, err)
+	require.NotPanics(t, client.Close)
+}

--- a/tools/pd-simulator/simulator/drive.go
+++ b/tools/pd-simulator/simulator/drive.go
@@ -345,7 +345,7 @@ func (d *Driver) Start() error {
 		}
 	}
 
-	PutPDConfig(d.pdConfig)
+	_ = PutPDConfig(d.pdConfig)
 	return nil
 }
 

--- a/tools/pd-simulator/simulator/drive.go
+++ b/tools/pd-simulator/simulator/drive.go
@@ -173,7 +173,11 @@ func (d *Driver) updateNodesClient() error {
 	PDHTTPClient = pdHttp.NewClientWithServiceDiscovery("pd-simulator", SD)
 
 	for _, node := range d.conn.Nodes {
-		node.client = newRetryClient(node)
+		client, err := newRetryClient(node)
+		if err != nil {
+			return err
+		}
+		node.client = client
 	}
 	return nil
 }
@@ -298,7 +302,10 @@ func (d *Driver) RegionsHeartbeat(ctx context.Context) {
 						}
 						// Add halt schedule check to avoid the situation that the leader count is always less than 80%.
 						if leaderCount > int64(float64(d.simConfig.TotalRegion)*0.8) || !haltSchedule.Load() {
-							ChooseToHaltPDSchedule(false)
+							if err := ChooseToHaltPDSchedule(false); err != nil {
+								simutil.Logger.Error("resume PD scheduling failed", zap.Error(err))
+								continue
+							}
 							firstReport = false
 							ticker.Stop()
 							simutil.Logger.Info("first region heartbeat done", zap.Int64("leaderCount", leaderCount), zap.Int("checkRegions", len(regions)))
@@ -345,8 +352,7 @@ func (d *Driver) Start() error {
 		}
 	}
 
-	_ = PutPDConfig(d.pdConfig)
-	return nil
+	return PutPDConfig(d.pdConfig)
 }
 
 // Stop stops all nodes.

--- a/tools/pd-simulator/simulator/event.go
+++ b/tools/pd-simulator/simulator/event.go
@@ -202,7 +202,12 @@ func (*AddNode) Run(raft *RaftEngine, _ int64) bool {
 
 	raft.conn.Nodes[s.ID] = n
 	n.raftEngine = raft
-	n.client = newRetryClient(n)
+	n.client, err = newRetryClient(n)
+	if err != nil {
+		delete(raft.conn.Nodes, s.ID)
+		simutil.Logger.Error("create client failed", zap.Uint64("node-id", s.ID), zap.Error(err))
+		return false
+	}
 
 	err = n.Start()
 	if err != nil {

--- a/tools/pd-tso-bench/main.go
+++ b/tools/pd-tso-bench/main.go
@@ -267,8 +267,14 @@ func createPDClient(ctx context.Context) (pd.Client, error) {
 		return nil, err
 	}
 
-	_ = pdCli.UpdateOption(opt.MaxTSOBatchWaitInterval, *maxBatchWaitInterval)
-	_ = pdCli.UpdateOption(opt.EnableTSOFollowerProxy, *enableTSOFollowerProxy)
+	if err := pdCli.UpdateOption(opt.MaxTSOBatchWaitInterval, *maxBatchWaitInterval); err != nil {
+		pdCli.Close()
+		return nil, err
+	}
+	if err := pdCli.UpdateOption(opt.EnableTSOFollowerProxy, *enableTSOFollowerProxy); err != nil {
+		pdCli.Close()
+		return nil, err
+	}
 	return pdCli, err
 }
 

--- a/tools/pd-tso-bench/main.go
+++ b/tools/pd-tso-bench/main.go
@@ -267,8 +267,8 @@ func createPDClient(ctx context.Context) (pd.Client, error) {
 		return nil, err
 	}
 
-	pdCli.UpdateOption(opt.MaxTSOBatchWaitInterval, *maxBatchWaitInterval)
-	pdCli.UpdateOption(opt.EnableTSOFollowerProxy, *enableTSOFollowerProxy)
+	_ = pdCli.UpdateOption(opt.MaxTSOBatchWaitInterval, *maxBatchWaitInterval)
+	_ = pdCli.UpdateOption(opt.EnableTSOFollowerProxy, *enableTSOFollowerProxy)
 	return pdCli, err
 }
 

--- a/tools/pd-ut/coverProfile.go
+++ b/tools/pd-ut/coverProfile.go
@@ -39,7 +39,10 @@ func collectCoverProfileFile() {
 	}
 	//nolint: errcheck
 	defer w.Close()
-	_, _ = w.WriteString("mode: atomic\n")
+	if _, err := w.WriteString("mode: atomic\n"); err != nil {
+		fmt.Println("write cover profile header error:", err)
+		os.Exit(-1)
+	}
 
 	result := make(map[string]*cover.Profile)
 	for _, file := range files {

--- a/tools/pd-ut/coverProfile.go
+++ b/tools/pd-ut/coverProfile.go
@@ -39,7 +39,7 @@ func collectCoverProfileFile() {
 	}
 	//nolint: errcheck
 	defer w.Close()
-	w.WriteString("mode: atomic\n")
+	_, _ = w.WriteString("mode: atomic\n")
 
 	result := make(map[string]*cover.Profile)
 	for _, file := range files {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #4322

The codebase still contains compatibility-safe findings from disabled lint
checks. In particular, `require` assertions called outside the test goroutine
can terminate only the calling goroutine and prevent later synchronization
steps from running.

### What is changed and how does it work?

```commit-message
Fix compatibility-safe findings reported by appendAssign, wastedassign,
errcheck, and testifylint/go-require.

Use non-fatal assertions outside test goroutines so failures are recorded
without aborting the goroutine. Preserve existing synchronization order and
return early only when subsequent operations depend on the asserted result.

Leave configuration-related and compatibility-sensitive findings unchanged.
```

### Check List

Tests

- Unit test
- Integration test

### Release note

```release-note
None.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graceful handling of closed streams during latency testing.
  * Preserved independent copies of region and placement configuration data.
  * Restored compatibility for partially malformed escaped keys in command-line tools.
  * Prevented heartbeat failure reports from being lost during shutdown.

* **Reliability**
  * Improved error handling across command-line, simulator, and benchmarking tools.
  * Added validation for unknown API benchmark cases.
  * Improved simulator startup, reconnection, cancellation, and shutdown handling.
  * Strengthened concurrent operation checks and failure reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->