### PR TITLE
tools: add a CLI for keyspace GC barriers

### DIFF
--- a/tools/pd-gc-barrier/README.md
+++ b/tools/pd-gc-barrier/README.md
@@ -1,0 +1,118 @@
+# pd-gc-barrier
+
+`pd-gc-barrier` is a standalone command-line tool for inspecting, creating, updating, and deleting keyspace GC barriers through PD's gRPC APIs. It operates on an explicitly selected keyspace with keyspace-level GC enabled.
+
+## Build
+
+From the repository root:
+
+```sh
+(
+  cd tools || exit 1
+  CGO_ENABLED=0 go build -tags nextgen -o ../bin/pd-gc-barrier ./pd-gc-barrier
+)
+./bin/pd-gc-barrier --help
+```
+
+Use Go 1.25 or newer for the repository's development environment. Set `GOOS` and `GOARCH` when building for another platform. Run the binary on a machine that can reach the PD endpoints.
+
+## Commands
+
+```text
+pd-gc-barrier --pd <endpoints> --keyspace-id <id> show
+pd-gc-barrier --pd <endpoints> --keyspace-id <id> set <barrier-id> <tso-or-rfc3339-time> --ttl <duration|never>
+pd-gc-barrier --pd <endpoints> --keyspace-id <id> delete <barrier-id>
+```
+
+Both `--pd` and `--keyspace-id` are required for every command. The examples below use placeholder values; replace them with the actual endpoints, an existing keyspace ID, and an appropriate target timestamp.
+
+```sh
+PD='http://127.0.0.1:2379'
+KEYSPACE_ID='123'
+BARRIER_ID='example-barrier'
+TARGET='<target TSO or RFC3339 time>'
+```
+
+### Show GC state
+
+```sh
+./bin/pd-gc-barrier --pd "$PD" --keyspace-id "$KEYSPACE_ID" show
+```
+
+Returns `keyspace_id`, `txn_safe_point`, `gc_safe_point`, and `barriers`. Barriers are sorted by timestamp, then by ID. Each barrier includes its ID, timestamp, and TTL.
+
+The result includes only barriers in the selected keyspace. Global barriers are not listed. Safe points describe GC boundaries; they do not indicate that physical data reclamation or compaction has completed.
+
+### Create or update a barrier
+
+```sh
+./bin/pd-gc-barrier --pd "$PD" --keyspace-id "$KEYSPACE_ID" \
+  set "$BARRIER_ID" "$TARGET" --ttl 2h
+```
+
+If the ID does not exist in the selected keyspace, `set` creates it. Otherwise, it replaces both its timestamp and TTL. Every call requires both values; to change only one, supply the desired unchanged value for the other.
+
+The target timestamp must be greater than or equal to the current transaction safe point. PD enforces this constraint when it writes the barrier. The API does not provide compare-and-swap or require the new timestamp to be greater than the barrier's previous timestamp. Coordinate writers that share a barrier ID.
+
+Use `never` for a barrier that should remain until explicitly deleted:
+
+```sh
+./bin/pd-gc-barrier --pd "$PD" --keyspace-id "$KEYSPACE_ID" \
+  set "$BARRIER_ID" "$TARGET" --ttl never
+```
+
+A finite TTL must be positive, such as `30m` or `2h`. PD rounds it up to whole seconds and resets the expiration time on each successful `set`. In `show` results, a finite TTL is the remaining lifetime reported at query time; expired entries may remain visible until cleaned up. `never` denotes no expiration.
+
+### Delete a barrier
+
+```sh
+./bin/pd-gc-barrier --pd "$PD" --keyspace-id "$KEYSPACE_ID" delete "$BARRIER_ID"
+```
+
+Returns the deleted barrier's information. Deleting an ID that does not exist succeeds with `deleted_barrier: null`.
+
+Deleting or expiring a barrier removes its retention constraint. Increasing its timestamp can also permit GC to advance. Neither operation reverses GC that has already occurred. The tool performs the requested operation without automatically installing a replacement barrier.
+
+## Timestamp input
+
+The timestamp argument accepts a positive decimal `uint64` TSO or an RFC3339 date and time with an explicit timezone.
+
+| Input | Example | Interpretation |
+| --- | --- | --- |
+| Decimal TSO | `262144001` | Preserves the exact physical and logical components |
+| Date and time with offset | `2025-10-01T00:10:00+08:00` | Uses the specified UTC offset |
+| Date and time with milliseconds | `2025-10-01T00:10:00.123+08:00` | Preserves millisecond precision |
+| UTC date and time | `2025-09-30T16:10:00Z` | Equivalent to the offset example above |
+
+Date and time input uses `T` as the separator and requires `Z` or an explicit offset. Date-only input and timestamps such as `2025-10-01 00:10:00` are rejected. The time must be after the Unix epoch and fit within the TSO range.
+
+Use at most three fractional digits. Inputs with more than nine fractional digits may currently be truncated before precision validation. Date and time input sets the TSO's logical counter to zero while preserving its physical date, time, and milliseconds. To retain an existing TSO exactly, copy its complete decimal value.
+
+## Connection options
+
+| Option | Description |
+| --- | --- |
+| `--pd` | Required. Comma-separated PD endpoints; the client discovers the leader. |
+| `--keyspace-id` | Required. An existing keyspace ID in the inclusive range `0..16777215`. |
+| `--timeout` | Positive timeout for the entire command, including connection initialization. Defaults to `30s`. |
+| `--cacert` | Path to the trusted CA certificate file. |
+| `--cert` | Path to the client certificate file. |
+| `--key` | Path to the client private key file. |
+
+Keyspace `0` is the `DEFAULT` keyspace. `NullKeyspaceID` (`4294967295`), unified GC, and global barrier management are unsupported. Before each operation, the tool reads GC state and rejects a returned scope that differs from the requested keyspace. The reserved barrier ID `gc_worker` cannot be set or deleted.
+
+For TLS connections, provide the certificate files with the command:
+
+```sh
+./bin/pd-gc-barrier --pd 'https://pd.example.com:2379' --keyspace-id "$KEYSPACE_ID" \
+  --cacert /path/to/ca.pem --cert /path/to/client.pem --key /path/to/client-key.pem \
+  show
+```
+
+This version of the PD client requires a client certificate and private key to enable TLS. The tool rejects a CA file supplied without the certificate and key, as well as HTTPS endpoints supplied without the client certificate and key.
+
+## Output and errors
+
+Successful commands write JSON to stdout. Diagnostics go to stderr, and failures return a nonzero exit status. Timestamp objects contain a decimal `tso` string and a UTC `time` string. Keeping the TSO as a string avoids precision loss in JSON consumers that use floating-point numbers.
+
+If `set` or `delete` times out or loses its connection, the write may already have succeeded. Run `show` to inspect the actual state before retrying. Exiting the tool does not delete a barrier or reset its TTL.

