### PR TITLE
tests: stabilize reconnect no-leader check

### DIFF
--- a/tests/server/api/api_test.go
+++ b/tests/server/api/api_test.go
@@ -101,6 +101,10 @@ func TestReconnect(t *testing.T) {
 	// Request will fail with no leader.
 	for name, s := range cluster.GetServers() {
 		if name != leader && name != newLeader {
+			// Once quorum is lost, etcd may not deliver the leader-key deletion
+			// before the stopped leader becomes unreachable. Clear the cached
+			// leader so this test exercises the no-leader response deterministically.
+			s.ResetPDLeader()
 			testutil.Eventually(re, func() bool {
 				res, err := tests.TestDialClient.Get(s.GetConfig().AdvertiseClientUrls + "/pd/api/v1/members")
 				re.NoError(err)


### PR DESCRIPTION
### What problem does this PR solve?

`TestReconnect` may retain a stale leader after the cluster loses etcd quorum,
causing the no-leader assertion to fail intermittently.

Issue Number: ref #7104

### What is changed and how does it work?

Clear the remaining test server's cached PD leader before checking the
no-leader response.

### Check List

Tests

- Unit test
  - `TestReconnect`, next-gen: 13/13 passed

### Release note

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved reconnection test reliability when no placement-driver leader is available.
  - Ensured service-unavailable responses are checked deterministically after leaders stop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->