### PR TITLE
tests: stabilize TSO consistency after leader change

### DIFF
--- a/tests/integrations/tso/consistency_test.go
+++ b/tests/integrations/tso/consistency_test.go
@@ -147,51 +147,62 @@ func (suite *tsoConsistencyTestSuite) request(ctx context.Context, count uint32)
 
 func (suite *tsoConsistencyTestSuite) TestRequestTSOConcurrently() {
 	re := suite.Require()
-	suite.requestTSOConcurrently()
+	lastTS := suite.requestTSOConcurrently(&pdpb.Timestamp{})
 	// Test TSO after the leader change
-	re.NoError(suite.pdLeaderServer.ResignLeader())
+	oldLeaderName := suite.pdLeaderServer.GetConfig().Name
+	suite.pdLeaderServer.GetServer().GetMember().Resign()
 	leaderName := suite.cluster.WaitLeader()
 	re.NotEmpty(leaderName)
 	leader := suite.cluster.GetServer(leaderName)
 	suite.pdLeaderServer = leader
 	if suite.legacy {
 		// The PD leader is published before its embedded TSO allocator becomes
-		// ready. Wait for that separate readiness condition, then reconnect the
-		// direct test client to the new leader before checking TSO consistency.
+		// ready. Wait for that separate readiness condition before checking TSO
+		// consistency. A direct gRPC client has no leader discovery, so reconnect
+		// it only when another PD becomes the leader.
 		testutil.Eventually(re, func() bool {
 			return leader.GetServer().GetTSOAllocator().IsInitialize()
 		})
-		re.NoError(suite.conn.Close())
-		suite.pdClient, suite.conn = testutil.MustNewGrpcClient(re, leader.GetAddr())
+		if leaderName != oldLeaderName {
+			re.NoError(suite.conn.Close())
+			suite.pdClient, suite.conn = testutil.MustNewGrpcClient(re, leader.GetAddr())
+		}
 	}
-	suite.requestTSOConcurrently()
+	suite.requestTSOConcurrently(lastTS)
 }
 
-func (suite *tsoConsistencyTestSuite) requestTSOConcurrently() {
+func (suite *tsoConsistencyTestSuite) requestTSOConcurrently(lowerBound *pdpb.Timestamp) *pdpb.Timestamp {
 	re := suite.Require()
 	ctx, cancel := context.WithCancel(suite.ctx)
 	defer cancel()
 
-	var wg sync.WaitGroup
+	var (
+		wg      sync.WaitGroup
+		maxTS   = lowerBound
+		maxTSMu sync.Mutex
+	)
 	wg.Add(tsoRequestConcurrencyNumber)
 	for range tsoRequestConcurrencyNumber {
 		go func() {
 			defer wg.Done()
-			last := &pdpb.Timestamp{
-				Physical: 0,
-				Logical:  0,
-			}
+			last := lowerBound
 			var ts *pdpb.Timestamp
 			for range tsoRequestRound {
 				ts = suite.request(ctx, tsoCount)
 				// Check whether the TSO fallbacks
 				re.Equal(1, tsoutil.CompareTimestamp(ts, last))
 				last = ts
+				maxTSMu.Lock()
+				if tsoutil.CompareTimestamp(ts, maxTS) > 0 {
+					maxTS = ts
+				}
+				maxTSMu.Unlock()
 				time.Sleep(10 * time.Millisecond)
 			}
 		}()
 	}
 	wg.Wait()
+	return maxTS
 }
 
 func (suite *tsoConsistencyTestSuite) TestFallbackTSOConsistency() {

--- a/tests/integrations/tso/consistency_test.go
+++ b/tests/integrations/tso/consistency_test.go
@@ -146,10 +146,24 @@ func (suite *tsoConsistencyTestSuite) request(ctx context.Context, count uint32)
 }
 
 func (suite *tsoConsistencyTestSuite) TestRequestTSOConcurrently() {
+	re := suite.Require()
 	suite.requestTSOConcurrently()
 	// Test TSO after the leader change
-	suite.pdLeaderServer.GetServer().GetMember().Resign()
-	suite.cluster.WaitLeader()
+	re.NoError(suite.pdLeaderServer.ResignLeader())
+	leaderName := suite.cluster.WaitLeader()
+	re.NotEmpty(leaderName)
+	leader := suite.cluster.GetServer(leaderName)
+	suite.pdLeaderServer = leader
+	if suite.legacy {
+		// The PD leader is published before its embedded TSO allocator becomes
+		// ready. Wait for that separate readiness condition, then reconnect the
+		// direct test client to the new leader before checking TSO consistency.
+		testutil.Eventually(re, func() bool {
+			return leader.GetServer().GetTSOAllocator().IsInitialize()
+		})
+		re.NoError(suite.conn.Close())
+		suite.pdClient, suite.conn = testutil.MustNewGrpcClient(re, leader.GetAddr())
+	}
 	suite.requestTSOConcurrently()
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

`TestLegacyTSOConsistencySuite/TestRequestTSOConcurrently` keeps a direct
gRPC client connected to the original PD leader. After resigning the leader,
the test can send requests to the old endpoint or start before the elected
leader's embedded TSO allocator is ready.

The two concurrent phases also reset their comparison state, so a timestamp
rollback across the leadership transition would not be detected.

Issue Number: close #11219

### What is changed and how does it work?

Keep the existing member-election resign trigger. After the new election,
wait for the elected legacy PD leader's embedded TSO allocator to initialize,
and reconnect the direct gRPC client only if another PD becomes leader.

Carry the maximum timestamp from the first concurrent phase into the second,
so every TSO returned after the transition must exceed the pre-transition
high-water mark.

### Check List

Tests

- Legacy targeted test passed 10 consecutive runs
- Legacy and microservice targeted tests passed 3 race-enabled runs

### Release note

```release-note
None.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved integration coverage for concurrent timestamp requests during leadership transitions.
  - Verified that timestamps requested in subsequent rounds continue beyond those issued in the initial round.
  - Added coverage for legacy-mode reconnection behavior when leadership changes, while preserving readiness checks.
  - Strengthened validation of leader transitions and timestamp ordering under concurrent request workloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
