### PR TITLE
*: enable ignored lint checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,6 +27,7 @@ linters:
     - testifylint
     - unconvert
     - unparam
+    - wastedassign
     - whitespace
   settings:
     depguard:
@@ -50,7 +51,6 @@ linters:
     gocritic:
       disabled-checks:
         - regexpMust
-        - appendAssign
         - exitAfterDefer
         - ifElseChain
         - deprecatedComment
@@ -270,6 +270,7 @@ linters:
         - error-nil
         - expected-actual
         - formatter
+        - go-require
         - len
         - negative-positive
         - require-error
@@ -279,7 +280,6 @@ linters:
         - useless-assert
       disable:
         - float-compare
-        - go-require
   exclusions:
     generated: lax
     presets:
@@ -290,9 +290,6 @@ linters:
       - linters:
           - errcheck
         path: (pkg/mock/.*\.go)
-      - linters:
-          - errcheck
-        path: (pd-analysis|pd-api-bench|pd-backup|pd-ctl|pd-heartbeat-bench|pd-recover|pd-simulator|pd-tso-bench|pd-ut|regions-dump|stores-dump)
       - linters:
           - recvcheck
         path: pkg/response/region.go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,10 +50,8 @@ linters:
         - (github.com/tikv/pd/pkg/ratelimit.Runner).RunTask
     gocritic:
       disabled-checks:
-        - regexpMust
         - exitAfterDefer
         - ifElseChain
-        - deprecatedComment
     # govet:
     #   disable:
     #     - buildtag

--- a/pkg/mcs/router/server/grpc_service.go
+++ b/pkg/mcs/router/server/grpc_service.go
@@ -86,6 +86,8 @@ func (s *Service) BatchScanRegions(_ctx context.Context, request *pdpb.BatchScan
 }
 
 // ScanRegions implements the ScanRegions RPC method.
