### PR TITLE
server: validate each --join endpoint separately

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -394,8 +394,10 @@ func (c *Config) Adjust(meta *toml.MetaData, reloading bool) error {
 	// server/join, which splits it on ","), so validate it per endpoint rather
 	// than passing the whole list to a single url.Parse, which accepts it as
 	// one malformed URL with a host of "pd-0:2379,http:".
-	if _, err := parseUrls(c.Join); err != nil {
-		return errors.Errorf("failed to parse join addr:%s, err:%v", c.Join, err)
+	if len(c.Join) > 0 {
+		if _, err := parseUrls(c.Join); err != nil {
+			return errors.Errorf("failed to parse join addr:%s, err:%v", c.Join, err)
+		}
 	}
 
 	configutil.AdjustInt(&c.MaxConcurrentTSOProxyStreamings, defaultMaxConcurrentTSOProxyStreamings)

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -391,16 +391,11 @@ func (c *Config) Adjust(meta *toml.MetaData, reloading bool) error {
 	configutil.AdjustString(&c.InitialClusterToken, defaultInitialClusterToken)
 
 	// Join is a comma-separated list of endpoints (see the field comment and
-	// server/join, which splits it on ","), so it must be validated per
-	// endpoint. Handing the whole list to a single url.Parse never validated
-	// the multi-endpoint form: under Go 1.25 semantics it accepted the list as
-	// one malformed URL, with a host of "pd-0:2379,http:". Go 1.26 rejects a
-	// colon in that position, which turned the latent gap into a startup
-	// failure for any PD given multiple --join endpoints.
-	if len(c.Join) > 0 {
-		if _, err := parseUrls(c.Join); err != nil {
-			return errors.Errorf("failed to parse join addr:%s, err:%v", c.Join, err)
-		}
+	// server/join, which splits it on ","), so validate it per endpoint rather
+	// than passing the whole list to a single url.Parse, which accepts it as
+	// one malformed URL with a host of "pd-0:2379,http:".
+	if _, err := parseUrls(c.Join); err != nil {
+		return errors.Errorf("failed to parse join addr:%s, err:%v", c.Join, err)
 	}
 
 	configutil.AdjustInt(&c.MaxConcurrentTSOProxyStreamings, defaultMaxConcurrentTSOProxyStreamings)

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -18,7 +18,6 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -391,8 +390,15 @@ func (c *Config) Adjust(meta *toml.MetaData, reloading bool) error {
 	configutil.AdjustString(&c.InitialClusterState, defaultInitialClusterState)
 	configutil.AdjustString(&c.InitialClusterToken, defaultInitialClusterToken)
 
+	// Join is a comma-separated list of endpoints (see the field comment and
+	// server/join, which splits it on ","), so it must be validated per
+	// endpoint. Handing the whole list to a single url.Parse never validated
+	// the multi-endpoint form: under Go 1.25 semantics it accepted the list as
+	// one malformed URL, with a host of "pd-0:2379,http:". Go 1.26 rejects a
+	// colon in that position, which turned the latent gap into a startup
+	// failure for any PD given multiple --join endpoints.
 	if len(c.Join) > 0 {
-		if _, err := url.Parse(c.Join); err != nil {
+		if _, err := parseUrls(c.Join); err != nil {
 			return errors.Errorf("failed to parse join addr:%s, err:%v", c.Join, err)
 		}
 	}

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -62,6 +62,52 @@ func TestBadFormatJoinAddr(t *testing.T) {
 	re.Error(cfg.Adjust(nil, false))
 }
 
+// TestJoinAddr covers that --join accepts the comma-separated endpoint list it
+// is documented to take, and still rejects a list containing a bad endpoint.
+func TestJoinAddr(t *testing.T) {
+	testCases := []struct {
+		name    string
+		join    string
+		wantErr bool
+	}{
+		{
+			name: "single endpoint",
+			join: "http://127.0.0.1:2379",
+		},
+		{
+			name: "two endpoints",
+			join: "http://127.0.0.1:2379,http://127.0.0.1:2381",
+		},
+		{
+			name: "three endpoints with mixed schemes",
+			join: "http://pd-0.pd-peer:2379,https://pd-1.pd-peer:2379,http://[::1]:2379",
+		},
+		{
+			// The form TiDB Operator generates for PD recovery.
+			name: "peer service endpoints",
+			join: "http://demo-pd-0.demo-pd-peer.demo.svc:2380,http://demo-pd-1.demo-pd-peer.demo.svc:2380",
+		},
+		{
+			name:    "second endpoint has no scheme",
+			join:    "http://127.0.0.1:2379,127.0.0.1:2381",
+			wantErr: true,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			re := require.New(t)
+			cfg := NewConfig()
+			cfg.Join = testCase.join
+			err := cfg.Adjust(nil, false)
+			if testCase.wantErr {
+				re.Error(err)
+				return
+			}
+			re.NoError(err)
+		})
+	}
+}
+
 func TestReloadConfig(t *testing.T) {
 	re := require.New(t)
 	opt, err := newTestScheduleOption()

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -83,7 +83,6 @@ func TestJoinAddr(t *testing.T) {
 			join: "http://pd-0.pd-peer:2379,https://pd-1.pd-peer:2379,http://[::1]:2379",
 		},
 		{
-			// The form TiDB Operator generates for PD recovery.
 			name: "peer service endpoints",
 			join: "http://demo-pd-0.demo-pd-peer.demo.svc:2380,http://demo-pd-1.demo-pd-peer.demo.svc:2380",
 		},


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #11202

`--join` takes a comma-separated list of endpoints, but configuration validation passed the whole list to a single `url.Parse` call, so it never validated the multi-endpoint form. Under Go 1.25 semantics that call accepted the list as one malformed URL — for `http://pd-0:2379,http://pd-1:2379` it returned no error and a host of `pd-0:2379,http:`. Go 1.26 rejects a colon in that position, so once the main module's `go` directive selects the new default (#11194), any PD configured with multiple `--join` endpoints fails to start:

```text
failed to parse join addr:http://pd-0:2379,http://pd-1:2379,
err:parse "http://pd-0:2379,http://pd-1:2379":
invalid port ":2379,http:" after host
```

This is a documented and commonly generated configuration: the PD configuration docs state that "multiply advertise client urls are separated by comma", and TiDB Operator's PD recovery workflow generates `--join=http://demo-pd-0.demo-pd-peer.demo.svc:2380,http://demo-pd-1.demo-pd-peer.demo.svc:2380`.

### What is changed and how does it work?

```commit-message
Validate the join configuration with the existing parseUrls helper, which
splits the value on "," and parses each endpoint, instead of passing the whole
comma-separated list to a single url.Parse call. This matches how peer-urls and
client-urls are already validated, and how server/join consumes the value via
strings.Split(cfg.Join, ",").

Each endpoint is now checked on its own, so a malformed endpoint anywhere in
the list is reported instead of being hidden by a whole-list parse. As a
result, a list whose second or later endpoint omits the scheme, such as
"http://127.0.0.1:2379,127.0.0.1:2381", is now rejected at startup; the same
value in the first position was already rejected before this change.
```

### Check List

Tests

- Unit test

Side effects

- Breaking backward compatibility

  Narrowly: a `--join` list whose second or later endpoint omits the URL scheme was silently accepted before and is now rejected during configuration validation. Such a value was never valid per the documented contract, and PD already rejected it in the first position, so this makes validation consistent rather than newly strict. On top of #11194 the same value fails anyway.

Related changes

- Need to cherry-pick to the release branch: TBD

  Released 8.5.x is built with a `go 1.25.x` directive and retains the compatibility behavior, so it does not hit the startup failure. Leaving the backport decision to maintainers.

### Release note

```release-note
Fix the validation of `--join` so that each endpoint in a comma-separated list is parsed individually. Previously the entire list was parsed as a single URL, which accepted malformed endpoints and prevented PD from starting under Go 1.26 URL parsing semantics.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for comma-separated join endpoints.
  - Join configurations now support single or multiple endpoints, including mixed URL schemes and TiDB Operator peer-service endpoints.
  - Invalid endpoints without a URL scheme are rejected, including entries within a comma-separated list.
  - Empty join values continue to be handled safely during configuration validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->