### PR TITLE
pd-ctl: keyspace-group support set show keyspaces 

### DIFF
--- a/tools/pd-ctl/pdctl/command/keyspace_group_command.go
+++ b/tools/pd-ctl/pdctl/command/keyspace_group_command.go
@@ -28,7 +28,10 @@ import (
 	"github.com/tikv/pd/pkg/storage/endpoint"
 )
 
-const keyspaceGroupsPrefix = "pd/api/v2/tso/keyspace-groups"
+const (
+	keyspaceGroupsPrefix = "pd/api/v2/tso/keyspace-groups"
+	flagShowKGKeyspaces  = "show-keyspaces"
+)
 
 // NewKeyspaceGroupCommand return a keyspace group subcommand of rootCmd
 func NewKeyspaceGroupCommand() *cobra.Command {
@@ -46,6 +49,7 @@ func NewKeyspaceGroupCommand() *cobra.Command {
 	cmd.AddCommand(newSetPriorityKeyspaceGroupCommand())
 	cmd.AddCommand(newShowKeyspaceGroupPrimaryCommand())
 	cmd.Flags().String("state", "", "state filter")
+	cmd.Flags().Bool(flagShowKGKeyspaces, false, "show keyspace list in keyspace group output")
 	return cmd
 }
 
@@ -130,16 +134,25 @@ func showKeyspaceGroupsCommandFunc(cmd *cobra.Command, args []string) {
 		cmd.Usage()
 		return
 	}
-	cFunc := convertToKeyspaceGroups
+	flags := cmd.Flags()
+	showKeyspaces, err := flags.GetBool(flagShowKGKeyspaces)
+	if err != nil {
+		cmd.Printf("Failed to get %s: %s\n", flagShowKGKeyspaces, err)
+		return
+	}
+	cFunc := func(content string) string {
+		return convertToKeyspaceGroups(content, showKeyspaces)
+	}
 	if len(args) == 1 {
 		if _, err := strconv.Atoi(args[0]); err != nil {
 			cmd.Println("keyspace_group_id should be a number")
 			return
 		}
 		prefix = fmt.Sprintf("%s/%s", keyspaceGroupsPrefix, args[0])
-		cFunc = convertToKeyspaceGroup
+		cFunc = func(content string) string {
+			return convertToKeyspaceGroup(content, showKeyspaces)
+		}
 	} else {
-		flags := cmd.Flags()
 		state, err := flags.GetString("state")
 		if err != nil {
 			cmd.Printf("Failed to get state: %s\n", err)
@@ -393,26 +406,56 @@ func showKeyspaceGroupPrimaryCommandFunc(cmd *cobra.Command, args []string) {
 	cmd.Println(r)
 }
 
-func convertToKeyspaceGroup(content string) string {
+type keyspaceGroupOutput struct {
+	ID         uint32                         `json:"id"`
+	UserKind   string                         `json:"user-kind"`
+	SplitState *endpoint.SplitState           `json:"split-state,omitempty"`
+	MergeState *endpoint.MergeState           `json:"merge-state,omitempty"`
+	Members    []endpoint.KeyspaceGroupMember `json:"members"`
+	Keyspaces  *[]uint32                      `json:"keyspaces,omitempty"`
+}
+
+func newKeyspaceGroupOutput(kg *endpoint.KeyspaceGroup, showKeyspaces bool) *keyspaceGroupOutput {
+	if kg == nil {
+		return nil
+	}
+	output := &keyspaceGroupOutput{
+		ID:         kg.ID,
+		UserKind:   kg.UserKind,
+		SplitState: kg.SplitState,
+		MergeState: kg.MergeState,
+		Members:    kg.Members,
+	}
+	if showKeyspaces {
+		output.Keyspaces = &kg.Keyspaces
+	}
+	return output
+}
+
+func convertToKeyspaceGroup(content string, showKeyspaces bool) string {
 	kg := endpoint.KeyspaceGroup{}
 	err := json.Unmarshal([]byte(content), &kg)
 	if err != nil {
 		return content
 	}
-	byteArr, err := json.MarshalIndent(kg, "", "  ")
+	byteArr, err := json.MarshalIndent(newKeyspaceGroupOutput(&kg, showKeyspaces), "", "  ")
 	if err != nil {
 		return content
 	}
 	return string(byteArr)
 }
 
-func convertToKeyspaceGroups(content string) string {
+func convertToKeyspaceGroups(content string, showKeyspaces bool) string {
 	kgs := []*endpoint.KeyspaceGroup{}
 	err := json.Unmarshal([]byte(content), &kgs)
 	if err != nil {
 		return content
 	}
-	byteArr, err := json.MarshalIndent(kgs, "", "  ")
+	output := make([]*keyspaceGroupOutput, 0, len(kgs))
+	for _, kg := range kgs {
+		output = append(output, newKeyspaceGroupOutput(kg, showKeyspaces))
+	}
+	byteArr, err := json.MarshalIndent(output, "", "  ")
 	if err != nil {
 		return content
 	}

--- a/tools/pd-ctl/pdctl/command/keyspace_group_command.go
+++ b/tools/pd-ctl/pdctl/command/keyspace_group_command.go
@@ -49,7 +49,7 @@ func NewKeyspaceGroupCommand() *cobra.Command {
 	cmd.AddCommand(newSetPriorityKeyspaceGroupCommand())
 	cmd.AddCommand(newShowKeyspaceGroupPrimaryCommand())
 	cmd.Flags().String("state", "", "state filter")
-	cmd.Flags().Bool(flagShowKGKeyspaces, false, "show keyspace list in keyspace group output")
+	cmd.Flags().Bool(flagShowKGKeyspaces, true, "show keyspace list in keyspace group output")
 	return cmd
 }
 

--- a/tools/pd-ctl/pdctl/command/keyspace_group_command.go
+++ b/tools/pd-ctl/pdctl/command/keyspace_group_command.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	keyspaceGroupsPrefix = "pd/api/v2/tso/keyspace-groups"
-	flagShowKGKeyspaces  = "show-keyspaces"
+	flagHideKGKeyspaces  = "hide-keyspaces"
 )
 
 // NewKeyspaceGroupCommand return a keyspace group subcommand of rootCmd
@@ -49,7 +49,7 @@ func NewKeyspaceGroupCommand() *cobra.Command {
 	cmd.AddCommand(newSetPriorityKeyspaceGroupCommand())
 	cmd.AddCommand(newShowKeyspaceGroupPrimaryCommand())
 	cmd.Flags().String("state", "", "state filter")
-	cmd.Flags().Bool(flagShowKGKeyspaces, true, "show keyspace list in keyspace group output")
+	cmd.Flags().Bool(flagHideKGKeyspaces, false, "hide keyspace list in keyspace group output")
 	return cmd
 }
 
@@ -135,13 +135,13 @@ func showKeyspaceGroupsCommandFunc(cmd *cobra.Command, args []string) {
 		return
 	}
 	flags := cmd.Flags()
-	showKeyspaces, err := flags.GetBool(flagShowKGKeyspaces)
+	hideKeyspaces, err := flags.GetBool(flagHideKGKeyspaces)
 	if err != nil {
-		cmd.Printf("Failed to get %s: %s\n", flagShowKGKeyspaces, err)
+		cmd.Printf("Failed to get %s: %s\n", flagHideKGKeyspaces, err)
 		return
 	}
 	cFunc := func(content string) string {
-		return convertToKeyspaceGroups(content, showKeyspaces)
+		return convertToKeyspaceGroups(content, !hideKeyspaces)
 	}
 	if len(args) == 1 {
 		if _, err := strconv.Atoi(args[0]); err != nil {
@@ -150,7 +150,7 @@ func showKeyspaceGroupsCommandFunc(cmd *cobra.Command, args []string) {
 		}
 		prefix = fmt.Sprintf("%s/%s", keyspaceGroupsPrefix, args[0])
 		cFunc = func(content string) string {
-			return convertToKeyspaceGroup(content, showKeyspaces)
+			return convertToKeyspaceGroup(content, !hideKeyspaces)
 		}
 	} else {
 		state, err := flags.GetString("state")

--- a/tools/pd-ctl/pdctl/command/keyspace_group_command_test.go
+++ b/tools/pd-ctl/pdctl/command/keyspace_group_command_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertToKeyspaceGroupHidesKeyspacesByDefault(t *testing.T) {
+	re := require.New(t)
+	content := `{"id":1,"user-kind":"basic","members":[{"address":"http://127.0.0.1:3379","priority":0}],"keyspaces":[1,2,3]}`
+
+	output := convertToKeyspaceGroup(content, false)
+	re.NotContains(output, "\"keyspaces\"")
+	reJSONHasNoKeyspaces(re, output)
+
+	output = convertToKeyspaceGroup(content, true)
+	re.Contains(output, "\"keyspaces\"")
+	reJSONHasKeyspaces(re, output, []any{float64(1), float64(2), float64(3)})
+}
+
+func TestConvertToKeyspaceGroupsHidesKeyspacesByDefault(t *testing.T) {
+	re := require.New(t)
+	content := `[{"id":1,"user-kind":"basic","members":[],"keyspaces":[1,2,3]},{"id":2,"user-kind":"standard","members":[],"keyspaces":[]}]`
+
+	output := convertToKeyspaceGroups(content, false)
+	re.NotContains(output, "\"keyspaces\"")
+	var groups []map[string]any
+	re.NoError(json.Unmarshal([]byte(output), &groups))
+	re.Len(groups, 2)
+	for _, group := range groups {
+		_, ok := group["keyspaces"]
+		re.False(ok)
+	}
+
+	output = convertToKeyspaceGroups(content, true)
+	re.Contains(output, "\"keyspaces\"")
+	re.NoError(json.Unmarshal([]byte(output), &groups))
+	re.Equal([]any{float64(1), float64(2), float64(3)}, groups[0]["keyspaces"])
+	re.Equal([]any{}, groups[1]["keyspaces"])
+}
+
+func reJSONHasNoKeyspaces(re *require.Assertions, output string) {
+	var group map[string]any
+	re.NoError(json.Unmarshal([]byte(output), &group))
+	_, ok := group["keyspaces"]
+	re.False(ok)
+}
+
+func reJSONHasKeyspaces(re *require.Assertions, output string, expected []any) {
+	var group map[string]any
+	re.NoError(json.Unmarshal([]byte(output), &group))
+	re.Equal(expected, group["keyspaces"])
+}

--- a/tools/pd-ctl/pdctl/command/keyspace_group_command_test.go
+++ b/tools/pd-ctl/pdctl/command/keyspace_group_command_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestConvertToKeyspaceGroupHidesKeyspacesByDefault(t *testing.T) {
+func TestConvertToKeyspaceGroup(t *testing.T) {
 	re := require.New(t)
 	content := `{"id":1,"user-kind":"basic","members":[{"address":"http://127.0.0.1:3379","priority":0}],"keyspaces":[1,2,3]}`
 
@@ -34,7 +34,7 @@ func TestConvertToKeyspaceGroupHidesKeyspacesByDefault(t *testing.T) {
 	reJSONHasKeyspaces(re, output, []any{float64(1), float64(2), float64(3)})
 }
 
-func TestConvertToKeyspaceGroupsHidesKeyspacesByDefault(t *testing.T) {
+func TestConvertToKeyspaceGroups(t *testing.T) {
 	re := require.New(t)
 	content := `[{"id":1,"user-kind":"basic","members":[],"keyspaces":[1,2,3]},{"id":2,"user-kind":"standard","members":[],"keyspaces":[]}]`
 
@@ -53,6 +53,13 @@ func TestConvertToKeyspaceGroupsHidesKeyspacesByDefault(t *testing.T) {
 	re.NoError(json.Unmarshal([]byte(output), &groups))
 	re.Equal([]any{float64(1), float64(2), float64(3)}, groups[0]["keyspaces"])
 	re.Equal([]any{}, groups[1]["keyspaces"])
+}
+
+func TestNewKeyspaceGroupCommandShowsKeyspacesByDefault(t *testing.T) {
+	re := require.New(t)
+	flag := NewKeyspaceGroupCommand().Flags().Lookup(flagShowKGKeyspaces)
+	re.NotNil(flag)
+	re.Equal("true", flag.DefValue)
 }
 
 func reJSONHasNoKeyspaces(re *require.Assertions, output string) {

--- a/tools/pd-ctl/pdctl/command/keyspace_group_command_test.go
+++ b/tools/pd-ctl/pdctl/command/keyspace_group_command_test.go
@@ -55,11 +55,11 @@ func TestConvertToKeyspaceGroups(t *testing.T) {
 	re.Equal([]any{}, groups[1]["keyspaces"])
 }
 
-func TestNewKeyspaceGroupCommandShowsKeyspacesByDefault(t *testing.T) {
+func TestNewKeyspaceGroupCommandDoesNotHideKeyspacesByDefault(t *testing.T) {
 	re := require.New(t)
-	flag := NewKeyspaceGroupCommand().Flags().Lookup(flagShowKGKeyspaces)
+	flag := NewKeyspaceGroupCommand().Flags().Lookup(flagHideKGKeyspaces)
 	re.NotNil(flag)
-	re.Equal("true", flag.DefValue)
+	re.Equal("false", flag.DefValue)
 }
 
 func reJSONHasNoKeyspaces(re *require.Assertions, output string) {

--- a/tools/pd-ctl/tests/keyspace/keyspace_group_test.go
+++ b/tools/pd-ctl/tests/keyspace/keyspace_group_test.go
@@ -57,6 +57,35 @@ func TestKeyspaceGroupTestsuite(t *testing.T) {
 	suite.Run(t, new(keyspaceGroupTestSuite))
 }
 
+func (suite *keyspaceGroupTestSuite) TestShowKeyspaceGroupHidesKeyspacesByDefault() {
+	re := suite.Require()
+	cmd := ctl.GetRootCmd()
+	defaultKeyspaceGroupID := strconv.FormatUint(uint64(constant.DefaultKeyspaceGroupID), 10)
+	args := []string{"-u", suite.pdAddr, "keyspace-group"}
+
+	output, err := tests.ExecuteCommand(cmd, append(args, defaultKeyspaceGroupID)...)
+	re.NoError(err)
+	re.NotContains(string(output), "\"keyspaces\"")
+	var raw map[string]any
+	re.NoError(json.Unmarshal(output, &raw))
+	_, ok := raw["keyspaces"]
+	re.False(ok)
+	var keyspaceGroup endpoint.KeyspaceGroup
+	re.NoError(json.Unmarshal(output, &keyspaceGroup))
+	re.Equal(constant.DefaultKeyspaceGroupID, keyspaceGroup.ID)
+
+	argsWithKeyspaces := []string{"-u", suite.pdAddr, "keyspace-group", "--show-keyspaces"}
+	testutil.Eventually(re, func() bool {
+		output, err = tests.ExecuteCommand(cmd, append(argsWithKeyspaces, defaultKeyspaceGroupID)...)
+		re.NoError(err)
+		re.Contains(string(output), "\"keyspaces\"")
+		keyspaceGroup = endpoint.KeyspaceGroup{}
+		err = json.Unmarshal(output, &keyspaceGroup)
+		re.NoError(err)
+		return slices.Contains(keyspaceGroup.Keyspaces, constant.DefaultKeyspaceID)
+	})
+}
+
 func (suite *keyspaceGroupTestSuite) SetupTest() {
 	re := suite.Require()
 	suite.ctx, suite.cancel = context.WithCancel(context.Background())
@@ -138,7 +167,7 @@ func (suite *keyspaceGroupTestSuite) TestExternalAllocNodeWhenStart() {
 	cmd := ctl.GetRootCmd()
 	// check keyspace group information.
 	defaultKeyspaceGroupID := strconv.FormatUint(uint64(constant.DefaultKeyspaceGroupID), 10)
-	args := []string{"-u", suite.pdAddr, "keyspace-group"}
+	args := []string{"-u", suite.pdAddr, "keyspace-group", "--show-keyspaces"}
 	testutil.Eventually(re, func() bool {
 		output, err := tests.ExecuteCommand(cmd, append(args, defaultKeyspaceGroupID)...)
 		re.NoError(err)
@@ -267,7 +296,7 @@ func (suite *keyspaceGroupTestSuite) TestMergeKeyspaceGroup() {
 	output, err = tests.ExecuteCommand(cmd, args...)
 	re.NoError(err)
 	strings.Contains(string(output), "Success")
-	args = []string{"-u", suite.pdAddr, "keyspace-group", defaultKeyspaceGroupID}
+	args = []string{"-u", suite.pdAddr, "keyspace-group", "--show-keyspaces", defaultKeyspaceGroupID}
 	output, err = tests.ExecuteCommand(cmd, args...)
 	re.NoError(err)
 	var keyspaceGroup endpoint.KeyspaceGroup
@@ -303,7 +332,7 @@ func (suite *keyspaceGroupTestSuite) TestMergeKeyspaceGroup() {
 	output, err = tests.ExecuteCommand(cmd, args...)
 	re.NoError(err)
 	strings.Contains(string(output), "Success")
-	args = []string{"-u", suite.pdAddr, "keyspace-group", defaultKeyspaceGroupID}
+	args = []string{"-u", suite.pdAddr, "keyspace-group", "--show-keyspaces", defaultKeyspaceGroupID}
 	output, err = tests.ExecuteCommand(cmd, args...)
 	re.NoError(err)
 	err = json.Unmarshal(output, &keyspaceGroup)
@@ -530,7 +559,7 @@ func (suite *keyspaceGroupTestSuite) checkKeyspaceContains(keyspaceGroupID uint3
 	re := suite.Require()
 	cmd := ctl.GetRootCmd()
 	keyspaceGroupIDStr := strconv.FormatUint(uint64(keyspaceGroupID), 10)
-	args := []string{"-u", suite.pdAddr, "keyspace-group"}
+	args := []string{"-u", suite.pdAddr, "keyspace-group", "--show-keyspaces"}
 
 	// Manager may not initialize when the server starts, so we need to wait for it.
 	testutil.Eventually(re, func() bool {

--- a/tools/pd-ctl/tests/keyspace/keyspace_group_test.go
+++ b/tools/pd-ctl/tests/keyspace/keyspace_group_test.go
@@ -57,33 +57,29 @@ func TestKeyspaceGroupTestsuite(t *testing.T) {
 	suite.Run(t, new(keyspaceGroupTestSuite))
 }
 
-func (suite *keyspaceGroupTestSuite) TestShowKeyspaceGroupHidesKeyspacesByDefault() {
+func (suite *keyspaceGroupTestSuite) TestShowKeyspaceGroupShowsKeyspacesByDefault() {
 	re := suite.Require()
 	cmd := ctl.GetRootCmd()
 	defaultKeyspaceGroupID := strconv.FormatUint(uint64(constant.DefaultKeyspaceGroupID), 10)
 	args := []string{"-u", suite.pdAddr, "keyspace-group"}
 
-	output, err := tests.ExecuteCommand(cmd, append(args, defaultKeyspaceGroupID)...)
+	testutil.Eventually(re, func() bool {
+		output, err := tests.ExecuteCommand(cmd, append(args, defaultKeyspaceGroupID)...)
+		re.NoError(err)
+		re.Contains(string(output), "\"keyspaces\"")
+		var keyspaceGroup endpoint.KeyspaceGroup
+		err = json.Unmarshal(output, &keyspaceGroup)
+		re.NoError(err)
+		return slices.Contains(keyspaceGroup.Keyspaces, constant.DefaultKeyspaceID)
+	})
+
+	output, err := tests.ExecuteCommand(cmd, "-u", suite.pdAddr, "keyspace-group", "--show-keyspaces=false", defaultKeyspaceGroupID)
 	re.NoError(err)
 	re.NotContains(string(output), "\"keyspaces\"")
 	var raw map[string]any
 	re.NoError(json.Unmarshal(output, &raw))
 	_, ok := raw["keyspaces"]
 	re.False(ok)
-	var keyspaceGroup endpoint.KeyspaceGroup
-	re.NoError(json.Unmarshal(output, &keyspaceGroup))
-	re.Equal(constant.DefaultKeyspaceGroupID, keyspaceGroup.ID)
-
-	argsWithKeyspaces := []string{"-u", suite.pdAddr, "keyspace-group", "--show-keyspaces"}
-	testutil.Eventually(re, func() bool {
-		output, err = tests.ExecuteCommand(cmd, append(argsWithKeyspaces, defaultKeyspaceGroupID)...)
-		re.NoError(err)
-		re.Contains(string(output), "\"keyspaces\"")
-		keyspaceGroup = endpoint.KeyspaceGroup{}
-		err = json.Unmarshal(output, &keyspaceGroup)
-		re.NoError(err)
-		return slices.Contains(keyspaceGroup.Keyspaces, constant.DefaultKeyspaceID)
-	})
 }
 
 func (suite *keyspaceGroupTestSuite) SetupTest() {

--- a/tools/pd-ctl/tests/keyspace/keyspace_group_test.go
+++ b/tools/pd-ctl/tests/keyspace/keyspace_group_test.go
@@ -65,15 +65,20 @@ func (suite *keyspaceGroupTestSuite) TestShowKeyspaceGroupShowsKeyspacesByDefaul
 
 	testutil.Eventually(re, func() bool {
 		output, err := tests.ExecuteCommand(cmd, append(args, defaultKeyspaceGroupID)...)
-		re.NoError(err)
-		re.Contains(string(output), "\"keyspaces\"")
+		if err != nil {
+			return false
+		}
 		var keyspaceGroup endpoint.KeyspaceGroup
-		err = json.Unmarshal(output, &keyspaceGroup)
-		re.NoError(err)
+		if err := json.Unmarshal(output, &keyspaceGroup); err != nil {
+			return false
+		}
+		if keyspaceGroup.ID != constant.DefaultKeyspaceGroupID {
+			return false
+		}
 		return slices.Contains(keyspaceGroup.Keyspaces, constant.DefaultKeyspaceID)
 	})
 
-	output, err := tests.ExecuteCommand(cmd, "-u", suite.pdAddr, "keyspace-group", "--show-keyspaces=false", defaultKeyspaceGroupID)
+	output, err := tests.ExecuteCommand(cmd, "-u", suite.pdAddr, "keyspace-group", "--hide-keyspaces", defaultKeyspaceGroupID)
 	re.NoError(err)
 	re.NotContains(string(output), "\"keyspaces\"")
 	var raw map[string]any
@@ -163,7 +168,7 @@ func (suite *keyspaceGroupTestSuite) TestExternalAllocNodeWhenStart() {
 	cmd := ctl.GetRootCmd()
 	// check keyspace group information.
 	defaultKeyspaceGroupID := strconv.FormatUint(uint64(constant.DefaultKeyspaceGroupID), 10)
-	args := []string{"-u", suite.pdAddr, "keyspace-group", "--show-keyspaces"}
+	args := []string{"-u", suite.pdAddr, "keyspace-group"}
 	testutil.Eventually(re, func() bool {
 		output, err := tests.ExecuteCommand(cmd, append(args, defaultKeyspaceGroupID)...)
 		re.NoError(err)
@@ -292,7 +297,7 @@ func (suite *keyspaceGroupTestSuite) TestMergeKeyspaceGroup() {
 	output, err = tests.ExecuteCommand(cmd, args...)
 	re.NoError(err)
 	strings.Contains(string(output), "Success")
-	args = []string{"-u", suite.pdAddr, "keyspace-group", "--show-keyspaces", defaultKeyspaceGroupID}
+	args = []string{"-u", suite.pdAddr, "keyspace-group", defaultKeyspaceGroupID}
 	output, err = tests.ExecuteCommand(cmd, args...)
 	re.NoError(err)
 	var keyspaceGroup endpoint.KeyspaceGroup
@@ -328,7 +333,7 @@ func (suite *keyspaceGroupTestSuite) TestMergeKeyspaceGroup() {
 	output, err = tests.ExecuteCommand(cmd, args...)
 	re.NoError(err)
 	strings.Contains(string(output), "Success")
-	args = []string{"-u", suite.pdAddr, "keyspace-group", "--show-keyspaces", defaultKeyspaceGroupID}
+	args = []string{"-u", suite.pdAddr, "keyspace-group", defaultKeyspaceGroupID}
 	output, err = tests.ExecuteCommand(cmd, args...)
 	re.NoError(err)
 	err = json.Unmarshal(output, &keyspaceGroup)
@@ -555,7 +560,7 @@ func (suite *keyspaceGroupTestSuite) checkKeyspaceContains(keyspaceGroupID uint3
 	re := suite.Require()
 	cmd := ctl.GetRootCmd()
 	keyspaceGroupIDStr := strconv.FormatUint(uint64(keyspaceGroupID), 10)
-	args := []string{"-u", suite.pdAddr, "keyspace-group", "--show-keyspaces"}
+	args := []string{"-u", suite.pdAddr, "keyspace-group"}
 
 	// Manager may not initialize when the server starts, so we need to wait for it.
 	testutil.Eventually(re, func() bool {


### PR DESCRIPTION
### What problem does this PR solve?

`pd-ctl keyspace-group` includes the keyspace ID list in its output by default. For keyspace groups with many keyspaces, this can make the output unnecessarily long. This PR adds an option to hide the keyspace ID list when a more concise output is preferred, while preserving the existing default behavior.

Issue Number: Close #11207

### What is changed and how does it work?

- Add the `--hide-keyspaces` flag to `pd-ctl keyspace-group`.
- Show the `keyspaces` field by default for both single-keyspace-group and list output.
- Support `--hide-keyspaces=true` to omit the `keyspaces` field from the output.
- Use a dedicated output structure so the `keyspaces` field is included or omitted consistently without changing the source API response.
- Add unit tests for single and list output conversion, including empty keyspace lists.
- Add integration coverage for the default behavior and the explicit hide behavior, and update existing tests to rely on the default output.

### Check List

Tests

- Unit test
- Integration test
- manual test

```bash
pd-ctl keyspace-group <keyspace-group-id>
pd-ctl keyspace-group --hide-keyspaces <keyspace-group-id>
```

### Release note

```release-note
`pd-ctl keyspace-group` now shows the keyspaces field by default. Use `--hide-keyspaces` to hide it.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Keyspace group listings and details now include keyspaces by default.
  - Added the `--hide-keyspaces` command-line option and `hide_keyspaces=true` API parameter to omit keyspaces.
  - Keyspace visibility controls are available for both collection and individual group responses.
  - The API accepts the `hide_keyspaces` parameter regardless of letter casing.

- **Tests**
  - Expanded coverage for default keyspace visibility and hidden-keyspace responses across command-line and API workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->