### PR TITLE
pd-ctl: support transfer-leader-in store limits

### DIFF
--- a/tools/pd-ctl/pdctl/command/store_command.go
+++ b/tools/pd-ctl/pdctl/command/store_command.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/pingcap/kvproto/pkg/metapb"
 
+	"github.com/tikv/pd/pkg/core/storelimit"
 	"github.com/tikv/pd/pkg/response"
 )
 
@@ -135,7 +136,7 @@ func NewStoreLimitCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "limit [<store_id>|<all> [<key> <value>]... <limit> <type>]",
 		Short: "show or set a store's rate limit",
-		Long:  "show or set a store's rate limit, <type> can be 'add-peer'(default) or 'remove-peer'",
+		Long:  "show or set a store's rate limit, <type> can be 'add-peer'(default), 'remove-peer', or 'transfer-leader-in'",
 		Run:   storeLimitCommandFunc,
 	}
 	return c
@@ -201,7 +202,7 @@ func NewShowStoresCommand() *cobra.Command {
 func NewShowAllStoresLimitCommand() *cobra.Command {
 	sc := &cobra.Command{
 		Use:        "limit <type>",
-		Short:      "show all stores' limit, <type> can be 'add-peer'(default) or 'remove-peer'",
+		Short:      "show all stores' limit, <type> can be 'add-peer'(default), 'remove-peer', or 'transfer-leader-in'",
 		Deprecated: "use store limit instead",
 		Run:        showAllStoresLimitCommandFunc,
 	}
@@ -224,7 +225,7 @@ func NewSetAllLimitCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:        "limit <rate> <type>",
 		Short:      "set all store's rate limit",
-		Long:       "set all store's rate limit, <type> can be 'add-peer'(default) or 'remove-peer'",
+		Long:       "set all store's rate limit, <type> can be 'add-peer'(default), 'remove-peer', or 'transfer-leader-in'",
 		Deprecated: "use store limit all <rate> instead",
 		Run:        setAllLimitCommandFunc,
 	}
@@ -565,7 +566,7 @@ func storeLimitCommandFunc(cmd *cobra.Command, args []string) {
 		var prefix string
 		if args[0] == "all" {
 			prefix = storesLimitPrefix
-			if rate > maxStoreLimit {
+			if rate > maxStoreLimit && rate != storelimit.Unlimited {
 				cmd.Printf("rate should be less than %.1f for all\n", maxStoreLimit)
 				return
 			}
@@ -595,7 +596,7 @@ func storeLimitCommandFunc(cmd *cobra.Command, args []string) {
 				cmd.Println("rate should be a number that > 0.")
 				return
 			}
-			if rate > maxStoreLimit {
+			if rate > maxStoreLimit && rate != storelimit.Unlimited {
 				cmd.Printf("rate should be less than %.1f for all\n", maxStoreLimit)
 				return
 			}

--- a/tools/pd-ctl/tests/store/store_test.go
+++ b/tools/pd-ctl/tests/store/store_test.go
@@ -363,6 +363,13 @@ func (s *storeTestSuite) checkStore(cluster *pdTests.TestCluster) {
 	limit = leaderServer.GetRaftCluster().GetStoreLimitByType(1, storelimit.AddPeer)
 	re.Equal(float64(10), limit)
 
+	// Omitting the type must preserve both custom and default leader limits.
+	defaultLeaderLimit := leaderServer.GetPersistOptions().GetScheduleConfig().DefaultStoreLimit.TransferLeaderIn
+	args = []string{"-u", pdAddr, "store", "limit", "1", "37", "transfer-leader-in"}
+	output, err = tests.ExecuteCommand(cmd, args...)
+	re.NoError(err)
+	re.Contains(string(output), "Success!")
+
 	// store limit all <rate>
 	args = []string{"-u", pdAddr, "store", "limit", "all", "20"}
 	_, err = tests.ExecuteCommand(cmd, args...)
@@ -379,6 +386,8 @@ func (s *storeTestSuite) checkStore(cluster *pdTests.TestCluster) {
 	re.Equal(float64(20), limit1)
 	re.Equal(float64(20), limit2)
 	re.Equal(float64(20), limit3)
+	re.Equal(float64(37), leaderServer.GetRaftCluster().GetStoreLimitByType(1, storelimit.TransferLeaderIn))
+	re.Equal(defaultLeaderLimit, leaderServer.GetPersistOptions().GetScheduleConfig().DefaultStoreLimit.TransferLeaderIn)
 
 	re.NoError(leaderServer.Stop())
 	re.NoError(leaderServer.Run())
@@ -387,6 +396,8 @@ func (s *storeTestSuite) checkStore(cluster *pdTests.TestCluster) {
 	storesLimit := leaderServer.GetPersistOptions().GetAllStoresLimit()
 	re.Equal(float64(20), storesLimit[1].AddPeer)
 	re.Equal(float64(20), storesLimit[1].RemovePeer)
+	re.Equal(float64(37), storesLimit[1].TransferLeaderIn)
+	re.Equal(defaultLeaderLimit, leaderServer.GetPersistOptions().GetScheduleConfig().DefaultStoreLimit.TransferLeaderIn)
 
 	// store limit all <rate> <type>
 	args = []string{"-u", pdAddr, "store", "limit", "all", "25", "remove-peer"}

--- a/tools/pd-ctl/tests/store/store_test.go
+++ b/tools/pd-ctl/tests/store/store_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -95,6 +96,104 @@ func (s *storeTestSuite) checkStoreLimitV2(cluster *pdTests.TestCluster) {
 func (s *storeTestSuite) TestStore() {
 	// TODO: enable this test in microservice mode
 	s.env.RunTestInNonMicroserviceEnv(s.checkStore)
+}
+
+func (s *storeTestSuite) TestTransferLeaderInStoreLimit() {
+	s.env.RunTestInNonMicroserviceEnv(s.checkTransferLeaderInStoreLimit)
+}
+
+func (s *storeTestSuite) checkTransferLeaderInStoreLimit(cluster *pdTests.TestCluster) {
+	re := s.Require()
+	pdAddr := cluster.GetConfig().GetClientURL()
+	leaderServer := cluster.GetLeaderServer()
+	for _, storeID := range []uint64{1, 2} {
+		pdTests.MustPutStore(re, cluster, &metapb.Store{
+			Id:        storeID,
+			State:     metapb.StoreState_Up,
+			NodeState: metapb.NodeState_Serving,
+			Labels:    []*metapb.StoreLabel{{Key: "zone", Value: strconv.FormatUint(storeID, 10)}},
+		})
+	}
+
+	peerLimits := leaderServer.GetRaftCluster().GetScheduleConfig().StoreLimit
+
+	cmd := ctl.GetRootCmd()
+	args := []string{"-u", pdAddr, "store", "limit", "1", "30", "transfer-leader-in"}
+	_, err := tests.ExecuteCommand(cmd, args...)
+	re.NoError(err)
+	re.Equal(float64(30), leaderServer.GetRaftCluster().GetStoreLimitByType(1, storelimit.TransferLeaderIn))
+
+	cmd = ctl.GetRootCmd()
+	args = []string{"-u", pdAddr, "store", "limit", "transfer-leader-in"}
+	output, err := tests.ExecuteCommand(cmd, args...)
+	re.NoError(err)
+	limits := make(map[string]map[string]float64)
+	re.NoError(json.Unmarshal(output, &limits))
+	re.Equal(float64(30), limits["1"]["transfer-leader-in"])
+
+	cmd = ctl.GetRootCmd()
+	args = []string{"-u", pdAddr, "store", "limit", "all", "20", "transfer-leader-in"}
+	_, err = tests.ExecuteCommand(cmd, args...)
+	re.NoError(err)
+	for _, storeID := range []uint64{1, 2} {
+		re.Equal(float64(20), leaderServer.GetRaftCluster().GetStoreLimitByType(storeID, storelimit.TransferLeaderIn))
+	}
+
+	re.NoError(leaderServer.Stop())
+	re.NoError(leaderServer.Run())
+	re.NotEmpty(cluster.WaitLeader())
+	re.Equal(float64(20), leaderServer.GetRaftCluster().GetStoreLimitByType(1, storelimit.TransferLeaderIn))
+
+	cmd = ctl.GetRootCmd()
+	args = []string{"-u", pdAddr, "store", "limit", "1", "0", "transfer-leader-in"}
+	output, err = tests.ExecuteCommand(cmd, args...)
+	re.NoError(err)
+	re.Contains(string(output), "rate should be a number")
+	re.Equal(float64(20), leaderServer.GetRaftCluster().GetStoreLimitByType(1, storelimit.TransferLeaderIn))
+
+	unlimited := strconv.FormatFloat(storelimit.Unlimited, 'f', -1, 64)
+	cmd = ctl.GetRootCmd()
+	args = []string{"-u", pdAddr, "store", "limit", "1", unlimited, "transfer-leader-in"}
+	output, err = tests.ExecuteCommand(cmd, args...)
+	re.NoError(err)
+	re.NotContains(string(output), "rate should")
+	re.Equal(storelimit.Unlimited, leaderServer.GetRaftCluster().GetStoreLimitByType(1, storelimit.TransferLeaderIn))
+
+	cmd = ctl.GetRootCmd()
+	args = []string{"-u", pdAddr, "store", "limit", "all", "0", "transfer-leader-in"}
+	output, err = tests.ExecuteCommand(cmd, args...)
+	re.NoError(err)
+	re.Contains(string(output), "rate should be a number")
+	re.Equal(float64(20), leaderServer.GetRaftCluster().GetStoreLimitByType(2, storelimit.TransferLeaderIn))
+
+	cmd = ctl.GetRootCmd()
+	args = []string{"-u", pdAddr, "store", "limit", "all", "zone", "2", unlimited, "transfer-leader-in"}
+	output, err = tests.ExecuteCommand(cmd, args...)
+	re.NoError(err)
+	re.Contains(string(output), "Success!")
+	re.Equal(storelimit.Unlimited, leaderServer.GetRaftCluster().GetStoreLimitByType(2, storelimit.TransferLeaderIn))
+
+	cmd = ctl.GetRootCmd()
+	args = []string{"-u", pdAddr, "store", "limit", "all", "zone", "2", "25", "transfer-leader-in"}
+	output, err = tests.ExecuteCommand(cmd, args...)
+	re.NoError(err)
+	re.Contains(string(output), "Success!")
+	re.Equal(float64(25), leaderServer.GetRaftCluster().GetStoreLimitByType(2, storelimit.TransferLeaderIn))
+	re.Equal(storelimit.Unlimited, leaderServer.GetRaftCluster().GetStoreLimitByType(1, storelimit.TransferLeaderIn))
+
+	cmd = ctl.GetRootCmd()
+	args = []string{"-u", pdAddr, "store", "limit", "all", unlimited, "transfer-leader-in"}
+	output, err = tests.ExecuteCommand(cmd, args...)
+	re.NoError(err)
+	re.NotContains(string(output), "rate should")
+	re.NoError(leaderServer.Stop())
+	re.NoError(leaderServer.Run())
+	re.NotEmpty(cluster.WaitLeader())
+	for _, storeID := range []uint64{1, 2} {
+		re.Equal(storelimit.Unlimited, leaderServer.GetRaftCluster().GetStoreLimitByType(storeID, storelimit.TransferLeaderIn))
+		re.Equal(peerLimits[storeID].AddPeer, leaderServer.GetRaftCluster().GetStoreLimitByType(storeID, storelimit.AddPeer))
+		re.Equal(peerLimits[storeID].RemovePeer, leaderServer.GetRaftCluster().GetStoreLimitByType(storeID, storelimit.RemovePeer))
+	}
 }
 
 func (s *storeTestSuite) checkStore(cluster *pdTests.TestCluster) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #11196

PD Control help does not list the `transfer-leader-in` store limit added by
#11197, and bulk updates reject the existing `Unlimited` value (100000000)
because it exceeds the CLI's ordinary rate ceiling of 200.

### What is changed and how does it work?

```commit-message
Document transfer-leader-in in store-limit command help, including the
existing deprecated commands. Allow the Unlimited sentinel for all-store
and label-filtered updates while retaining the ceiling for other rates
and existing type parsing.

Cover per-store and all-store configuration, querying, label selection,
zero-rate rejection, preservation of peer limits when setting leader limits,
and preservation of custom and default leader limits when the type is
omitted. Verify finite and Unlimited limits across PD restarts.
```

The server support from #11197 is merged and included in this branch's base.

### Check List

Tests

- Store integration tests: Go 1.25.12; Classic and NextGen passed with
  race/deadlock checks and failpoints enabled.
- `make check` passed using Go 1.25.12.
- Ablation: removing either bulk Unlimited exception or label selection makes
  the integration test fail. Removing the label cases lets the label-specific
  regression escape, confirming that this coverage is necessary. Adding
  transfer-leader-in to the omitted-type defaults also fails the regression
  assertion: the custom leader limit changes from 37 to 20.
- Command-entry comparison: 48 parameter combinations each on the base,
  original change, and final change confirmed rate boundaries and rejection
  of non-finite values before HTTP requests. Existing parsing and JSON
  encoding already provide that validation.

### Release note

```release-note
Support configuring transfer-leader-in store limits with PD Control.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring `transfer-leader-in` rate limits for stores and labels.
  - Added support for unlimited store rates without the standard maximum limit.
  - Updated command help text to document the new rate limit type.

- **Bug Fixes**
  - Improved validation when setting unlimited store rate limits.
  - Preserved configured limits across leader restarts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->