--- a/tools/pd-gc-barrier/integration_test.go
+++ b/tools/pd-gc-barrier/integration_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	pd "github.com/tikv/pd/client"
+	"github.com/tikv/pd/client/clients/gc"
+	"github.com/tikv/pd/pkg/keyspace"
+	"github.com/tikv/pd/server/config"
+	"github.com/tikv/pd/tests"
+)
+
+// TestBarrierControlsGC verifies the command against the actual release's PD
+// server and client, including persistence after each command's client closes.
+func TestBarrierControlsGC(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cluster, err := tests.NewTestCluster(ctx, 1, func(conf *config.Config, _ string) {
+		conf.Keyspace.WaitRegionSplit = false
+	})
+	require.NoError(t, err)
+	defer cluster.Destroy()
+	require.NoError(t, cluster.RunInitialServers())
+	require.NotEmpty(t, cluster.WaitLeader())
+	server := cluster.GetLeaderServer()
+	require.NoError(t, server.BootstrapCluster())
+	ks, err := server.GetKeyspaceManager().CreateKeyspace(&keyspace.CreateKeyspaceRequest{
+		Name:   "barrier-recovery",
+		Config: map[string]string{keyspace.GCManagementType: keyspace.KeyspaceLevelGC},
+	})
+	require.NoError(t, err)
+	other, err := server.GetKeyspaceManager().CreateKeyspace(&keyspace.CreateKeyspaceRequest{
+		Name:   "unaffected",
+		Config: map[string]string{keyspace.GCManagementType: keyspace.KeyspaceLevelGC},
+	})
+	require.NoError(t, err)
+	client, err := pd.NewClientWithContext(ctx, "barrier-tool-test", []string{server.GetAddr()}, pd.SecurityOption{})
+	require.NoError(t, err)
+	defer client.Close()
+	for _, id := range []uint32{ks.GetId(), other.GetId()} {
+		_, err = client.GetGCStatesClient(id).SetGCBarrier(ctx, "ticdc-old", 100, gc.TTLNeverExpire)
+		require.NoError(t, err)
+	}
+	gcClient := client.GetGCStatesClient(ks.GetId())
+	controller := client.GetGCInternalController(ks.GetId())
+	assertLimit := func(want uint64) {
+		result, err := controller.AdvanceTxnSafePoint(ctx, 1000)
+		require.NoError(t, err)
+		require.Equal(t, want, result.NewTxnSafePoint)
+	}
+	run := func(args ...string) string {
+		cmd := newCommand(connectPD)
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetArgs(append([]string{"--pd", server.GetAddr(), "--keyspace-id", strconv.FormatUint(uint64(ks.GetId()), 10)}, args...))
+		require.NoError(t, cmd.ExecuteContext(ctx))
+		return out.String()
+	}
+	assertLimit(100)
+	run("set", "recovery", "200", "--ttl=never")
+	assertLimit(100)
+	run("delete", "ticdc-old")
+	assertLimit(200)
+	run("set", "recovery", "300", "--ttl=never")
+	assertLimit(300)
+	state, err := gcClient.GetGCState(ctx)
+	require.NoError(t, err)
+	require.Len(t, state.GCBarriers, 1)
+	require.Equal(t, gc.TTLNeverExpire, state.GCBarriers[0].TTL)
+	require.Contains(t, run("show"), `"tso": "300"`)
+	run("delete", "recovery")
+	assertLimit(1000)
+	state, err = client.GetGCStatesClient(other.GetId()).GetGCState(ctx)
+	require.NoError(t, err)
+	require.Len(t, state.GCBarriers, 1)
+	require.Equal(t, "ticdc-old", state.GCBarriers[0].BarrierID)
+	require.Equal(t, uint64(100), state.GCBarriers[0].BarrierTS)
+}

