### PR TITLE
tests: stabilize region label scheduler test

### DIFF
--- a/tests/integrations/realcluster/scheduler_test.go
+++ b/tests/integrations/realcluster/scheduler_test.go
@@ -16,6 +16,7 @@ package realcluster
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"sort"
 	"testing"
@@ -109,8 +110,23 @@ func (s *schedulerSuite) TestRegionLabelDenyScheduler() {
 	defer pdHTTPCli.Close()
 	regions, err := pdHTTPCli.GetRegions(ctx)
 	re.NoError(err)
-	re.NotEmpty(regions.Regions)
+	re.GreaterOrEqual(len(regions.Regions), 2)
 	region1 := regions.Regions[0]
+	makeKeyRange := func(region http.RegionInfo) *http.KeyRange {
+		startKey, err := hex.DecodeString(region.StartKey)
+		re.NoError(err)
+		endKey, err := hex.DecodeString(region.EndKey)
+		re.NoError(err)
+		return http.NewKeyRange(startKey, endKey)
+	}
+	deniedKeyRange := makeKeyRange(region1)
+	controlKeyRange := makeKeyRange(regions.Regions[1])
+	getLeaderStoreID := func(keyRange *http.KeyRange) int64 {
+		regions, err := pdHTTPCli.GetRegionsByKeyRange(ctx, keyRange, 1)
+		re.NoError(err)
+		re.NotEmpty(regions.Regions)
+		return regions.Regions[0].Leader.StoreID
+	}
 
 	err = pdHTTPCli.DeleteScheduler(ctx, types.BalanceLeaderScheduler.String())
 	if err == nil {
@@ -130,14 +146,8 @@ func (s *schedulerSuite) TestRegionLabelDenyScheduler() {
 
 	// wait leader transfer
 	testutil.Eventually(re, func() bool {
-		regions, err := pdHTTPCli.GetRegions(ctx)
-		re.NoError(err)
-		for _, region := range regions.Regions {
-			if region.Leader.StoreID != region1.Leader.StoreID {
-				return false
-			}
-		}
-		return true
+		return getLeaderStoreID(deniedKeyRange) == region1.Leader.StoreID &&
+			getLeaderStoreID(controlKeyRange) == region1.Leader.StoreID
 	}, testutil.WithWaitFor(time.Minute))
 
 	// disable schedule for region1
@@ -172,14 +182,8 @@ func (s *schedulerSuite) TestRegionLabelDenyScheduler() {
 		}
 	}()
 	testutil.Eventually(re, func() bool {
-		regions, err := pdHTTPCli.GetRegions(ctx)
-		re.NoError(err)
-		for _, region := range regions.Regions {
-			if region.Leader.StoreID == region1.Leader.StoreID {
-				return false
-			}
-		}
-		return true
+		return getLeaderStoreID(deniedKeyRange) != region1.Leader.StoreID &&
+			getLeaderStoreID(controlKeyRange) != region1.Leader.StoreID
 	}, testutil.WithWaitFor(time.Minute))
 
 	re.NoError(pdHTTPCli.DeleteScheduler(ctx, types.EvictLeaderScheduler.String()))
@@ -190,21 +194,13 @@ func (s *schedulerSuite) TestRegionLabelDenyScheduler() {
 			re.ErrorContains(err, "scheduler not found")
 		}
 	}()
-	// Newly split regions can remain pending for close to a minute before the
-	// grant-leader scheduler can select them.
+	// Verify that the scheduler can grant an unlabeled region while leaving the
+	// labeled region unchanged. Tracking the ranges instead of every region
+	// avoids depending on unrelated pending regions and survives region splits.
 	testutil.Eventually(re, func() bool {
-		regions, err := pdHTTPCli.GetRegions(ctx)
-		re.NoError(err)
-		for _, region := range regions.Regions {
-			if region.ID == region1.ID {
-				continue
-			}
-			if region.Leader.StoreID != region1.Leader.StoreID {
-				return false
-			}
-		}
-		return true
-	}, testutil.WithWaitFor(2*time.Minute))
+		return getLeaderStoreID(deniedKeyRange) != region1.Leader.StoreID &&
+			getLeaderStoreID(controlKeyRange) == region1.Leader.StoreID
+	}, testutil.WithWaitFor(time.Minute))
 
 	err = pdHTTPCli.PatchRegionLabelRules(ctx, &http.LabelRulePatch{DeleteRules: []string{labelRule.ID}})
 	re.NoError(err)
@@ -213,14 +209,7 @@ func (s *schedulerSuite) TestRegionLabelDenyScheduler() {
 	re.Len(labelRules, 1)
 
 	testutil.Eventually(re, func() bool {
-		regions, err := pdHTTPCli.GetRegions(ctx)
-		re.NoError(err)
-		for _, region := range regions.Regions {
-			if region.Leader.StoreID != region1.Leader.StoreID {
-				return false
-			}
-		}
-		return true
+		return getLeaderStoreID(deniedKeyRange) == region1.Leader.StoreID
 	}, testutil.WithWaitFor(time.Minute))
 }
 

--- a/tests/integrations/realcluster/scheduler_test.go
+++ b/tests/integrations/realcluster/scheduler_test.go
@@ -190,6 +190,8 @@ func (s *schedulerSuite) TestRegionLabelDenyScheduler() {
 			re.ErrorContains(err, "scheduler not found")
 		}
 	}()
+	// Newly split regions can remain pending for close to a minute before the
+	// grant-leader scheduler can select them.
 	testutil.Eventually(re, func() bool {
 		regions, err := pdHTTPCli.GetRegions(ctx)
 		re.NoError(err)
@@ -202,7 +204,7 @@ func (s *schedulerSuite) TestRegionLabelDenyScheduler() {
 			}
 		}
 		return true
-	}, testutil.WithWaitFor(time.Minute))
+	}, testutil.WithWaitFor(2*time.Minute))
 
 	err = pdHTTPCli.PatchRegionLabelRules(ctx, &http.LabelRulePatch{DeleteRules: []string{labelRule.ID}})
 	re.NoError(err)


### PR DESCRIPTION
### What problem does this PR solve?

`TestRegionLabelDenyScheduler` waits for every unrelated region to transfer
its leader. A newly split or pending region can legitimately be filtered by
the scheduler, making the test fail even when `schedule=deny` works correctly.

Issue Number: ref #8339

### What is changed and how does it work?

Track one denied key range and one unlabeled control key range. Verify that the
grant-leader scheduler moves the control range while leaving the denied range
unchanged, then verify that the denied range can move after its label is
removed. Keep the original one-minute waits.

### Check List

Tests

- Integration test package compilation on the exact candidate overlay
- `pull-integration-realcluster-test` will run the updated real-cluster scenario

### Release note

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refined scheduler coverage to validate leader placement across targeted labeled and unlabeled ranges.
  * Added checks confirming multiple regions are available before evaluating scheduling behavior.
  * Updated final scheduling assertions to verify denied ranges remain moved while control ranges return to their original leader location within the expected timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->