### PR TITLE
tests: stabilize dashboard config update test

### DIFF
--- a/tests/server/server_test.go
+++ b/tests/server/server_test.go
@@ -554,10 +554,17 @@ func TestSetPDServerConfigWithDashboard(t *testing.T) {
 
 	leader := cluster.WaitLeader()
 	re.NotEmpty(leader)
-	svr := cluster.GetServer(leader).GetServer()
+	testServer := cluster.GetServer(leader)
+	svr := testServer.GetServer()
+
+	// Use a concrete member URL so the dashboard manager cannot asynchronously
+	// resolve "auto" between the update and the assertion.
+	cfg := svr.GetPDServerConfig()
+	cfg.DashboardAddress = testServer.GetConfig().AdvertiseClientUrls
+	re.NoError(svr.SetPDServerConfig(*cfg))
 
 	// Test updating config without changing dashboard address
-	cfg := svr.GetPDServerConfig()
+	cfg = svr.GetPDServerConfig()
 	originalDashboard := cfg.DashboardAddress
 	originalUseRegionStorage := cfg.UseRegionStorage
 


### PR DESCRIPTION
### What problem does this PR solve?

The dashboard manager may asynchronously resolve `dashboard-address` from
`auto` while `TestSetPDServerConfigWithDashboard` is taking its snapshot,
making the assertion race with the background update.

Issue Number: close #11218

### What is changed and how does it work?

Initialize the test with the current member's concrete client URL before
checking that an unrelated configuration update preserves the address.

### Check List

Tests

- Unit test
  - next-gen: 10/10 passed
  - next-gen without Dashboard: 10/10 passed

### Release note

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated server configuration test coverage to explicitly validate behavior when the dashboard address matches the leader server’s advertised client URLs.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->