--- a/tools/pd-gc-barrier/main.go
+++ b/tools/pd-gc-barrier/main.go
@@ -1,0 +1,286 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"os/signal"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/log"
+
+	pd "github.com/tikv/pd/client"
+	"github.com/tikv/pd/client/clients/gc"
+	"github.com/tikv/pd/client/constants"
+	"github.com/tikv/pd/client/opt"
+	"github.com/tikv/pd/pkg/utils/tsoutil"
+)
+
+type options struct {
+	addresses  []string
+	keyspaceID uint32
+	security   pd.SecurityOption
+	timeout    time.Duration
+}
+
+type connectFunc func(context.Context, options) (gc.GCStatesClient, func(), error)
+
+func main() {
+	// The release's client logger defaults to stdout; reserve stdout for JSON.
+	sink := zapcore.Lock(zapcore.AddSync(os.Stderr))
+	logger, props, err := log.InitLoggerWithWriteSyncer(&log.Config{Level: "warn"}, sink, sink)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	log.ReplaceGlobals(logger, props)
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	cmd := newCommand(connectPD)
+	err = cmd.ExecuteContext(ctx)
+	stop()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func connectPD(ctx context.Context, opts options) (gc.GCStatesClient, func(), error) {
+	client, err := pd.NewClientWithContext(ctx, "pd-gc-barrier", opts.addresses, opts.security,
+		opt.WithCustomTimeoutOption(opts.timeout))
+	if err != nil {
+		return nil, nil, err
+	}
+	return client.GetGCStatesClient(opts.keyspaceID), client.Close, nil
+}
+
+func newCommand(connect connectFunc) *cobra.Command {
+	var opts options
+	root := &cobra.Command{
+		Use:           "pd-gc-barrier",
+		Short:         "Inspect and manually manage keyspace GC barriers",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	flags := root.PersistentFlags()
+	flags.StringSliceVar(&opts.addresses, "pd", nil, "PD endpoints, separated by commas")
+	flags.Uint32Var(&opts.keyspaceID, "keyspace-id", 0, "Keyspace ID (0..16777215); must use keyspace-level GC")
+	flags.DurationVar(&opts.timeout, "timeout", 30*time.Second, "Timeout for the entire command, including connection")
+	flags.StringVar(&opts.security.CAPath, "cacert", "", "Trusted CA certificate path")
+	flags.StringVar(&opts.security.CertPath, "cert", "", "Client certificate path")
+	flags.StringVar(&opts.security.KeyPath, "key", "", "Client private key path")
+	// A missing flag here is a programming error in command registration.
+	if err := root.MarkPersistentFlagRequired("pd"); err != nil {
+		panic(err)
+	}
+	if err := root.MarkPersistentFlagRequired("keyspace-id"); err != nil {
+		panic(err)
+	}
+
+	withClient := func(cmd *cobra.Command, action func(context.Context, gc.GCStatesClient, gc.GCState) (any, error)) error {
+		if opts.keyspaceID > constants.MaxKeyspaceID {
+			return fmt.Errorf("keyspace ID must be in [0, %d]; unified and global GC are unsupported", constants.MaxKeyspaceID)
+		}
+		if opts.timeout <= 0 {
+			return errors.New("timeout must be positive")
+		}
+		if len(opts.addresses) == 0 {
+			return errors.New("at least one PD endpoint is required")
+		}
+		for i, address := range opts.addresses {
+			opts.addresses[i] = strings.TrimSpace(address)
+			if opts.addresses[i] == "" {
+				return errors.New("PD endpoints must not be empty")
+			}
+			if strings.HasPrefix(strings.ToLower(opts.addresses[i]), "https://") && opts.security.CertPath == "" {
+				return errors.New("https requires cert and key with this version of the PD client")
+			}
+		}
+		if (opts.security.CertPath == "") != (opts.security.KeyPath == "") {
+			return errors.New("cert and key must be supplied together")
+		}
+		if opts.security.CAPath != "" && opts.security.CertPath == "" {
+			return errors.New("cacert requires cert and key with this version of the PD client")
+		}
+		ctx, cancel := context.WithTimeout(cmd.Context(), opts.timeout)
+		defer cancel()
+		client, closeClient, err := connect(ctx, opts)
+		if err != nil {
+			return fmt.Errorf("connect to PD: %w", err)
+		}
+		defer closeClient()
+		state, err := client.GetGCState(ctx)
+		if err != nil {
+			return fmt.Errorf("read GC state: %w", err)
+		}
+		if state.KeyspaceID != opts.keyspaceID {
+			return fmt.Errorf("GC scope mismatch: requested keyspace %d, PD returned %d; refusing operation", opts.keyspaceID, state.KeyspaceID)
+		}
+		result, err := action(ctx, client, state)
+		if err != nil {
+			return err
+		}
+		encoder := json.NewEncoder(cmd.OutOrStdout())
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(result)
+	}
+
+	show := &cobra.Command{
+		Use:   "show",
+		Short: "Show safe points and keyspace barriers (not physical GC completion or global barriers)",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return withClient(cmd, func(_ context.Context, _ gc.GCStatesClient, state gc.GCState) (any, error) {
+				barriers := make([]*barrierOutput, 0, len(state.GCBarriers))
+				sort.Slice(state.GCBarriers, func(i, j int) bool {
+					if state.GCBarriers[i].BarrierTS == state.GCBarriers[j].BarrierTS {
+						return state.GCBarriers[i].BarrierID < state.GCBarriers[j].BarrierID
+					}
+					return state.GCBarriers[i].BarrierTS < state.GCBarriers[j].BarrierTS
+				})
+				for _, b := range state.GCBarriers {
+					barriers = append(barriers, formatBarrier(b))
+				}
+				return struct {
+					KeyspaceID   uint32           `json:"keyspace_id"`
+					TxnSafePoint timestampOutput  `json:"txn_safe_point"`
+					GCSafePoint  timestampOutput  `json:"gc_safe_point"`
+					Barriers     []*barrierOutput `json:"barriers"`
+				}{state.KeyspaceID, formatTimestamp(state.TxnSafePoint), formatTimestamp(state.GCSafePoint), barriers}, nil
+			})
+		},
+	}
+	var ttlInput string
+	set := &cobra.Command{
+		Use:   "set <barrier-id> <tso-or-rfc3339-time> --ttl <duration|never>",
+		Short: "Create or update a barrier; time input requires a timezone and millisecond precision",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateBarrierID(args[0]); err != nil {
+				return err
+			}
+			ts, err := parseTimestamp(args[1])
+			if err != nil {
+				return err
+			}
+			ttl := gc.TTLNeverExpire
+			if ttlInput != "never" {
+				ttl, err = time.ParseDuration(ttlInput)
+				if err != nil || ttl <= 0 {
+					return errors.New("ttl must be a positive duration such as 2h, or never")
+				}
+			}
+			return withClient(cmd, func(ctx context.Context, client gc.GCStatesClient, state gc.GCState) (any, error) {
+				if ts < state.TxnSafePoint {
+					return nil, fmt.Errorf("barrier timestamp %d is behind transaction safe point %d", ts, state.TxnSafePoint)
+				}
+				b, err := client.SetGCBarrier(ctx, args[0], ts, ttl)
+				if err != nil {
+					return nil, fmt.Errorf("set barrier: %w; query state before retrying because the write may have succeeded", err)
+				}
+				return struct {
+					KeyspaceID uint32         `json:"keyspace_id"`
+					Barrier    *barrierOutput `json:"barrier"`
+				}{state.KeyspaceID, formatBarrier(b)}, nil
+			})
+		},
+	}
+	set.Flags().StringVar(&ttlInput, "ttl", "", "Lifetime such as 2h, or never (requires manual deletion)")
+	if err := set.MarkFlagRequired("ttl"); err != nil {
+		panic(err)
+	}
+	deleteCmd := &cobra.Command{
+		Use:   "delete <barrier-id>",
+		Short: "Delete a barrier; verify the replacement barrier before removing an old one",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateBarrierID(args[0]); err != nil {
+				return err
+			}
+			return withClient(cmd, func(ctx context.Context, client gc.GCStatesClient, state gc.GCState) (any, error) {
+				b, err := client.DeleteGCBarrier(ctx, args[0])
+				if err != nil {
+					return nil, fmt.Errorf("delete barrier: %w; query state before retrying because the write may have succeeded", err)
+				}
+				return struct {
+					KeyspaceID     uint32         `json:"keyspace_id"`
+					DeletedBarrier *barrierOutput `json:"deleted_barrier"`
+				}{state.KeyspaceID, formatBarrier(b)}, nil
+			})
+		},
+	}
+	root.AddCommand(show, set, deleteCmd)
+	return root
+}
+
+func validateBarrierID(id string) error {
+	if strings.TrimSpace(id) == "" || id == "gc_worker" {
+		return errors.New("barrier ID must be non-empty and must not be the reserved ID gc_worker")
+	}
+	return nil
+}
+
+func parseTimestamp(input string) (uint64, error) {
+	if ts, err := strconv.ParseUint(input, 10, 64); err == nil && ts > 0 {
+		return ts, nil
+	}
+	t, err := time.Parse(time.RFC3339Nano, input)
+	if err != nil {
+		return 0, fmt.Errorf("timestamp must be a positive decimal TSO or RFC3339 time with timezone: %q", input)
+	}
+	ms := t.UnixMilli()
+	if ms <= 0 || uint64(ms) > math.MaxUint64>>18 || t.Nanosecond()%int(time.Millisecond) != 0 {
+		return 0, errors.New("time must be after the Unix epoch, fit in a TSO, and have at most millisecond precision")
+	}
+	return tsoutil.ComposeTS(ms, 0), nil
+}
+
+type timestampOutput struct {
+	TSO  string `json:"tso"`
+	Time string `json:"time"`
+}
+
+func formatTimestamp(ts uint64) timestampOutput {
+	physical, _ := tsoutil.ParseTS(ts)
+	return timestampOutput{strconv.FormatUint(ts, 10), physical.UTC().Format(time.RFC3339Nano)}
+}
+
+type barrierOutput struct {
+	BarrierID string          `json:"barrier_id"`
+	BarrierTS timestampOutput `json:"barrier_ts"`
+	TTL       string          `json:"ttl"`
+}
+
+func formatBarrier(b *gc.GCBarrierInfo) *barrierOutput {
+	if b == nil {
+		return nil
+	}
+	ttl := b.TTL.String()
+	if b.TTL == gc.TTLNeverExpire {
+		ttl = "never"
+	}
+	return &barrierOutput{b.BarrierID, formatTimestamp(b.BarrierTS), ttl}
+}