+//
+// Deprecated: use BatchScanRegions instead.
 func (s *Service) ScanRegions(_ctx context.Context, request *pdpb.ScanRegionsRequest) (*pdpb.ScanRegionsResponse, error) {
 	resp, err := grpcutil.ScanRegions(s.GetBasicCluster(), request, false)
 	grpcutil.RequestCounter("ScanRegions", request.GetHeader(), resp.GetHeader().GetError(), regionRequestCounter)

--- a/pkg/mcs/tso/server/server.go
+++ b/pkg/mcs/tso/server/server.go
@@ -392,7 +392,7 @@ func (s *Server) startServer() (err error) {
 func CreateServer(ctx context.Context, cfg *Config) *Server {
 	addr := cfg.GetAdvertiseListenAddr()
 	parsed, err := url.Parse(addr)
-	advertiseListenHost := ""
+	var advertiseListenHost string
 	if err != nil {
 		if _, _, splitErr := net.SplitHostPort(addr); splitErr != nil {
 			panic(fmt.Sprintf("invalid advertise listen address: %s", addr))

--- a/pkg/schedule/config/config.go
+++ b/pkg/schedule/config/config.go
@@ -17,6 +17,7 @@ package config
 import (
 	"encoding/json"
 	"math"
+	"slices"
 	"time"
 
 	"github.com/pingcap/errors"
@@ -171,7 +172,7 @@ func adjustSchedulers(v *SchedulerConfigs, defValue SchedulerConfigs) {
 		// Make a copy to avoid changing DefaultSchedulers unexpectedly.
 		// When reloading from storage, the config is passed to json.Unmarshal.
 		// Without clone, the DefaultSchedulers could be overwritten.
-		*v = append(defValue[:0:0], defValue...)
+		*v = slices.Clone(defValue)
 	}
 }
 
@@ -343,7 +344,7 @@ type ScheduleConfig struct {
 
 // Clone returns a cloned scheduling configuration.
 func (c *ScheduleConfig) Clone() *ScheduleConfig {
-	schedulers := append(c.Schedulers[:0:0], c.Schedulers...)
+	schedulers := slices.Clone(c.Schedulers)
 	var storeLimit map[uint64]StoreLimitConfig
 	if c.StoreLimit != nil {
 		storeLimit = make(map[uint64]StoreLimitConfig, len(c.StoreLimit))
@@ -760,7 +761,7 @@ type ReplicationConfig struct {
 
 // Clone makes a deep copy of the config.
 func (c *ReplicationConfig) Clone() *ReplicationConfig {
-	locationLabels := append(c.LocationLabels[:0:0], c.LocationLabels...)
+	locationLabels := slices.Clone(c.LocationLabels)
 	cfg := *c
 	cfg.LocationLabels = locationLabels
 	return &cfg

--- a/pkg/schedule/labeler/labeler.go
+++ b/pkg/schedule/labeler/labeler.go
@@ -141,6 +141,7 @@ func (l *RegionLabeler) loadRules() error {
 }
 
 // BuildRangeListLocked publishes pending derived rule-index updates.
+//
 // Deprecated: Unlock publishes them automatically.
 func (l *RegionLabeler) BuildRangeListLocked() {
 	l.ruleIndex.buildRanges()

--- a/pkg/schedule/schedulers/balance_region_test.go
+++ b/pkg/schedule/schedulers/balance_region_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/docker/go-units"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/pingcap/kvproto/pkg/metapb"
@@ -857,29 +858,37 @@ func TestBalanceRegionEmptyRegion(t *testing.T) {
 }
 
 func TestConcurrencyUpdateConfig(t *testing.T) {
+	as := assert.New(t)
 	re := require.New(t)
 	cancel, _, tc, oc := prepareSchedulersTest()
 	defer cancel()
 	hb, err := CreateScheduler(types.ScatterRangeScheduler, oc, storage.NewStorageWithMemoryBackend(), ConfigSliceDecoder(types.ScatterRangeScheduler, []string{"s_00", "s_50", "t"}))
 	sche := hb.(*scatterRangeScheduler)
 	re.NoError(err)
-	ch := make(chan struct{})
+	stopCh := make(chan struct{})
+	workerDone := make(chan struct{})
 	args := []string{"test", "s_00", "s_99"}
 	go func() {
+		defer close(workerDone)
 		for {
 			select {
-			case <-ch:
+			case <-stopCh:
 				return
 			default:
 			}
-			re.NoError(sche.config.buildWithArgs(args))
-			re.NoError(sche.config.persist())
+			if !as.NoError(sche.config.buildWithArgs(args)) {
+				return
+			}
+			if !as.NoError(sche.config.persist()) {
+				return
+			}
 		}
 	}()
 	for range 1000 {
 		sche.Schedule(tc, false)
 	}
-	ch <- struct{}{}
+	close(stopCh)
+	<-workerDone
 }
 
 func TestBalanceWhenRegionNotHeartbeat(t *testing.T) {

--- a/pkg/schedule/schedulers/hot_region_config.go
+++ b/pkg/schedule/schedulers/hot_region_config.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"slices"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -571,9 +572,9 @@ type prioritiesConfig struct {
 }
 
 func (conf *hotRegionSchedulerConfig) applyPrioritiesConfig(p prioritiesConfig) {
-	conf.ReadPriorities = append(p.read[:0:0], p.read...)
-	conf.WriteLeaderPriorities = append(p.writeLeader[:0:0], p.writeLeader...)
-	conf.WritePeerPriorities = append(p.writePeer[:0:0], p.writePeer...)
+	conf.ReadPriorities = slices.Clone(p.read)
+	conf.WriteLeaderPriorities = slices.Clone(p.writeLeader)
+	conf.WritePeerPriorities = slices.Clone(p.writePeer)
 }
 
 func getReadPriorities(c *prioritiesConfig) []string {

--- a/pkg/utils/grpcutil/cluster.go
+++ b/pkg/utils/grpcutil/cluster.go
@@ -114,6 +114,7 @@ func GetRegionByID(rc *core.BasicCluster, request *pdpb.GetRegionByIDRequest, is
 }
 
 // ScanRegions implements gRPC PDServer.
+//
 // Deprecated: use BatchScanRegions instead.
 func ScanRegions(rc *core.BasicCluster, request *pdpb.ScanRegionsRequest, isFollower bool) (resp *pdpb.ScanRegionsResponse, err error) {
 	if rc == nil {

--- a/pkg/utils/testutil/testutil.go
+++ b/pkg/utils/testutil/testutil.go
@@ -95,13 +95,22 @@ func NewRequestHeader(clusterID uint64) *pdpb.RequestHeader {
 	}
 }
 
-// MustNewGrpcClient must create a new PD grpc client.
-func MustNewGrpcClient(re *require.Assertions, addr string) (pdpb.PDClient, *grpc.ClientConn) {
+// NewGrpcClient creates a new PD grpc client.
+func NewGrpcClient(addr string) (pdpb.PDClient, *grpc.ClientConn, error) {
 	// TODO: use grpc.NewClient instead of grpc.Dial.
 	//nolint:staticcheck
 	conn, err := grpc.Dial(strings.TrimPrefix(addr, "http://"), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return nil, nil, err
+	}
+	return pdpb.NewPDClient(conn), conn, nil
+}
+
+// MustNewGrpcClient must create a new PD grpc client.
+func MustNewGrpcClient(re *require.Assertions, addr string) (pdpb.PDClient, *grpc.ClientConn) {
+	client, conn, err := NewGrpcClient(addr)
 	re.NoError(err)
-	return pdpb.NewPDClient(conn), conn
+	return client, conn
 }
 
 // CleanServer is used to clean data directory.

--- a/pkg/utils/testutil/testutil.go
+++ b/pkg/utils/testutil/testutil.go
@@ -15,6 +15,7 @@
 package testutil
 
 import (
+	"context"
 	"os"
 	"runtime"
 	"strings"
@@ -95,11 +96,11 @@ func NewRequestHeader(clusterID uint64) *pdpb.RequestHeader {
 	}
 }
 
-// NewGrpcClient creates a new PD grpc client.
-func NewGrpcClient(addr string) (pdpb.PDClient, *grpc.ClientConn, error) {
-	// TODO: use grpc.NewClient instead of grpc.Dial.
+// NewGRPCClient creates a new PD gRPC client.
+func NewGRPCClient(ctx context.Context, addr string) (pdpb.PDClient, *grpc.ClientConn, error) {
+	// TODO: use grpc.NewClient instead of grpc.DialContext.
 	//nolint:staticcheck
-	conn, err := grpc.Dial(strings.TrimPrefix(addr, "http://"), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.DialContext(ctx, strings.TrimPrefix(addr, "http://"), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -108,9 +109,11 @@ func NewGrpcClient(addr string) (pdpb.PDClient, *grpc.ClientConn, error) {
 
 // MustNewGrpcClient must create a new PD grpc client.
 func MustNewGrpcClient(re *require.Assertions, addr string) (pdpb.PDClient, *grpc.ClientConn) {
-	client, conn, err := NewGrpcClient(addr)
+	// TODO: use grpc.NewClient instead of grpc.Dial.
+	//nolint:staticcheck
+	conn, err := grpc.Dial(strings.TrimPrefix(addr, "http://"), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	re.NoError(err)
-	return client, conn
+	return pdpb.NewPDClient(conn), conn
 }
 
 // CleanServer is used to clean data directory.

--- a/pkg/utils/testutil/testutil.go
+++ b/pkg/utils/testutil/testutil.go
@@ -107,11 +107,11 @@ func NewGRPCClient(ctx context.Context, addr string) (pdpb.PDClient, *grpc.Clien
 	return pdpb.NewPDClient(conn), conn, nil
 }
 
-// MustNewGrpcClient must create a new PD grpc client.
-func MustNewGrpcClient(re *require.Assertions, addr string) (pdpb.PDClient, *grpc.ClientConn) {
-	// TODO: use grpc.NewClient instead of grpc.Dial.
+// MustNewGRPCClient must create a new PD gRPC client.
+func MustNewGRPCClient(ctx context.Context, re *require.Assertions, addr string) (pdpb.PDClient, *grpc.ClientConn) {
+	// TODO: use grpc.NewClient instead of grpc.DialContext.
 	//nolint:staticcheck
-	conn, err := grpc.Dial(strings.TrimPrefix(addr, "http://"), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.DialContext(ctx, strings.TrimPrefix(addr, "http://"), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	re.NoError(err)
 	return pdpb.NewPDClient(conn), conn
 }

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -594,7 +595,7 @@ func migrateConfigurationFromFile(meta *configutil.ConfigMetaData) error {
 
 // Clone returns a cloned PD server config.
 func (c *PDServerConfig) Clone() *PDServerConfig {
-	runtimeServices := append(c.RuntimeServices[:0:0], c.RuntimeServices...)
+	runtimeServices := slices.Clone(c.RuntimeServices)
 	cfg := *c
 	cfg.RuntimeServices = runtimeServices
 	return &cfg
@@ -954,7 +955,7 @@ func AdjustMetaServiceGroups(metaGroups map[string]string) error {
 // Clone makes a deep copy of the keyspace config.
 func (c *KeyspaceConfig) Clone() *KeyspaceConfig {
 	cfg := *c
-	cfg.PreAlloc = append(c.PreAlloc[:0:0], c.PreAlloc...)
+	cfg.PreAlloc = slices.Clone(c.PreAlloc)
 	if c.MetaServiceGroups != nil {
 		cfg.MetaServiceGroups = make(map[string]string, len(c.MetaServiceGroups))
 		for name, endpoint := range c.MetaServiceGroups {

--- a/tests/integrations/client/client_test.go
+++ b/tests/integrations/client/client_test.go
@@ -531,7 +531,7 @@ func (suite *followerForwardAndHandleTestSuite) SetupSuite() {
 	suite.endpoints = runServer(re, cluster)
 	re.NotEmpty(cluster.WaitLeader())
 	leader := cluster.GetLeaderServer()
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, leader.GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(suite.ctx, re, leader.GetAddr())
 	defer conn.Close()
 	suite.regionID = regionIDAllocator.alloc()
 	testutil.Eventually(re, func() bool {
@@ -1106,7 +1106,7 @@ func (suite *clientTestSuiteImpl) setup() {
 	leaderName := suite.cluster.WaitLeader()
 	re.NotEmpty(leaderName)
 	suite.srv = suite.cluster.GetLeaderServer().GetServer()
-	suite.grpcPDClient, suite.conn = testutil.MustNewGrpcClient(re, suite.srv.GetAddr())
+	suite.grpcPDClient, suite.conn = testutil.MustNewGRPCClient(suite.ctx, re, suite.srv.GetAddr())
 	suite.grpcSvr = &server.GrpcServer{Server: suite.srv}
 
 	tests.MustWaitLeader(re, []*server.Server{suite.srv})

--- a/tests/integrations/client/gc_test.go
+++ b/tests/integrations/client/gc_test.go
@@ -53,7 +53,7 @@ func TestServiceSafePointV2Operations(t *testing.T) {
 	})
 	re.NoError(err)
 
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, leaderServer.GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(ctx, re, leaderServer.GetAddr())
 	defer conn.Close()
 	header := testutil.NewRequestHeader(leaderServer.GetClusterID())
 

--- a/tests/integrations/client/global_config_test.go
+++ b/tests/integrations/client/global_config_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -41,7 +41,7 @@ import (
 const globalConfigPath = "/global/config/"
 
 type testReceiver struct {
-	re  *require.Assertions
+	as  *assert.Assertions
 	ctx context.Context
 	grpc.ServerStream
 }
@@ -49,7 +49,7 @@ type testReceiver struct {
 func (s testReceiver) Send(m *pdpb.WatchGlobalConfigResponse) error {
 	log.Info("received", zap.Any("received", m.GetChanges()))
 	for _, change := range m.GetChanges() {
-		s.re.Contains(change.Name, globalConfigPath+string(change.Payload))
+		s.as.Contains(change.Name, globalConfigPath+string(change.Payload))
 	}
 	return nil
 }
@@ -174,7 +174,7 @@ func (suite *globalConfigTestSuite) TestRejectInvalidConfigPath() {
 
 		err = suite.server.WatchGlobalConfig(&pdpb.WatchGlobalConfigRequest{
 			ConfigPath: configPath,
-		}, testReceiver{re: re, ctx: suite.server.Context()})
+		}, testReceiver{as: assert.New(suite.T()), ctx: suite.server.Context()})
 		re.Equal(codes.InvalidArgument, status.Code(err), configPath)
 	}
 }
@@ -265,7 +265,7 @@ func (suite *globalConfigTestSuite) TestResourceGroupControllerPrefixLoadCompati
 
 	err = suite.server.WatchGlobalConfig(&pdpb.WatchGlobalConfigRequest{
 		ConfigPath: controllerPath,
-	}, testReceiver{re: re, ctx: suite.server.Context()})
+	}, testReceiver{as: assert.New(suite.T()), ctx: suite.server.Context()})
 	re.Equal(codes.InvalidArgument, status.Code(err))
 }
 
@@ -455,14 +455,20 @@ func (suite *globalConfigTestSuite) TestWatch() {
 		}
 	}()
 	ctx, cancel := context.WithCancel(suite.server.Context())
-	defer cancel()
-	server := testReceiver{re: suite.Require(), ctx: ctx}
+	as := assert.New(suite.T())
+	server := testReceiver{as: as, ctx: ctx}
+	watchDone := make(chan struct{})
 	go func() {
+		defer close(watchDone)
 		err := suite.server.WatchGlobalConfig(&pdpb.WatchGlobalConfigRequest{
 			ConfigPath: globalConfigPath,
 			Revision:   0,
 		}, server)
-		re.NoError(err)
+		as.NoError(err)
+	}()
+	defer func() {
+		cancel()
+		<-watchDone
 	}()
 	for i := range 6 {
 		_, err := suite.server.GetClient().Put(suite.server.Context(), getEtcdPath(strconv.Itoa(i)), strconv.Itoa(i))

--- a/tests/integrations/client/router_client_test.go
+++ b/tests/integrations/client/router_client_test.go
@@ -74,7 +74,7 @@ func (suite *routerClientSuite) SetupSuite() {
 
 	re.NotEmpty(suite.cluster.WaitLeader())
 	leader := suite.cluster.GetLeaderServer()
-	suite.grpcPDClient, suite.conn = testutil.MustNewGrpcClient(re, leader.GetAddr())
+	suite.grpcPDClient, suite.conn = testutil.MustNewGRPCClient(suite.ctx, re, leader.GetAddr())
 	suite.client = setupCli(suite.ctx, re, endpoints,
 		opt.WithEnableRouterClient(suite.routerClientEnabled),
 		opt.WithEnableFollowerHandle(true))

--- a/tests/integrations/mcs/scheduling/server_test.go
+++ b/tests/integrations/mcs/scheduling/server_test.go
@@ -555,7 +555,7 @@ func (suite *serverTestSuite) TestForwardRegionHeartbeat() {
 		re.Empty(resp.GetHeader().GetError())
 	}
 
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, suite.pdLeader.GetServer().GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(suite.ctx, re, suite.pdLeader.GetServer().GetAddr())
 	defer conn.Close()
 	stream, err := grpcPDClient.RegionHeartbeat(suite.ctx)
 	re.NoError(err)
@@ -640,7 +640,7 @@ func (suite *serverTestSuite) TestForwardReportBuckets() {
 		re.Empty(resp.GetHeader().GetError())
 	}
 
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, suite.pdLeader.GetServer().GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(suite.ctx, re, suite.pdLeader.GetServer().GetAddr())
 	defer conn.Close()
 
 	// First create a region via region heartbeat
@@ -766,7 +766,7 @@ func (suite *serverTestSuite) TestStoreLimit() {
 	conf.MaxReplicas = 1
 	err = leaderServer.SetReplicationConfig(*conf)
 	re.NoError(err)
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, suite.pdLeader.GetServer().GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(suite.ctx, re, suite.pdLeader.GetServer().GetAddr())
 	defer conn.Close()
 	for i := uint64(1); i <= 2; i++ {
 		resp, err := grpcPDClient.PutStore(
@@ -1023,7 +1023,7 @@ func (suite *serverTestSuite) TestPrepareChecker() {
 	}
 
 	// Send enough regions to satisfy the prepare checker in the initial cluster
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, suite.pdLeader.GetServer().GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(suite.ctx, re, suite.pdLeader.GetServer().GetAddr())
 	defer conn.Close()
 	stream, err := grpcPDClient.RegionHeartbeat(suite.ctx)
 	re.NoError(err)
@@ -1244,7 +1244,7 @@ func (suite *serverTestSuite) TestBatchSplit() {
 		re.NoError(err)
 		re.Empty(resp.GetHeader().GetError())
 	}
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, suite.pdLeader.GetServer().GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(suite.ctx, re, suite.pdLeader.GetServer().GetAddr())
 	defer conn.Close()
 	stream, err := grpcPDClient.RegionHeartbeat(suite.ctx)
 	re.NoError(err)
@@ -1325,7 +1325,7 @@ func (suite *serverTestSuite) TestBatchSplitCompatibility() {
 		re.NoError(err)
 		re.Empty(resp.GetHeader().GetError())
 	}
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, suite.pdLeader.GetServer().GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(suite.ctx, re, suite.pdLeader.GetServer().GetAddr())
 	defer conn.Close()
 	stream, err := grpcPDClient.RegionHeartbeat(suite.ctx)
 	re.NoError(err)
@@ -1472,7 +1472,7 @@ func (suite *serverTestSuite) TestConcurrentBatchSplit() {
 		re.NoError(err)
 		re.Empty(resp.GetHeader().GetError())
 	}
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, suite.pdLeader.GetServer().GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(suite.ctx, re, suite.pdLeader.GetServer().GetAddr())
 	defer conn.Close()
 	stream, err := grpcPDClient.RegionHeartbeat(suite.ctx)
 	re.NoError(err)
@@ -1609,7 +1609,7 @@ func (suite *serverTestSuite) TestForwardSplitRegion() {
 	}
 
 	// Create a region via region heartbeat
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, suite.pdLeader.GetServer().GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(suite.ctx, re, suite.pdLeader.GetServer().GetAddr())
 	defer conn.Close()
 	stream, err := grpcPDClient.RegionHeartbeat(suite.ctx)
 	re.NoError(err)

--- a/tests/integrations/tso/consistency_test.go
+++ b/tests/integrations/tso/consistency_test.go
@@ -89,7 +89,7 @@ func (suite *tsoConsistencyTestSuite) SetupSuite() {
 	re.NoError(err)
 	backendEndpoints := suite.pdLeaderServer.GetAddr()
 	if suite.legacy {
-		suite.pdClient, suite.conn = testutil.MustNewGrpcClient(re, backendEndpoints)
+		suite.pdClient, suite.conn = testutil.MustNewGRPCClient(suite.ctx, re, backendEndpoints)
 	} else {
 		suite.tsoServer, suite.tsoServerCleanup = tests.StartSingleTSOTestServer(suite.ctx, re, backendEndpoints, tempurl.Alloc())
 		suite.tsoClientConn, suite.tsoClient = tso.MustNewGrpcClient(re, suite.tsoServer.GetAddr())

--- a/tests/integrations/tso/server_test.go
+++ b/tests/integrations/tso/server_test.go
@@ -87,7 +87,7 @@ func (suite *tsoServerTestSuite) SetupSuite() {
 	re.NoError(err)
 	backendEndpoints := suite.pdLeaderServer.GetAddr()
 	if suite.legacy {
-		suite.pdClient, suite.conn = testutil.MustNewGrpcClient(re, backendEndpoints)
+		suite.pdClient, suite.conn = testutil.MustNewGRPCClient(suite.ctx, re, backendEndpoints)
 	} else {
 		suite.tsoServer, suite.tsoServerCleanup = tests.StartSingleTSOTestServer(suite.ctx, re, backendEndpoints, tempurl.Alloc())
 		suite.tsoClientConn, suite.tsoClient = tso.MustNewGrpcClient(re, suite.tsoServer.GetAddr())

--- a/tests/scheduling_cluster.go
+++ b/tests/scheduling_cluster.go
@@ -125,7 +125,7 @@ func (tc *TestSchedulingCluster) WaitForPrimaryServing(re *require.Assertions) *
 		return tc.pd.GetLeaderServer().GetRaftCluster().IsServiceIndependent(constant.SchedulingServiceName)
 	})
 	// send a heartbeat immediately to make prepare checker pass
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, tc.pd.GetLeaderServer().GetServer().GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(tc.ctx, re, tc.pd.GetLeaderServer().GetServer().GetAddr())
 	defer conn.Close()
 	stream, err := grpcPDClient.RegionHeartbeat(tc.ctx)
 	re.NoError(err)

--- a/tests/server/api/api_test.go
+++ b/tests/server/api/api_test.go
@@ -1115,7 +1115,7 @@ func TestRemovingProgress(t *testing.T) {
 
 	re.NotEmpty(cluster.WaitLeader())
 	leader := cluster.GetLeaderServer()
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, leader.GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(t.Context(), re, leader.GetAddr())
 	defer conn.Close()
 	clusterID := leader.GetClusterID()
 	req := &pdpb.BootstrapRequest{
@@ -1431,7 +1431,7 @@ func TestSendApiWhenRestartRaftCluster(t *testing.T) {
 	re.NotEmpty(cluster.WaitLeader())
 	leader := cluster.GetLeaderServer()
 
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, leader.GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(t.Context(), re, leader.GetAddr())
 	defer conn.Close()
 	clusterID := leader.GetClusterID()
 	req := &pdpb.BootstrapRequest{
@@ -1478,7 +1478,7 @@ func TestPreparingProgress(t *testing.T) {
 
 	re.NotEmpty(cluster.WaitLeader())
 	leader := cluster.GetLeaderServer()
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, leader.GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(t.Context(), re, leader.GetAddr())
 	defer conn.Close()
 	clusterID := leader.GetClusterID()
 	req := &pdpb.BootstrapRequest{

--- a/tests/server/api/rule_test.go
+++ b/tests/server/api/rule_test.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
@@ -1179,6 +1180,7 @@ func (suite *ruleTestSuite) checkConcurrency(cluster *tests.TestCluster) {
 func (suite *ruleTestSuite) checkConcurrencyWith(cluster *tests.TestCluster,
 	genBundle func(int) []placement.GroupBundle,
 	checkBundle func([]placement.GroupBundle, int) bool) {
+	as := assert.New(suite.T())
 	re := suite.Require()
 	leaderServer := cluster.GetLeaderServer()
 	pdAddr := leaderServer.GetAddr()
@@ -1187,7 +1189,7 @@ func (suite *ruleTestSuite) checkConcurrencyWith(cluster *tests.TestCluster,
 		syncutil.RWMutex
 		val int
 	}{}
-	wg := sync.WaitGroup{}
+	wg := &sync.WaitGroup{}
 
 	for i := 1; i <= 10; i++ {
 		wg.Add(1)
@@ -1195,13 +1197,23 @@ func (suite *ruleTestSuite) checkConcurrencyWith(cluster *tests.TestCluster,
 			defer wg.Done()
 			bundle := genBundle(i)
 			data, err := json.Marshal(bundle)
-			re.NoError(err)
+			if !as.NoError(err) {
+				return
+			}
 			for range 10 {
 				expectResult.Lock()
-				err = testutil.CheckPostJSON(tests.TestDialClient, urlPrefix+"/config/placement-rule", data, testutil.StatusOK(re))
-				re.NoError(err)
-				expectResult.val = i
+				statusOK := false
+				err = testutil.CheckPostJSON(tests.TestDialClient, urlPrefix+"/config/placement-rule", data,
+					func(resp []byte, statusCode int, _ http.Header) {
+						statusOK = as.Equal(http.StatusOK, statusCode, "resp: "+string(resp))
+					})
+				if err == nil && statusOK {
+					expectResult.val = i
+				}
 				expectResult.Unlock()
+				if !as.NoError(err) || !statusOK {
+					return
+				}
 			}
 		}(i)
 	}

--- a/tests/server/apiv2/handlers/keyspace_test.go
+++ b/tests/server/apiv2/handlers/keyspace_test.go
@@ -198,12 +198,16 @@ func (suite *keyspaceTestSuite) TestUpdateKeyspaceConfigPreconditionsConcurrentS
 
 	nextKey := "next_file_id"
 	start := make(chan struct{})
-	results := make(chan int, 2)
+	type updateResult struct {
+		status int
+		body   string
+		err    error
+	}
+	results := make(chan updateResult, 2)
 
-	go func() {
+	update := func(next string) {
 		<-start
-		next := "1000"
-		status, body, _ := tryUpdateKeyspaceConfig(re, suite.server, created.Name, &handlers.UpdateConfigParams{
+		status, body, _, err := updateKeyspaceConfig(suite.server, created.Name, &handlers.UpdateConfigParams{
 			Config: map[string]*string{
 				nextKey: &next,
 			},
@@ -211,33 +215,20 @@ func (suite *keyspaceTestSuite) TestUpdateKeyspaceConfigPreconditionsConcurrentS
 				nextKey: nil,
 			},
 		})
-		if status != http.StatusOK && status != http.StatusConflict {
-			re.FailNow("unexpected status", "status=%d body=%s", status, body)
-		}
-		results <- status
-	}()
-	go func() {
-		<-start
-		next := "2000"
-		status, body, _ := tryUpdateKeyspaceConfig(re, suite.server, created.Name, &handlers.UpdateConfigParams{
-			Config: map[string]*string{
-				nextKey: &next,
-			},
-			Preconditions: map[string]*string{
-				nextKey: nil,
-			},
-		})
-		if status != http.StatusOK && status != http.StatusConflict {
-			re.FailNow("unexpected status", "status=%d body=%s", status, body)
-		}
-		results <- status
-	}()
+		results <- updateResult{status: status, body: body, err: err}
+	}
+	go update("1000")
+	go update("2000")
 
 	close(start)
 
-	s1 := <-results
-	s2 := <-results
-	re.ElementsMatch([]int{http.StatusOK, http.StatusConflict}, []int{s1, s2})
+	r1 := <-results
+	r2 := <-results
+	re.NoError(r1.err)
+	re.NoError(r2.err)
+	re.Contains([]int{http.StatusOK, http.StatusConflict}, r1.status, r1.body)
+	re.Contains([]int{http.StatusOK, http.StatusConflict}, r2.status, r2.body)
+	re.ElementsMatch([]int{http.StatusOK, http.StatusConflict}, []int{r1.status, r2.status})
 }
 
 func (suite *keyspaceTestSuite) TestUpdateKeyspaceState() {

--- a/tests/server/apiv2/handlers/keyspace_test.go
+++ b/tests/server/apiv2/handlers/keyspace_test.go
@@ -197,6 +197,8 @@ func (suite *keyspaceTestSuite) TestUpdateKeyspaceConfigPreconditionsConcurrentS
 	re.NotNil(created)
 
 	nextKey := "next_file_id"
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 	start := make(chan struct{})
 	type updateResult struct {
 		status int
@@ -207,7 +209,7 @@ func (suite *keyspaceTestSuite) TestUpdateKeyspaceConfigPreconditionsConcurrentS
 
 	update := func(next string) {
 		<-start
-		status, body, _, err := updateKeyspaceConfig(suite.server, created.Name, &handlers.UpdateConfigParams{
+		status, body, _, err := updateKeyspaceConfig(ctx, suite.server, created.Name, &handlers.UpdateConfigParams{
 			Config: map[string]*string{
 				nextKey: &next,
 			},

--- a/tests/server/apiv2/handlers/testutil.go
+++ b/tests/server/apiv2/handlers/testutil.go
@@ -155,21 +155,37 @@ func mustUpdateKeyspaceConfig(re *require.Assertions, server *tests.TestServer, 
 }
 
 func tryUpdateKeyspaceConfig(re *require.Assertions, server *tests.TestServer, name string, request *handlers.UpdateConfigParams) (int, string, *keyspacepb.KeyspaceMeta) {
+	status, body, meta, err := updateKeyspaceConfig(server, name, request)
+	re.NoError(err)
+	return status, body, meta
+}
+
+func updateKeyspaceConfig(server *tests.TestServer, name string, request *handlers.UpdateConfigParams) (int, string, *keyspacepb.KeyspaceMeta, error) {
 	data, err := json.Marshal(request)
-	re.NoError(err)
+	if err != nil {
+		return 0, "", nil, err
+	}
 	httpReq, err := http.NewRequest(http.MethodPatch, server.GetAddr()+keyspacesPrefix+"/"+name+"/config", bytes.NewBuffer(data))
-	re.NoError(err)
+	if err != nil {
+		return 0, "", nil, err
+	}
 	resp, err := tests.TestDialClient.Do(httpReq)
-	re.NoError(err)
+	if err != nil {
+		return 0, "", nil, err
+	}
 	defer resp.Body.Close()
 	data, err = io.ReadAll(resp.Body)
-	re.NoError(err)
+	if err != nil {
+		return 0, "", nil, err
+	}
 	if resp.StatusCode != http.StatusOK {
-		return resp.StatusCode, string(data), nil
+		return resp.StatusCode, string(data), nil, nil
 	}
 	meta := &handlers.KeyspaceMeta{}
-	re.NoError(json.Unmarshal(data, meta))
-	return resp.StatusCode, string(data), meta.KeyspaceMeta
+	if err := json.Unmarshal(data, meta); err != nil {
+		return 0, "", nil, err
+	}
+	return resp.StatusCode, string(data), meta.KeyspaceMeta, nil
 }
 
 func mustLoadKeyspaces(re *require.Assertions, server *tests.TestServer, name string) *keyspacepb.KeyspaceMeta {

--- a/tests/server/apiv2/handlers/testutil.go
+++ b/tests/server/apiv2/handlers/testutil.go
@@ -16,6 +16,7 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -155,17 +156,17 @@ func mustUpdateKeyspaceConfig(re *require.Assertions, server *tests.TestServer, 
 }
 
 func tryUpdateKeyspaceConfig(re *require.Assertions, server *tests.TestServer, name string, request *handlers.UpdateConfigParams) (int, string, *keyspacepb.KeyspaceMeta) {
-	status, body, meta, err := updateKeyspaceConfig(server, name, request)
+	status, body, meta, err := updateKeyspaceConfig(context.Background(), server, name, request)
 	re.NoError(err)
 	return status, body, meta
 }
 
-func updateKeyspaceConfig(server *tests.TestServer, name string, request *handlers.UpdateConfigParams) (int, string, *keyspacepb.KeyspaceMeta, error) {
+func updateKeyspaceConfig(ctx context.Context, server *tests.TestServer, name string, request *handlers.UpdateConfigParams) (int, string, *keyspacepb.KeyspaceMeta, error) {
 	data, err := json.Marshal(request)
 	if err != nil {
 		return 0, "", nil, err
 	}
-	httpReq, err := http.NewRequest(http.MethodPatch, server.GetAddr()+keyspacesPrefix+"/"+name+"/config", bytes.NewBuffer(data))
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPatch, server.GetAddr()+keyspacesPrefix+"/"+name+"/config", bytes.NewBuffer(data))
 	if err != nil {
 		return 0, "", nil, err
 	}

--- a/tests/server/cluster/cluster_test.go
+++ b/tests/server/cluster/cluster_test.go
@@ -344,6 +344,7 @@ func TestStaleRegion(t *testing.T) {
 
 // Ref https://github.com/tikv/pd/issues/9221
 func TestConcurrencyGetPutConfig(t *testing.T) {
+	as := assert.New(t)
 	re := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -367,16 +368,28 @@ func TestConcurrencyGetPutConfig(t *testing.T) {
 	re.Len(region.GetPeers(), 1)
 	peer := region.GetPeers()[0]
 
-	wg := sync.WaitGroup{}
+	wg := &sync.WaitGroup{}
 	for i := range 10 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			for j := range 100 {
 				storeID := peer.GetStoreId()
-				client, conn := testutil.MustNewGrpcClient(re, leaderServer.GetAddr())
+				client, conn, err := testutil.NewGrpcClient(leaderServer.GetAddr())
+				if !as.NoError(err) {
+					return
+				}
 				defer conn.Close()
-				store := getStore(re, clusterID, client, storeID)
+				resp, err := client.GetStore(context.Background(), &pdpb.GetStoreRequest{
+					Header:  testutil.NewRequestHeader(clusterID),
+					StoreId: storeID,
+				})
+				if !as.NoError(err) ||
+					!as.Equal(pdpb.ErrorType_OK, resp.GetHeader().GetError().GetType()) ||
+					!as.Equal(storeID, resp.GetStore().GetId()) {
+					return
+				}
+				store := resp.GetStore()
 				store.Address = "mock://tikv-1:1"
 				store.Labels = []*metapb.StoreLabel{
 					{
@@ -384,8 +397,10 @@ func TestConcurrencyGetPutConfig(t *testing.T) {
 						Value: "testValue_" + strconv.Itoa(i) + "_" + strconv.Itoa(j),
 					},
 				}
-				_, err := putStore(grpcPDClient, clusterID, store)
-				re.NoError(err)
+				_, err = putStore(grpcPDClient, clusterID, store)
+				if !as.NoError(err) {
+					return
+				}
 			}
 		}()
 	}

--- a/tests/server/cluster/cluster_test.go
+++ b/tests/server/cluster/cluster_test.go
@@ -87,7 +87,7 @@ func TestBootstrap(t *testing.T) {
 
 	tc.WaitLeader()
 	leaderServer := tc.GetLeaderServer()
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, leaderServer.GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(t.Context(), re, leaderServer.GetAddr())
 	defer conn.Close()
 	clusterID := leaderServer.GetClusterID()
 
@@ -128,7 +128,7 @@ func TestDamagedRegion(t *testing.T) {
 
 	tc.WaitLeader()
 	leaderServer := tc.GetLeaderServer()
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, leaderServer.GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(t.Context(), re, leaderServer.GetAddr())
 	defer conn.Close()
 	clusterID := leaderServer.GetClusterID()
 	bootstrapCluster(re, clusterID, grpcPDClient)
@@ -213,7 +213,7 @@ func TestRegionStatistics(t *testing.T) {
 
 	leaderName := tc.WaitLeader()
 	leaderServer := tc.GetLeaderServer()
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, leaderServer.GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(t.Context(), re, leaderServer.GetAddr())
 	defer conn.Close()
 	clusterID := leaderServer.GetClusterID()
 	bootstrapCluster(re, clusterID, grpcPDClient)
@@ -308,7 +308,7 @@ func TestStaleRegion(t *testing.T) {
 
 	tc.WaitLeader()
 	leaderServer := tc.GetLeaderServer()
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, leaderServer.GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(t.Context(), re, leaderServer.GetAddr())
 	defer conn.Close()
 	clusterID := leaderServer.GetClusterID()
 	bootstrapCluster(re, clusterID, grpcPDClient)
@@ -357,7 +357,7 @@ func TestConcurrencyGetPutConfig(t *testing.T) {
 
 	tc.WaitLeader()
 	leaderServer := tc.GetServer(tc.GetLeader())
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, leaderServer.GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(t.Context(), re, leaderServer.GetAddr())
 	defer conn.Close()
 	clusterID := leaderServer.GetClusterID()
 	bootstrapCluster(re, clusterID, grpcPDClient)
@@ -420,7 +420,7 @@ func TestGetPutConfig(t *testing.T) {
 
 	tc.WaitLeader()
 	leaderServer := tc.GetLeaderServer()
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, leaderServer.GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(t.Context(), re, leaderServer.GetAddr())
 	defer conn.Close()
 	clusterID := leaderServer.GetClusterID()
 	bootstrapCluster(re, clusterID, grpcPDClient)
@@ -660,7 +660,7 @@ func TestRaftClusterRestart(t *testing.T) {
 
 	tc.WaitLeader()
 	leaderServer := tc.GetLeaderServer()
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, leaderServer.GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(t.Context(), re, leaderServer.GetAddr())
 	defer conn.Close()
 	clusterID := leaderServer.GetClusterID()
 	bootstrapCluster(re, clusterID, grpcPDClient)
@@ -693,7 +693,7 @@ func TestRaftClusterMultipleRestart(t *testing.T) {
 
 	tc.WaitLeader()
 	leaderServer := tc.GetLeaderServer()
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, leaderServer.GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(t.Context(), re, leaderServer.GetAddr())
 	defer conn.Close()
 	clusterID := leaderServer.GetClusterID()
 	bootstrapCluster(re, clusterID, grpcPDClient)
@@ -836,7 +836,7 @@ func TestGetPDMembers(t *testing.T) {
 
 	tc.WaitLeader()
 	leaderServer := tc.GetLeaderServer()
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, leaderServer.GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(t.Context(), re, leaderServer.GetAddr())
 	defer conn.Close()
 	clusterID := leaderServer.GetClusterID()
 	req := &pdpb.GetMembersRequest{Header: testutil.NewRequestHeader(clusterID)}
@@ -857,7 +857,7 @@ func TestNotLeader(t *testing.T) {
 	re.NoError(tc.RunInitialServers())
 	tc.WaitLeader()
 	followerServer := tc.GetServer(tc.GetFollower())
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, followerServer.GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(t.Context(), re, followerServer.GetAddr())
 	defer conn.Close()
 	clusterID := followerServer.GetClusterID()
 	req := &pdpb.AllocIDRequest{Header: testutil.NewRequestHeader(clusterID)}
@@ -882,7 +882,7 @@ func TestStoreVersionChange(t *testing.T) {
 
 	tc.WaitLeader()
 	leaderServer := tc.GetLeaderServer()
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, leaderServer.GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(t.Context(), re, leaderServer.GetAddr())
 	defer conn.Close()
 	clusterID := leaderServer.GetClusterID()
 	bootstrapCluster(re, clusterID, grpcPDClient)
@@ -925,7 +925,7 @@ func TestConcurrentHandleRegion(t *testing.T) {
 	re.NoError(err)
 	tc.WaitLeader()
 	leaderServer := tc.GetLeaderServer()
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, leaderServer.GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(t.Context(), re, leaderServer.GetAddr())
 	defer conn.Close()
 	clusterID := leaderServer.GetClusterID()
 	bootstrapCluster(re, clusterID, grpcPDClient)
@@ -1051,7 +1051,7 @@ func TestSetScheduleOpt(t *testing.T) {
 
 	tc.WaitLeader()
 	leaderServer := tc.GetLeaderServer()
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, leaderServer.GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(t.Context(), re, leaderServer.GetAddr())
 	defer conn.Close()
 	clusterID := leaderServer.GetClusterID()
 	bootstrapCluster(re, clusterID, grpcPDClient)
@@ -1214,7 +1214,7 @@ func TestTiFlashWithPlacementRules(t *testing.T) {
 	re.NoError(err)
 	tc.WaitLeader()
 	leaderServer := tc.GetLeaderServer()
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, leaderServer.GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(t.Context(), re, leaderServer.GetAddr())
 	defer conn.Close()
 	clusterID := leaderServer.GetClusterID()
 	bootstrapCluster(re, clusterID, grpcPDClient)
@@ -1268,7 +1268,7 @@ func TestReplicationModeStatus(t *testing.T) {
 	re.NoError(err)
 	tc.WaitLeader()
 	leaderServer := tc.GetLeaderServer()
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, leaderServer.GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(t.Context(), re, leaderServer.GetAddr())
 	defer conn.Close()
 	clusterID := leaderServer.GetClusterID()
 	req := newBootstrapRequest(clusterID)
@@ -1370,7 +1370,7 @@ func TestOfflineStoreLimit(t *testing.T) {
 	tc.WaitLeader()
 	leaderServer := tc.GetLeaderServer()
 	leaderServer.GetPersistOptions().SetMaxReplicas(1) // ensure it is successful to offline store
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, leaderServer.GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(t.Context(), re, leaderServer.GetAddr())
 	defer conn.Close()
 	clusterID := leaderServer.GetClusterID()
 	bootstrapCluster(re, clusterID, grpcPDClient)
@@ -1465,7 +1465,7 @@ func TestUpgradeStoreLimit(t *testing.T) {
 	re.NoError(err)
 	tc.WaitLeader()
 	leaderServer := tc.GetLeaderServer()
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, leaderServer.GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(t.Context(), re, leaderServer.GetAddr())
 	defer conn.Close()
 	clusterID := leaderServer.GetClusterID()
 	bootstrapCluster(re, clusterID, grpcPDClient)
@@ -1524,7 +1524,7 @@ func TestStaleTermHeartbeat(t *testing.T) {
 	re.NoError(err)
 	tc.WaitLeader()
 	leaderServer := tc.GetLeaderServer()
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, leaderServer.GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(t.Context(), re, leaderServer.GetAddr())
 	defer conn.Close()
 	clusterID := leaderServer.GetClusterID()
 	bootstrapCluster(re, clusterID, grpcPDClient)
@@ -1623,7 +1623,7 @@ func TestTransferLeaderForScheduler(t *testing.T) {
 	re.NotNil(rc)
 
 	storesNum := 2
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, leaderServer.GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(t.Context(), re, leaderServer.GetAddr())
 	defer conn.Close()
 	for i := 1; i <= storesNum; i++ {
 		store := &metapb.Store{
@@ -1797,7 +1797,7 @@ func TestMinResolvedTS(t *testing.T) {
 	tc.WaitLeader()
 	leaderServer := tc.GetLeaderServer()
 	id := leaderServer.GetAllocator()
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, leaderServer.GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(t.Context(), re, leaderServer.GetAddr())
 	defer conn.Close()
 	clusterID := leaderServer.GetClusterID()
 	bootstrapCluster(re, clusterID, grpcPDClient)
@@ -1977,7 +1977,7 @@ func TestExternalTimestamp(t *testing.T) {
 	re.NoError(err)
 	tc.WaitLeader()
 	leaderServer := tc.GetLeaderServer()
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, leaderServer.GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(t.Context(), re, leaderServer.GetAddr())
 	defer conn.Close()
 	clusterID := leaderServer.GetClusterID()
 	bootstrapCluster(re, clusterID, grpcPDClient)
@@ -2197,7 +2197,7 @@ func TestPutStoreInvalidEngineLabel(t *testing.T) {
 	re.NoError(err)
 	tc.WaitLeader()
 	leaderServer := tc.GetLeaderServer()
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, leaderServer.GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(t.Context(), re, leaderServer.GetAddr())
 	defer conn.Close()
 	clusterID := leaderServer.GetClusterID()
 

--- a/tests/server/cluster/cluster_test.go
+++ b/tests/server/cluster/cluster_test.go
@@ -375,7 +375,7 @@ func TestConcurrencyGetPutConfig(t *testing.T) {
 			defer wg.Done()
 			for j := range 100 {
 				storeID := peer.GetStoreId()
-				client, conn, err := testutil.NewGrpcClient(leaderServer.GetAddr())
+				client, conn, err := testutil.NewGRPCClient(ctx, leaderServer.GetAddr())
 				if !as.NoError(err) {
 					return
 				}

--- a/tests/server/gc/gc_test.go
+++ b/tests/server/gc/gc_test.go
@@ -87,7 +87,7 @@ func newGCStateLeaderTransitionCluster(t *testing.T) (*tests.TestCluster, *pdpb.
 }
 
 func getGCStateFromAddr(ctx context.Context, re *require.Assertions, addr string, req *pdpb.GetGCStateRequest) (*pdpb.GetGCStateResponse, error) {
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, addr)
+	grpcPDClient, conn := testutil.MustNewGRPCClient(ctx, re, addr)
 	defer conn.Close()
 	return grpcPDClient.GetGCState(ctx, req)
 }
@@ -162,7 +162,7 @@ func TestGCOperations(t *testing.T) {
 	})
 	re.NoError(err)
 
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, leaderServer.GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(t.Context(), re, leaderServer.GetAddr())
 	defer conn.Close()
 	clusterID := leaderServer.GetClusterID()
 	header := testutil.NewRequestHeader(clusterID)
@@ -725,7 +725,7 @@ func TestGetGCStateReturnsCachedStateIfLeaderLostBeforeReply(t *testing.T) {
 	point := enableBlockingFailpoint(re, postGetGCStateCallFailpoint)
 	defer point.releaseAndDisable(re)
 
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, leaderServer.GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(t.Context(), re, leaderServer.GetAddr())
 	defer conn.Close()
 
 	type result struct {
@@ -791,7 +791,7 @@ func TestGetGCStateReturnsCachedStateAfterLeadershipRecovery(t *testing.T) {
 	point := enableBlockingFailpoint(re, postGetGCStateCallFailpoint)
 	defer point.releaseAndDisable(re)
 
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, leaderServer.GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(t.Context(), re, leaderServer.GetAddr())
 	defer conn.Close()
 
 	type result struct {
@@ -850,7 +850,7 @@ func TestGetGCStateSlowPathReadsLatestStateIfLeaderLostBeforeRead(t *testing.T) 
 	point := enableBlockingFailpoint(re, getGCStateBeforeSlowPathFailpoint)
 	defer point.releaseAndDisable(re)
 
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, leaderServer.GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(t.Context(), re, leaderServer.GetAddr())
 	defer conn.Close()
 
 	type result struct {

--- a/tests/server/id/id_test.go
+++ b/tests/server/id/id_test.go
@@ -109,7 +109,7 @@ func (s *idAllocatorTestSuite) checkCommand(cluster *tests.TestCluster) {
 	leaderServer := cluster.GetLeaderServer()
 	req := &pdpb.AllocIDRequest{Header: testutil.NewRequestHeader(leaderServer.GetClusterID())}
 
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, leaderServer.GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(s.T().Context(), re, leaderServer.GetAddr())
 	defer conn.Close()
 	var last uint64
 	for range 2 * id.DefaultAllocStep {

--- a/tests/server/member/member_test.go
+++ b/tests/server/member/member_test.go
@@ -398,7 +398,7 @@ func TestGetLeader(t *testing.T) {
 	re.NotNil(leaderServer)
 
 	// Send requests after server has started.
-	go sendRequest(re, wg, done, leaderServer.GetAddr())
+	go sendRequest(ctx, re, wg, done, leaderServer.GetAddr())
 	time.Sleep(100 * time.Millisecond)
 
 	re.NotNil(leaderServer.GetLeader())
@@ -407,7 +407,7 @@ func TestGetLeader(t *testing.T) {
 	wg.Wait()
 }
 
-func sendRequest(re *require.Assertions, wg *sync.WaitGroup, done <-chan bool, addr string) {
+func sendRequest(ctx context.Context, re *require.Assertions, wg *sync.WaitGroup, done <-chan bool, addr string) {
 	defer wg.Done()
 
 	req := &pdpb.AllocIDRequest{Header: testutil.NewRequestHeader(0)}
@@ -419,9 +419,9 @@ func sendRequest(re *require.Assertions, wg *sync.WaitGroup, done <-chan bool, a
 		default:
 			// We don't need to check the response and error,
 			// just make sure the server will not panic.
-			grpcPDClient, conn := testutil.MustNewGrpcClient(re, addr)
+			grpcPDClient, conn := testutil.MustNewGRPCClient(ctx, re, addr)
 			if grpcPDClient != nil {
-				_, _ = grpcPDClient.AllocID(context.Background(), req)
+				_, _ = grpcPDClient.AllocID(ctx, req)
 			}
 			if conn != nil {
 				conn.Close()

--- a/tests/server/server_test.go
+++ b/tests/server/server_test.go
@@ -159,7 +159,7 @@ func TestGRPCRateLimit(t *testing.T) {
 	leaderServer := cluster.GetServer(leader)
 	clusterID := leaderServer.GetClusterID()
 	addr := leaderServer.GetAddr()
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, addr)
+	grpcPDClient, conn := testutil.MustNewGRPCClient(t.Context(), re, addr)
 	defer conn.Close()
 	err = leaderServer.BootstrapCluster()
 	re.NoError(err)
@@ -240,7 +240,7 @@ func TestGRPCRateLimit(t *testing.T) {
 		}
 	}()
 
-	grpcPDClient1, conn1 := testutil.MustNewGrpcClient(re, addr)
+	grpcPDClient1, conn1 := testutil.MustNewGRPCClient(t.Context(), re, addr)
 	defer conn1.Close()
 	go func() {
 		defer wg.Done()

--- a/tests/server/tso/tso_proxy_test.go
+++ b/tests/server/tso/tso_proxy_test.go
@@ -76,7 +76,7 @@ func (s *tsoProxyTestSuite) SetupTest() {
 		}
 	}
 
-	s.pdClient, s.conn = testutil.MustNewGrpcClient(re, s.follower.GetAddr())
+	s.pdClient, s.conn = testutil.MustNewGRPCClient(s.T().Context(), re, s.follower.GetAddr())
 	clusterID := s.leader.GetClusterID()
 	s.defaultReq = &pdpb.TsoRequest{
 		Header: testutil.NewRequestHeader(clusterID),
@@ -145,7 +145,7 @@ func (s *tsoProxyTestSuite) verifyProxyIsHealthyWith(client pdpb.PD_TsoClient) {
 
 func (s *tsoProxyTestSuite) TestRejectFollowerForwardedHost() {
 	re := s.Require()
-	client, conn := testutil.MustNewGrpcClient(re, s.leader.GetAddr())
+	client, conn := testutil.MustNewGRPCClient(s.T().Context(), re, s.leader.GetAddr())
 	defer conn.Close()
 
 	s.verifyForwardedHostRejected(client, s.follower.GetAddr())

--- a/tests/server/tso/tso_test.go
+++ b/tests/server/tso/tso_test.go
@@ -81,7 +81,7 @@ func (s *tsoTestSuite) checkRequestFollower(cluster *tests.TestCluster) {
 	}
 	re.NotNil(followerServer)
 
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, followerServer.GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(s.T().Context(), re, followerServer.GetAddr())
 	defer conn.Close()
 	clusterID := followerServer.GetClusterID()
 	req := &pdpb.TsoRequest{
@@ -128,7 +128,7 @@ func (s *tsoTestSuite) checkDelaySyncTimestamp(cluster *tests.TestCluster) {
 	}
 	re.NotNil(nextLeaderServer)
 
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, nextLeaderServer.GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(s.T().Context(), re, nextLeaderServer.GetAddr())
 	defer conn.Close()
 	clusterID := nextLeaderServer.GetClusterID()
 	req := &pdpb.TsoRequest{
@@ -177,7 +177,7 @@ func (s *tsoTestSuite) checkLogicalOverflow(cluster *tests.TestCluster) {
 
 	leaderServer := cluster.GetLeaderServer()
 	re.NotNil(leaderServer)
-	grpcPDClient, conn := testutil.MustNewGrpcClient(re, leaderServer.GetAddr())
+	grpcPDClient, conn := testutil.MustNewGRPCClient(s.T().Context(), re, leaderServer.GetAddr())
 	defer conn.Close()
 	clusterID := leaderServer.GetClusterID()
 

--- a/tools/pd-ctl/tests/config/config_test.go
+++ b/tools/pd-ctl/tests/config/config_test.go
@@ -17,6 +17,7 @@ package config_test
 import (
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
@@ -524,7 +525,7 @@ func (suite *configTestSuite) checkConfigForwardControl(cluster *pdTests.TestClu
 	// inject different rule to scheduling server
 	if sche := cluster.GetSchedulingPrimaryServer(); sche != nil {
 		ruleManager := sche.GetCluster().GetRuleManager()
-		ruleManager.SetAllGroupBundles([]placement.GroupBundle{{
+		re.NoError(ruleManager.SetAllGroupBundles([]placement.GroupBundle{{
 			ID:       placement.DefaultGroupID,
 			Index:    233,
 			Override: true,
@@ -544,11 +545,11 @@ func (suite *configTestSuite) checkConfigForwardControl(cluster *pdTests.TestClu
 					Count:   3,
 				},
 			},
-		}}, true)
+		}}, true))
 		re.Len(ruleManager.GetAllRules(), 2)
 		defer func() {
 			bundles := leaderServer.GetRaftCluster().GetRuleManager().GetAllGroupBundles()
-			ruleManager.SetAllGroupBundles(bundles, true)
+			re.NoError(ruleManager.SetAllGroupBundles(bundles, true))
 		}()
 	}
 
@@ -610,7 +611,7 @@ func (suite *configTestSuite) checkPlacementRules(cluster *pdTests.TestCluster) 
 	})
 	b, err := json.Marshal(rules)
 	re.NoError(err)
-	os.WriteFile(fname, b, 0600)
+	re.NoError(os.WriteFile(fname, b, 0600))
 	_, err = tests.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "save", "--in="+fname)
 	re.NoError(err)
 
@@ -626,7 +627,7 @@ func (suite *configTestSuite) checkPlacementRules(cluster *pdTests.TestCluster) 
 	rules[0].Count = 0
 	b, err = json.Marshal(rules)
 	re.NoError(err)
-	os.WriteFile(fname, b, 0600)
+	re.NoError(os.WriteFile(fname, b, 0600))
 	_, err = tests.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "save", "--in="+fname)
 	re.NoError(err)
 	checkShowRuleKey(re, pdAddr, [][2]string{{placement.DefaultGroupID, "test1"}}, "--group=pd")
@@ -1178,7 +1179,7 @@ func (suite *configTestSuite) checkUpdateDefaultReplicaConfig(cluster *pdTests.T
 	checkRuleIsolationLevel("host")
 
 	// update unsuccessfully when many rule exists.
-	fname := suite.T().TempDir()
+	fname := filepath.Join(suite.T().TempDir(), "rules.json")
 	rules := []placement.Rule{
 		{
 			GroupID: placement.DefaultGroupID,
@@ -1189,7 +1190,7 @@ func (suite *configTestSuite) checkUpdateDefaultReplicaConfig(cluster *pdTests.T
 	}
 	b, err := json.Marshal(rules)
 	re.NoError(err)
-	os.WriteFile(fname, b, 0600)
+	re.NoError(os.WriteFile(fname, b, 0600))
 	_, err = tests.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "save", "--in="+fname)
 	re.NoError(err)
 	checkMaxReplicas(3)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #4322

This is a follow-up to #11199. Several lint checks still require changes to
error handling or concurrent tests before they can be enabled safely.

### What is changed and how does it work?

```commit-message
Enable appendAssign, wastedassign, errcheck for tools, and
testifylint/go-require.

Preserve slice-copy semantics with slices.Clone, propagate helper errors,
and make concurrent test assertions safe by joining workers before tests
finish.
```

### Check List

Tests

- Unit test
- Integration test

Code changes

- Has the configuration change

### Release note

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved error handling and assertion behavior across concurrency, integration, API, and configuration tests.
  * Added safer cancellation, cleanup, and completion checks for asynchronous operations.
  * Added validation for previously unchecked file, rule, and request operations.
  * Updated test connections to support cancellation through test contexts.

* **Documentation**
  * Clarified that the ScanRegions API is deprecated and that BatchScanRegions should be used instead.

* **Chores**
  * Expanded static analysis checks and removed selected error-checking exclusions.
  * Simplified internal test and configuration utilities without changing runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->