### PR TITLE
tests: stabilize redirector leader-election test

### DIFF
--- a/tests/server/api/api_test.go
+++ b/tests/server/api/api_test.go
@@ -697,8 +697,10 @@ func (suite *redirectorTestSuite) TestRedirect() {
 	// Test redirect during leader election.
 	leader = suite.cluster.GetLeaderServer()
 	re.NotNil(leader)
-	err := leader.ResignLeaderWithRetry()
-	re.NoError(err)
+	// Reset only PD leadership. ResignLeaderWithRetry also transfers etcd
+	// leadership, which can race with the leader loop campaigning again and
+	// leave the test cluster without a stable leader.
+	leader.ResetPDLeader()
 	for _, svr := range suite.cluster.GetServers() {
 		url := fmt.Sprintf("%s/pd/api/v1/members", svr.GetServer().GetAddr())
 		testutil.Eventually(re, func() bool {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #8712

`TestRedirectorTestSuite/TestRedirect` can intermittently receive HTTP 503
after `ResignLeaderWithRetry` transfers both PD and etcd leadership. The PD
leader loop can campaign again while the etcd transfer is still in progress,
leaving the test cluster without a stable PD leader within the redirector
timeout.

The failure was observed in this [Prow
run](https://prow.tidb.net/view/gs/prow-tidb-logs/pr-logs/pull/tikv_pd/11161/pull-unit-test-next-gen-2/2097587036121731072).

### What is changed and how does it work?

Use `ResetPDLeader` in the redirector test so it exercises PD leader election
without starting a concurrent etcd leader transfer. The redirect assertions
remain unchanged.

```commit-message
tests: stabilize redirector leader-election test
```

### Check List

Tests

- Unit test
  - `make gotest GOTEST_ARGS='./tests/server/api -tags=nextgen,without_dashboard -run TestRedirectorTestSuite -count=20'`
  - `make gotest GOTEST_ARGS='./tests/server/api -tags=nextgen,without_dashboard -run TestRedirectorTestSuite -race -count=5'`

### Release note

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the redirector leader-election test to reset only PD leadership, avoiding unintended etcd leadership transfers during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->