--- a/tools/pd-gc-barrier/main_test.go
+++ b/tools/pd-gc-barrier/main_test.go
@@ -1,0 +1,222 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tikv/pd/client/clients/gc"
+)
+
+func TestTimestampInput(t *testing.T) {
+	for _, tc := range []struct {
+		input string
+		want  uint64
+	}{
+		{"262144001", 262144001},
+		{"1970-01-01T00:00:01Z", 262144000},
+		{"1970-01-01T08:00:01.001+08:00", 262406144},
+		{"18446744073709551615", 18446744073709551615},
+	} {
+		t.Run(tc.input, func(t *testing.T) {
+			got, err := parseTimestamp(tc.input)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+	for _, input := range []string{"", "0", "-1", "18446744073709551616", "2026-09-10 12:00:00", "1969-12-31T23:59:59Z", "9999-01-01T00:00:00Z", "2026-09-10T00:00:00.000001Z"} {
+		t.Run(input, func(t *testing.T) {
+			_, err := parseTimestamp(input)
+			require.Error(t, err)
+		})
+	}
+}
+
+// Incorrect input must fail before opening a connection, particularly IDs that
+// PD would otherwise redirect to unified GC.
+func TestInvalidArgumentsDoNotConnect(t *testing.T) {
+	for _, args := range [][]string{
+		{"show"},
+		{"--pd=p:2379", "show"},
+		{"--keyspace-id=1", "show"},
+		{"--pd=p:2379", "--keyspace-id=16777216", "show"},
+		{"--pd=p:2379", "--keyspace-id=4294967295", "delete", "old"},
+		{"--pd=p:2379", "--keyspace-id=1", "--timeout=0s", "show"},
+		{"--pd=p:2379", "--keyspace-id=1", "set", "temporary", "100"},
+		{"--pd=p:2379", "--keyspace-id=1", "set", "temporary", "100", "--ttl=0s"},
+		{"--pd=p:2379", "--keyspace-id=1", "set", "temporary", "100", "--ttl=-1s"},
+		{"--pd=p:2379", "--keyspace-id=1", "set", "gc_worker", "100", "--ttl=never"},
+		{"--pd=p:2379", "--keyspace-id=1", "delete", "gc_worker"},
+		{"--pd=p:2379", "--keyspace-id=1", "delete", ""},
+		{"--pd=p:2379", "--keyspace-id=1", "show", "extra"},
+		{"--pd=p:2379", "--keyspace-id=1", "--cert=client.pem", "show"},
+		{"--pd=p:2379", "--keyspace-id=1", "--cacert=ca.pem", "show"},
+		{"--pd=https://p:2379", "--keyspace-id=1", "show"},
+	} {
+		t.Run(string(mustJSON(t, args)), func(t *testing.T) {
+			connected := false
+			cmd := newCommand(func(context.Context, options) (gc.GCStatesClient, func(), error) {
+				connected = true
+				return nil, nil, errors.New("unexpected connection")
+			})
+			cmd.SetArgs(args)
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+			require.Error(t, cmd.Execute())
+			require.False(t, connected)
+		})
+	}
+}
+
+func TestManualBarrierLifecycle(t *testing.T) {
+	client := &memoryGCClient{state: gc.GCState{KeyspaceID: 42, TxnSafePoint: 100, GCSafePoint: 80}}
+	client.state.GCBarriers = []*gc.GCBarrierInfo{gc.NewGCBarrierInfo("ticdc-old", 100, gc.TTLNeverExpire, time.Now())}
+
+	out, err := executeTestCommand(t, client, "set", "recovery", "262144001", "--ttl=never")
+	require.NoError(t, err)
+	require.Contains(t, out, `"tso": "262144001"`)
+	require.Contains(t, out, `"time": "1970-01-01T00:00:01Z"`)
+	require.Contains(t, out, `"ttl": "never"`)
+	require.Len(t, client.state.GCBarriers, 2)
+	require.Equal(t, uint64(262144001), client.state.GCBarriers[1].BarrierTS)
+	require.Equal(t, gc.TTLNeverExpire, client.state.GCBarriers[1].TTL)
+
+	_, err = executeTestCommand(t, client, "delete", "ticdc-old")
+	require.NoError(t, err)
+	require.Len(t, client.state.GCBarriers, 1)
+	require.Equal(t, "recovery", client.state.GCBarriers[0].BarrierID)
+
+	_, err = executeTestCommand(t, client, "set", "recovery", "1970-01-01T00:00:02Z", "--ttl=2h")
+	require.NoError(t, err)
+	require.Len(t, client.state.GCBarriers, 1)
+	require.Equal(t, uint64(524288000), client.state.GCBarriers[0].BarrierTS)
+	require.Equal(t, 2*time.Hour, client.state.GCBarriers[0].TTL)
+
+	out, err = executeTestCommand(t, client, "show")
+	require.NoError(t, err)
+	var state map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out), &state))
+	require.Equal(t, float64(42), state["keyspace_id"])
+	require.Contains(t, out, `"txn_safe_point"`)
+	require.Contains(t, out, `"gc_safe_point"`)
+	require.Contains(t, out, "recovery")
+
+	_, err = executeTestCommand(t, client, "delete", "recovery")
+	require.NoError(t, err)
+	require.Empty(t, client.state.GCBarriers)
+	out, err = executeTestCommand(t, client, "delete", "recovery")
+	require.NoError(t, err)
+	require.Contains(t, out, `"deleted_barrier": null`)
+}
+
+func TestPreflightAndRPCErrors(t *testing.T) {
+	for _, action := range [][]string{{"show"}, {"set", "recovery", "200", "--ttl=never"}, {"delete", "old"}} {
+		client := &memoryGCClient{state: gc.GCState{KeyspaceID: 4294967295}}
+		_, err := executeTestCommand(t, client, action...)
+		require.ErrorContains(t, err, "scope")
+		require.Zero(t, client.mutations)
+		client.state.KeyspaceID = 42
+		client.readErr = errors.New("read unavailable")
+		_, err = executeTestCommand(t, client, action...)
+		require.ErrorContains(t, err, "read unavailable")
+		require.Zero(t, client.mutations)
+	}
+	client := &memoryGCClient{state: gc.GCState{KeyspaceID: 42, TxnSafePoint: 300}}
+	_, err := executeTestCommand(t, client, "set", "recovery", "200", "--ttl=never")
+	require.Error(t, err)
+	require.Zero(t, client.mutations)
+	client.state.TxnSafePoint = 100
+	client.writeErr = errors.New("write unavailable")
+	for _, action := range [][]string{{"set", "recovery", "200", "--ttl=never"}, {"delete", "old"}} {
+		out, err := executeTestCommand(t, client, action...)
+		require.ErrorContains(t, err, "write unavailable")
+		require.Empty(t, out)
+	}
+}
+
+func executeTestCommand(t *testing.T, client gc.GCStatesClient, args ...string) (string, error) {
+	t.Helper()
+	closed := false
+	cmd := newCommand(func(ctx context.Context, opts options) (gc.GCStatesClient, func(), error) {
+		require.Equal(t, uint32(42), opts.keyspaceID)
+		_, hasDeadline := ctx.Deadline()
+		require.True(t, hasDeadline)
+		return client, func() { closed = true }, nil
+	})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs(append([]string{"--pd=p:2379", "--keyspace-id=42"}, args...))
+	err := cmd.Execute()
+	require.True(t, closed)
+	return out.String(), err
+}
+
+func mustJSON(t *testing.T, value any) []byte {
+	t.Helper()
+	b, err := json.Marshal(value)
+	require.NoError(t, err)
+	return b
+}
+
+// Only the external GC service is substituted; command parsing, validation,
+// scope checks, timestamp conversion and output encoding run unchanged.
+type memoryGCClient struct {
+	state     gc.GCState
+	readErr   error
+	writeErr  error
+	mutations int
+}
+
+func (c *memoryGCClient) GetGCState(context.Context) (gc.GCState, error) {
+	return c.state, c.readErr
+}
+
+func (c *memoryGCClient) SetGCBarrier(_ context.Context, id string, ts uint64, ttl time.Duration) (*gc.GCBarrierInfo, error) {
+	c.mutations++
+	if c.writeErr != nil {
+		return nil, c.writeErr
+	}
+	b := gc.NewGCBarrierInfo(id, ts, ttl, time.Now())
+	for i, old := range c.state.GCBarriers {
+		if old.BarrierID == id {
+			c.state.GCBarriers[i] = b
+			return b, nil
+		}
+	}
+	c.state.GCBarriers = append(c.state.GCBarriers, b)
+	return b, nil
+}
+
+func (c *memoryGCClient) DeleteGCBarrier(_ context.Context, id string) (*gc.GCBarrierInfo, error) {
+	c.mutations++
+	if c.writeErr != nil {
+		return nil, c.writeErr
+	}
+	for i, b := range c.state.GCBarriers {
+		if b.BarrierID == id {
+			c.state.GCBarriers = append(c.state.GCBarriers[:i], c.state.GCBarriers[i+1:]...)
+			return b, nil
+		}
+	}
+	return nil, nil
+}


