### PR TITLE
statistics: stop publishing tombstone store metrics in 7.5

### DIFF
--- a/pkg/mcs/scheduling/server/meta/watcher.go
+++ b/pkg/mcs/scheduling/server/meta/watcher.go
@@ -16,6 +16,7 @@ package meta
 
 import (
 	"context"
+	"strconv"
 	"sync"
 
 	"github.com/gogo/protobuf/proto"
@@ -95,7 +96,7 @@ func (w *Watcher) initializeStoreWatcher() error {
 		if origin != nil {
 			w.basicCluster.DeleteStore(origin)
 			// Let concurrent collectors detect the deletion before cleaning up metrics.
-			statistics.DeleteClusterStatusMetrics(origin)
+			statistics.ResetStoreStatistics(origin.GetAddress(), strconv.FormatUint(storeID, 10))
 		}
 		return nil
 	}

--- a/pkg/statistics/metrics_test.go
+++ b/pkg/statistics/metrics_test.go
@@ -94,9 +94,51 @@ func TestObserveStoresAfterDeletion(t *testing.T) {
 			otherID := strconv.FormatUint(other.GetID(), 10)
 			re.False(clusterStatusGauge.DeleteLabelValues(clusterStatusStoreTombstoneCount, id))
 			re.False(clusterStatusGauge.DeleteLabelValues(clusterStatusStorageSize, id))
-			// A tombstone that is still in the cluster must retain its metrics.
+			// A known tombstone retains state metrics, but not storage metrics.
 			re.True(clusterStatusGauge.DeleteLabelValues(clusterStatusStoreTombstoneCount, otherID))
-			re.True(clusterStatusGauge.DeleteLabelValues(clusterStatusStorageSize, otherID))
+			re.False(clusterStatusGauge.DeleteLabelValues(clusterStatusStorageSize, otherID))
 		})
 	}
+}
+
+func TestTombstoneStoreMetricsLifecycle(t *testing.T) {
+	re := require.New(t)
+	store := core.NewStoreInfo(&metapb.Store{Id: 9876543220, Address: "old-address"})
+	id := strconv.FormatUint(store.GetID(), 10)
+	t.Cleanup(func() { ResetStoreStatistics(store.GetAddress(), id) })
+	stats := NewStoresStats()
+	stats.GetOrCreateRollingStoreStats(store.GetID())
+	m := NewStoreStatisticsMap(mockconfig.NewTestOptions())
+	m.Observe(store)
+	m.ObserveHotStat(store, stats)
+	re.True(storeStatusGauge.DeleteLabelValues(store.GetAddress(), id, "region_size"))
+	re.True(storeStatusGauge.DeleteLabelValues(store.GetAddress(), id, "store_cpu_usage"))
+	// Bury-time cleanup must also remove instant/disk metrics and old addresses.
+	ResetStoreStatistics("new-address", id)
+	tombstone := store.Clone(core.SetStoreState(metapb.StoreState_Tombstone))
+	m.Observe(tombstone)
+	m.ObserveHotStat(tombstone, stats)
+	re.Zero(storeStatusGauge.DeletePartialMatch(map[string]string{"store": id}))
+	re.True(clusterStatusGauge.DeleteLabelValues(clusterStatusStoreTombstoneCount, id))
+	re.True(clusterStatusGauge.DeleteLabelValues(clusterStatusStoreRemovedCount, id))
+	re.False(clusterStatusGauge.DeleteLabelValues(clusterStatusStorageSize, id))
+}
+
+func TestObserveStoresCleansDeletedStoreSnapshot(t *testing.T) {
+	re := require.New(t)
+	cluster := core.NewBasicCluster()
+	store := core.NewStoreInfo(&metapb.Store{Id: 9876543230, Address: "store-address"})
+	id := strconv.FormatUint(store.GetID(), 10)
+	cluster.PutStore(store)
+	stats := NewStoresStats()
+	stats.GetOrCreateRollingStoreStats(store.GetID())
+	t.Cleanup(func() { ResetStoreStatistics(store.GetAddress(), id) })
+	opt := &storeMetricsTestConfig{ConfProvider: mockconfig.NewTestOptions()}
+	opt.beforeObserve = func() {
+		cluster.DeleteStore(store)
+		ResetStoreStatistics(store.GetAddress(), id)
+	}
+	NewStoreStatisticsMap(opt).ObserveStores(cluster, stats)
+	re.Zero(storeStatusGauge.DeletePartialMatch(map[string]string{"store": id}))
+	re.Zero(clusterStatusGauge.DeletePartialMatch(map[string]string{"store": id}))
 }

