### PR TITLE
resourcemanager: fix client allocation under service limits

### DIFF
--- a/pkg/mcs/resourcemanager/server/token_buckets.go
+++ b/pkg/mcs/resourcemanager/server/token_buckets.go
@@ -309,7 +309,8 @@ func (gtb *GroupTokenBucket) balanceSlotTokens(
 
 	var (
 		totalFillRate, totalBurstLimit = gtb.getFillRateAndBurstLimit()
-		basicFillRate                  = float64(totalFillRate) * evenRatio
+		allocationBudget               = float64(totalFillRate)
+		basicFillRate                  = allocationBudget * evenRatio
 		allocatedFillRate              = 0.0
 		allocationMap                  = make(map[uint64]float64, len(gtb.tokenSlots))
 		extraDemandSlots               = make(map[uint64]float64, len(gtb.tokenSlots))
@@ -335,6 +336,12 @@ func (gtb *GroupTokenBucket) balanceSlotTokens(
 		}
 		return
 	}
+	// Service-limited burstable groups distribute capacity against the available
+	// service budget without changing the group refill rate or the loan algorithm.
+	if gtb.overrideBurstLimit > 0 && gtb.getBurstLimitSetting() < 0 {
+		allocationBudget = math.Min(allocationBudget, float64(gtb.overrideBurstLimit))
+		basicFillRate = allocationBudget * evenRatio
+	}
 	if gtb.grt == nil {
 		gtb.grt = newGroupRUTracker()
 	}
@@ -357,7 +364,7 @@ func (gtb *GroupTokenBucket) balanceSlotTokens(
 		allocationMap[clientUniqueID] = allocation
 		allocatedFillRate += allocation
 	}
-	remainingFillRate := float64(totalFillRate) - allocatedFillRate
+	remainingFillRate := allocationBudget - allocatedFillRate
 	// For the remaining fill rate, allocate it proportionally to the high demand slots.
 	if remainingFillRate > 0 && len(extraDemandSlots) > 0 {
 		for clientUniqueID, extraDemand := range extraDemandSlots {
@@ -375,7 +382,7 @@ func (gtb *GroupTokenBucket) balanceSlotTokens(
 		// Distribute the fill rate.
 		fillRate := allocationMap[clientUniqueID]
 		// Distribute the burst limit and assign tokens based on the allocation ratio.
-		ratio := fillRate / float64(totalFillRate)
+		ratio := fillRate / allocationBudget
 		burstLimit := float64(totalBurstLimit) * ratio
 		assignTokens := tokensForBalance * ratio
 		// Need to reserve burst limit to next balance.
@@ -390,6 +397,9 @@ func (gtb *GroupTokenBucket) balanceSlotTokens(
 		slot.lastTokenCapacity += assignTokens
 		// Update the slot fill rate and burst limit.
 		slot.fillRate = uint64(fillRate)
+		if allocationBudget != float64(totalFillRate) {
+			slot.fillRate = uint64(float64(totalFillRate) * ratio)
+		}
 		slot.burstLimit = int64(burstLimit)
 	}
 }

--- a/pkg/mcs/resourcemanager/server/token_buckets.go
+++ b/pkg/mcs/resourcemanager/server/token_buckets.go
@@ -336,8 +336,15 @@ func (gtb *GroupTokenBucket) balanceSlotTokens(
 		}
 		return
 	}
-	// Service-limited burstable groups distribute capacity against the available
-	// service budget without changing the group refill rate or the loan algorithm.
+	// A negative configured burst limit allows bursting, but even the default group
+	// can be constrained by the keyspace Service Limit. A positive override burst
+	// limit is the capacity assigned to this group by Service Limit coordination.
+	// Use that result, capped by the effective fill rate, as the client allocation
+	// budget. Using a huge fill rate (e.g. the default group's UnlimitedRate) instead
+	// makes client demand negligible relative to the budget, so distributing the
+	// unused budget evenly produces nearly equal shares despite unequal demand.
+	// This only changes how shares are calculated; the group refill rate and loan
+	// algorithm remain unchanged.
 	if gtb.overrideBurstLimit > 0 && gtb.getBurstLimitSetting() < 0 {
 		allocationBudget = math.Min(allocationBudget, float64(gtb.overrideBurstLimit))
 		basicFillRate = allocationBudget * evenRatio

--- a/pkg/mcs/resourcemanager/server/token_buckets_test.go
+++ b/pkg/mcs/resourcemanager/server/token_buckets_test.go
@@ -429,3 +429,71 @@ func TestBalanceSlotTokensFillRateAllocation(t *testing.T) {
 		}
 	}
 }
+
+func TestServiceLimitedClientAllocation(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		fillRate      uint64
+		burstLimit    int64
+		overrideFill  float64
+		overrideBurst int64
+		wantHot       int64
+		wantCold      int64
+	}{
+		{"unlimited group", UnlimitedRate, -1, -1, 160000, 92500, 67500},
+		{"lower service budget", UnlimitedRate, -1, -1, 120000, 72500, 47500},
+		{"hot demand above equal share", UnlimitedRate, -1, -1, 80000, 55000, 25000},
+		{"both demands above equal share", UnlimitedRate, -1, -1, 40000, 20000, 20000},
+		{"moderated group", UnlimitedRate, -2, -1, 160000, 92500, 67500},
+		{"finite refill below budget", 100000, -1, -1, 160000, 100000, 60000},
+		{"overridden refill", UnlimitedRate, -1, 100000, 100000, 62500, 37500},
+		{"explicit burst", UnlimitedRate, 160000, -1, 120000, 60000, 59999},
+		{"rate controlled", UnlimitedRate, 0, -1, 120000, 60000, 59999},
+		{"service disabled", UnlimitedRate, -1, -1, -1, -1, -1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			re := require.New(t)
+			gtb := NewGroupTokenBucket(testResourceGroupName, &rmpb.TokenBucket{
+				Settings: &rmpb.TokenLimitSettings{FillRate: tc.fillRate, BurstLimit: tc.burstLimit},
+			})
+			gtb.overrideFillRate = tc.overrideFill
+			gtb.overrideBurstLimit = tc.overrideBurst
+			gtb.grt = newGroupRUTracker()
+			now := time.Now()
+			for i, demand := range []float64{50000, 25000} {
+				id := uint64(i + 1)
+				gtb.tokenSlots[id] = newTokenSlot(id, now)
+				rt := gtb.grt.getOrCreateRUTracker(id)
+				rt.initialized = true
+				rt.lastSampleTime = now
+				rt.lastEMA = demand
+			}
+			fillRate := gtb.getFillRate()
+			const tokensForBalance = 10000.0
+			gtb.balanceSlotTokens(now, 1, 1, tokensForBalance)
+			re.Equal(fillRate, gtb.getFillRate())
+			re.Equal(tc.fillRate, gtb.Settings.FillRate)
+			re.Equal(tc.burstLimit, gtb.Settings.BurstLimit)
+			re.Equal(tc.wantHot, gtb.tokenSlots[1].burstLimit)
+			re.Equal(tc.wantCold, gtb.tokenSlots[2].burstLimit)
+			re.InDelta(fillRate, float64(gtb.tokenSlots[1].fillRate)+float64(gtb.tokenSlots[2].fillRate), 2)
+			if tc.overrideBurst > 0 {
+				for _, slot := range gtb.tokenSlots {
+					// Refill and newly assigned tokens must use the same share as capacity.
+					ratio := float64(slot.burstLimit) / float64(tc.overrideBurst)
+					re.InDelta(ratio, float64(slot.fillRate)/fillRate, 1/float64(tc.overrideBurst))
+					re.InDelta(ratio, slot.curTokenCapacity/tokensForBalance, 1/float64(tc.overrideBurst))
+					re.Equal(slot.curTokenCapacity, slot.lastTokenCapacity)
+				}
+				re.InDelta(tokensForBalance, gtb.tokenSlots[1].curTokenCapacity+gtb.tokenSlots[2].curTokenCapacity, 1e-7)
+				// Removing the other client restores the whole group allocation.
+				gtb.Tokens = tokensForBalance
+				gtb.balanceSlotTokens(now, 2, 0, 0)
+				re.Len(gtb.tokenSlots, 1)
+				re.Equal(uint64(fillRate), gtb.tokenSlots[1].fillRate)
+				re.Equal(tc.overrideBurst, gtb.tokenSlots[1].burstLimit)
+				re.Equal(tokensForBalance, gtb.tokenSlots[1].curTokenCapacity)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #11211

A burstable group with a very large fill rate can split its finite Service Limit bucket capacity almost equally between clients, causing a busy TiDB instance to wait for RU tokens while aggregate consumption remains below the limit.

### What is changed and how does it work?

```commit-message
Bound the client allocation budget by the positive service burst override
for burstable groups. Apply the resulting demand-based shares to bucket
capacity, newly available tokens, and the original group fill rate.

Preserve the group refill rate and the existing loan algorithm. Individual
clients receive loan shares matching their new allocations.
```

For a group with `F = MaxInt32`, a 160K service budget, and client demands of 50K/25K RU/s, capacities become 92.5K/67.5K RU. Unused budget is still shared evenly.

### Check List

Tests

- Unit test
- Manual test

Manual validation used a single-host TiDB X cluster with NextGen PD/TiDB, CSE TiKV, MinIO, and two business TiDB instances in the same keyspace:

1. Set Service Limit to 24K RU/s and keep the default RU cost configuration.
2. Use 16 connections per TiDB to update disjoint rows with 16 KiB BLOBs, targeting 400/200 CPS. Warm up for 20 seconds, then alternate one active second at twice the target rate with one idle second for 90 seconds.
3. Switch only PD between baseline, fix, and baseline, keeping TiDB, CSE, and MinIO running. Hot-client cumulative RU wait was 114.50s, 0.0105s, and 181.74s respectively; aggregate net RU stayed below 24K/s in all three runs.
4. Check steady traffic and overload at 1200/600 CPS. The fixed overload run averaged 23.80K RU/s over its final 30 seconds. Its full 60-second average was 27.12K RU/s, including cached-token and transition overshoot.

The smaller payload and service budget avoid the storage bottleneck observed with 128 KiB writes in this single-host setup. This validates client allocation and service limiting, with no claim of production storage performance.

### Release note

```release-note
Fix unnecessary RU waits on busy TiDB instances caused by nearly equal client bucket allocation when a resource group has a large fill rate and a finite Service Limit.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token allocation for service-limited burstable groups.
  * Ensured burst capacity and refill rates are distributed consistently across client slots.
  * Preserved configured total refill rates when burst capacity is capped.
  * Restored full group allocation when client slots are removed.
  * Improved handling of fractional token demand, borrowing, and small allocation budgets.
  * Ensured limited-mode buckets continue replenishing and repaying loans when burst capacity is zero.

* **Tests**
  * Added coverage for varied service configurations, fractional allocations, and client slot changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->