### PR DESCRIPTION
### What problem does this PR solve?

A stale TiCDC GC barrier can prevent obsolete data from being reclaimed. Operators need a way to inspect, update, and delete individual barriers so they can control how much history becomes eligible for GC.

This is a review-only draft and is not intended to be merged. The implementation is based on `v8.5.4-nextgen.202510.7` and uses that version's existing PD gRPC APIs.

Issue Number: None (review-only draft).

### What is changed and how does it work?

```commit-message
Add a standalone pd-gc-barrier CLI with show, set, and delete commands for explicitly selected keyspaces. Set creates or updates both the barrier timestamp and TTL, including non-expiring barriers.

Accept decimal TSO and timezone-bearing RFC3339 input, validate the requested GC scope, and preserve full TSO precision in JSON output. Support TLS credentials, command timeouts, and clear error reporting. Include unit tests, local NextGen PD integration coverage, and an English usage reference.
```

### Build

From the root of this PR's source checkout, run:

```bash
(cd tools && CGO_ENABLED=0 go build -tags nextgen -o ../bin/pd-gc-barrier ./pd-gc-barrier)
```

The executable is generated at `bin/pd-gc-barrier`.

### Check List

Tests

- Unit tests and local PD integration test: `go test -tags nextgen,without_dashboard,integration ./pd-gc-barrier -count=1 -timeout=5m` from `tools/`, with failpoints enabled and then disabled.
- Static checks: targeted `golangci-lint` passed for the tool and its tests.
- Manual executable checks: help, invalid keyspace IDs, TSO/TTL validation, TLS argument validation, connection timeout, nonzero error exit status, and stderr/stdout separation.

### Release note

```release-note
None.
```