--- a/pkg/statistics/store_collection.go
+++ b/pkg/statistics/store_collection.go
@@ -133,6 +133,9 @@ func (s *storeStatistics) Observe(store *core.StoreInfo) {
 	for statusType, value := range storeStatusStats {
 		clusterStatusGauge.WithLabelValues(statusType, id).Set(value)
 	}
+	if store.GetNodeState() == metapb.NodeState_Removed {
+		return
+	}
 
 	// Store stats.
 	clusterStatusGauge.WithLabelValues(clusterStatusStorageSize, id).Set(float64(store.StorageSize()))
@@ -173,6 +176,9 @@ func (s *storeStatistics) Observe(store *core.StoreInfo) {
 }
 
 func (s *storeStatistics) ObserveHotStat(store *core.StoreInfo, stats *StoresStats) {
+	if store.GetNodeState() == metapb.NodeState_Removed {
+		return
+	}
 	// Store flows.
 	storeAddress := store.GetAddress()
 	id := strconv.FormatUint(store.GetID(), 10)
@@ -263,34 +269,8 @@ func (s *storeStatistics) Collect() {
 
 // ResetStoreStatistics resets the metrics of store.
 func ResetStoreStatistics(storeAddress string, id string) {
-	metrics := []string{
-		"region_score",
-		"leader_score",
-		"region_size",
-		"region_count",
-		"leader_size",
-		"leader_count",
-		"witness_count",
-		"learner_count",
-		"store_available",
-		"store_used",
-		"store_capacity",
-		"store_write_rate_bytes",
-		"store_read_rate_bytes",
-		"store_write_rate_keys",
-		"store_read_rate_keys",
-		"store_write_query_rate",
-		"store_read_query_rate",
-		"store_regions_write_rate_bytes",
-		"store_regions_write_rate_keys",
-		"store_slow_trend_cause_value",
-		"store_slow_trend_cause_rate",
-		"store_slow_trend_result_value",
-		"store_slow_trend_result_rate",
-	}
-	for _, m := range metrics {
-		storeStatusGauge.DeleteLabelValues(storeAddress, id, m)
-	}
+	// Match the stable store ID, including series recorded under an old address.
+	storeStatusGauge.DeletePartialMatch(utils.SingleLabel("store", id))
 	clusterStatusGauge.DeletePartialMatch(utils.SingleLabel("store", id))
 }
 
@@ -323,7 +303,7 @@ func (m *storeStatisticsMap) ObserveStores(cluster *core.BasicCluster, stats *St
 		// A stale snapshot can recreate metrics after the deletion path cleaned
 		// them up. Check after writing; deletion must remove the store first.
 		if cluster.GetStore(store.GetID()) == nil {
-			DeleteClusterStatusMetrics(store)
+			ResetStoreStatistics(store.GetAddress(), strconv.FormatUint(store.GetID(), 10))
 		}
 	}
 }

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -2172,7 +2172,7 @@ func (c *RaftCluster) deleteStore(store *core.StoreInfo) error {
 	}
 	c.core.DeleteStore(store)
 	// Let concurrent collectors detect the deletion before cleaning up metrics.
-	statistics.DeleteClusterStatusMetrics(store)
+	statistics.ResetStoreStatistics(store.GetAddress(), strconv.FormatUint(store.GetID(), 10))
 	return nil
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #11206, ref #9855, ref #9942

#10060 moved tombstone state handling from `Observe` into `observeStoreStatus` without preserving the outer early return. Unlike v7.5.7, release-7.5 now republishes `pd_scheduler_store_status` for tombstone stores after bury-time cleanup. #10188 clears `pd_cluster_status` at final deletion, but leaves the republished scheduler metrics behind.

The v7.5.8 scale-in tests expose this in the subsequent region balance checks:
- https://tcms.pingcap.net/dashboard/executions/plan/8231253: removed store 201502 remains in the region-size query.
- https://tcms.pingcap.net/dashboard/executions/plan/8183340: tombstone count reaches zero after remove-tombstone, but scheduler metrics remain in the region-score query.

### What is changed and how does it work?

```commit-message
Restore the tombstone early return after publishing cluster state metrics,
and skip hot-stat publication for removed stores.

Clear scheduler store metrics by store ID rather than a hand-maintained
list of types and a potentially outdated address. This also covers CPU,
disk, instant-rate and window metrics in the same metric family.

Use the complete statistics cleanup at final deletion in classic PD and
the scheduling watcher, preserving delete-before-cleanup ordering. Extend
the existing post-observation deletion check to clean scheduler metrics
recreated by stale snapshots as well as cluster status metrics.
```

This is a targeted release-7.5 fix. It does not backport the broader hotcache/filter/heartbeat cleanup from #11127.

### Check List

Tests

- Unit test: tombstone observation preserves state metrics without republishing scheduler or storage metrics, including when rolling statistics still exist.
- Unit test: cleanup covers all scheduler types and old addresses; stale snapshots cannot leave metrics after final deletion.
- Passed: `go test ./pkg/statistics ./pkg/mcs/scheduling/server/meta -count=1`.
- Passed with failpoints enabled: `go test ./pkg/statistics ./pkg/mcs/scheduling/server/meta ./server/cluster -run 'Test.*(Store|Tomb|Bury)' -count=1 -timeout=120s`.
- Passed: `git diff --check` and gofmt.
- `make check` is blocked during tool installation: the branch's `golang.org/x/tools/internal/tokeninternal` fails to compile with the local Go toolchain (`invalid array length -delta * delta`).
- TCMS scale-in validation is pending and will be performed separately.

### Release note

```release-note
Fix stale scheduler store metrics after TiKV scale-in in v7.5.8 that could cause region balance monitoring to include tombstone stores.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected metrics cleanup when stores are deleted or tombstoned.
  - Removed stale store status, flow, storage-size, and address metrics after store removal.
  - Prevented deleted or tombstoned stores from continuing to report store-level metrics.
  - Preserved tombstone count metrics while clearing obsolete storage metrics.
  - Improved cleanup for stores removed during monitoring snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->