### PR TITLE
tests: stabilize TestShowKeyspaceGroupPrimary

### DIFF
--- a/tools/pd-ctl/tests/keyspace/keyspace_group_test.go
+++ b/tools/pd-ctl/tests/keyspace/keyspace_group_test.go
@@ -414,22 +414,33 @@ func (suite *keyspaceGroupTestSuite) TestKeyspaceGroupState() {
 func (suite *keyspaceGroupTestSuite) TestShowKeyspaceGroupPrimary() {
 	re := suite.Require()
 	cmd := ctl.GetRootCmd()
+	waitKeyspaceGroup := func(id uint32) endpoint.KeyspaceGroup {
+		var keyspaceGroup endpoint.KeyspaceGroup
+		testutil.Eventually(re, func() bool {
+			args := []string{"-u", suite.pdAddr, "keyspace-group", strconv.FormatUint(uint64(id), 10)}
+			output, err := tests.ExecuteCommand(cmd, args...)
+			if err != nil {
+				return false
+			}
+			var current endpoint.KeyspaceGroup
+			if err := json.Unmarshal(output, &current); err != nil {
+				return false
+			}
+			if current.ID != id || len(current.Members) != 2 {
+				return false
+			}
+			keyspaceGroup = current
+			return true
+		})
+		return keyspaceGroup
+	}
 
 	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/tso/fastGroupSplitPatroller", `return(true)`))
 
 	defaultKeyspaceGroupID := strconv.FormatUint(uint64(constant.DefaultKeyspaceGroupID), 10)
 
 	// check keyspace group 0 information.
-	var keyspaceGroup endpoint.KeyspaceGroup
-	testutil.Eventually(re, func() bool {
-		args := []string{"-u", suite.pdAddr, "keyspace-group"}
-		output, err := tests.ExecuteCommand(cmd, append(args, defaultKeyspaceGroupID)...)
-		re.NoError(err)
-		err = json.Unmarshal(output, &keyspaceGroup)
-		re.NoError(err)
-		re.Equal(constant.DefaultKeyspaceGroupID, keyspaceGroup.ID)
-		return len(keyspaceGroup.Members) == 2
-	})
+	keyspaceGroup := waitKeyspaceGroup(constant.DefaultKeyspaceGroupID)
 	for _, member := range keyspaceGroup.Members {
 		re.Contains(suite.tsoAddrs, member.Address)
 	}
@@ -453,19 +464,7 @@ func (suite *keyspaceGroupTestSuite) TestShowKeyspaceGroupPrimary() {
 	})
 
 	// check keyspace group 1 information.
-	testutil.Eventually(re, func() bool {
-		args := []string{"-u", suite.pdAddr, "keyspace-group"}
-		output, err := tests.ExecuteCommand(cmd, append(args, "1")...)
-		re.NoError(err)
-		if strings.Contains(string(output), "Failed") {
-			// If the error is ErrEtcdTxnConflict, it means there is a temporary failure.
-			re.Contains(string(output), "ErrEtcdTxnConflict", "output: %s", string(output))
-			return false
-		}
-		err = json.Unmarshal(output, &keyspaceGroup)
-		re.NoError(err)
-		return len(keyspaceGroup.Members) == 2
-	})
+	keyspaceGroup = waitKeyspaceGroup(1)
 	for _, member := range keyspaceGroup.Members {
 		re.Contains(suite.tsoAddrs, member.Address)
 	}


### PR DESCRIPTION
### What problem does this PR solve?

`TestKeyspaceGroupTestsuite/TestShowKeyspaceGroupPrimary` performs assertions
inside `Eventually` while keyspace group metadata is still becoming ready. A
single transient command error or non-JSON PD response therefore permanently
marks the test as failed, even if a later attempt succeeds.

Issue Number: close #11221

### What is changed and how does it work?

Use one helper to wait for both the default keyspace group and keyspace group
1. Command errors, non-JSON responses, unexpected group IDs, and incomplete
membership make the condition retry. A persistent failure still fails when
`Eventually` reaches its timeout.

### Check List

Tests

- `go test ./pd-ctl/tests/keyspace -tags=deadlock -run '^TestKeyspaceGroupTestsuite$/^TestShowKeyspaceGroupPrimary$' -count=10`
- `go test -race ./pd-ctl/tests/keyspace -tags=deadlock -run '^TestKeyspaceGroupTestsuite$/^TestShowKeyspaceGroupPrimary$' -count=5`

### Release note

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved keyspace group test reliability by centralizing polling and retry handling.
  * Tests now tolerate transient parsing and timing issues while waiting for keyspace groups to reach the expected state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->