### PR TITLE
tests: stabilize asynchronous next-gen tests

### DIFF
--- a/tests/cluster.go
+++ b/tests/cluster.go
@@ -875,6 +875,17 @@ func (c *TestCluster) GetLeaderServer() *TestServer {
 // WaitLeader is used to get leader.
 // If it exceeds the maximum number of loops, it will return an empty string.
 func (c *TestCluster) WaitLeader(ops ...WaitOption) string {
+	return c.waitLeaderExcept("", ops...)
+}
+
+// WaitLeaderChange waits until all running servers agree on a leader that is
+// different from oldLeader. If it exceeds the maximum number of loops, it will
+// return an empty string.
+func (c *TestCluster) WaitLeaderChange(oldLeader string, ops ...WaitOption) string {
+	return c.waitLeaderExcept(oldLeader, ops...)
+}
+
+func (c *TestCluster) waitLeaderExcept(oldLeader string, ops ...WaitOption) string {
 	option := &WaitOp{
 		retryTimes:   WaitLeaderRetryTimes,
 		waitInterval: WaitLeaderCheckInterval,
@@ -897,7 +908,7 @@ func (c *TestCluster) WaitLeader(ops ...WaitOption) string {
 			}
 		}
 		for name, num := range counter {
-			if num == running && c.GetServer(name).IsLeader() {
+			if name != oldLeader && num == running && c.GetServer(name).IsLeader() {
 				time.Sleep(WaitLeaderReturnDelay)
 				return name
 			}

--- a/tests/integrations/client/client_test.go
+++ b/tests/integrations/client/client_test.go
@@ -201,10 +201,10 @@ func TestLeaderTransferAndMoveCluster(t *testing.T) {
 	// Transfer leader.
 	for range 3 {
 		oldLeaderName := cluster.WaitLeader()
-		err := cluster.GetServer(oldLeaderName).ResignLeader()
+		err := cluster.GetServer(oldLeaderName).ResignLeaderWithRetry()
 		re.NoError(err)
-		newLeaderName := cluster.WaitLeader()
-		re.NotEqual(oldLeaderName, newLeaderName)
+		newLeaderName := cluster.WaitLeaderChange(oldLeaderName)
+		re.NotEmpty(newLeaderName)
 	}
 
 	// ABC->ABCDEF
@@ -252,11 +252,10 @@ func TestGetTSAfterTransferLeader(t *testing.T) {
 		leaderSwitched.Store(true)
 		return nil
 	})
-	err = cluster.GetServer(leader).ResignLeader()
+	err = cluster.GetServer(leader).ResignLeaderWithRetry()
 	re.NoError(err)
-	newLeader := cluster.WaitLeader()
+	newLeader := cluster.WaitLeaderChange(leader)
 	re.NotEmpty(newLeader)
-	re.NotEqual(leader, newLeader)
 	leader = cluster.WaitLeader()
 	re.NotEmpty(leader)
 	err = cli.GetServiceDiscovery().CheckMemberChanged()
@@ -643,8 +642,9 @@ func (suite *followerForwardAndHandleTestSuite) TestGetTsoByFollowerForwarding2(
 	})
 
 	lastTS = checkTS(re, cli, lastTS)
-	re.NoError(suite.cluster.GetLeaderServer().ResignLeader())
-	re.NotEmpty(suite.cluster.WaitLeader())
+	oldLeaderName := suite.cluster.WaitLeader()
+	re.NoError(suite.cluster.GetServer(oldLeaderName).ResignLeaderWithRetry())
+	re.NotEmpty(suite.cluster.WaitLeaderChange(oldLeaderName))
 	lastTS = checkTS(re, cli, lastTS)
 
 	re.NoError(failpoint.Disable("github.com/tikv/pd/client/clients/tso/unreachableNetwork"))
@@ -984,9 +984,8 @@ func TestConfigTTLAfterTransferLeader(t *testing.T) {
 			!options.IsLocationReplacementEnabled()
 	})
 	re.NoError(cluster.GetServer(leaderName).ResignLeaderWithRetry())
-	newLeaderName := cluster.WaitLeader()
+	newLeaderName := cluster.WaitLeaderChange(leaderName)
 	re.NotEmpty(newLeaderName)
-	re.NotEqual(leaderName, newLeaderName)
 	leader = cluster.GetServer(newLeaderName)
 	re.NotNil(leader)
 	testutil.Eventually(re, func() bool {

--- a/tests/server/apiv2/handlers/testutil.go
+++ b/tests/server/apiv2/handlers/testutil.go
@@ -305,9 +305,19 @@ func MustFinishSplitKeyspaceGroup(re *require.Assertions, server *tests.TestServ
 		if err != nil {
 			return false
 		}
-		if resp.StatusCode == http.StatusServiceUnavailable ||
-			resp.StatusCode == http.StatusInternalServerError {
+		if resp.StatusCode == http.StatusServiceUnavailable {
 			return false
+		}
+		if resp.StatusCode == http.StatusInternalServerError {
+			// A TSO server can finish the split after this test observes that the
+			// target group is ready but before this request reaches PD. Treat that
+			// race as success only after verifying the intended final state.
+			manager := server.GetServer().GetKeyspaceGroupManager()
+			if manager == nil {
+				return false
+			}
+			group, err := manager.GetKeyspaceGroupByID(id)
+			return err == nil && group != nil && !group.IsSplitting()
 		}
 		re.Equal(http.StatusOK, resp.StatusCode, string(data))
 		return true

--- a/tests/server/apiv2/handlers/tso_keyspace_group_test.go
+++ b/tests/server/apiv2/handlers/tso_keyspace_group_test.go
@@ -197,6 +197,9 @@ func (suite *keyspaceGroupTestSuite) TestSplitKeyspaceGroup() {
 	re.Equal(kg1.Members, kg2.Members)
 	// Finish the split and check the split state.
 	MustFinishSplitKeyspaceGroup(re, suite.server, 2)
+	// A TSO server may finish the split before the helper's request arrives.
+	// Calling it again covers that already-finished race.
+	MustFinishSplitKeyspaceGroup(re, suite.server, 2)
 	kg1 = MustLoadKeyspaceGroupByID(re, suite.server, 1)
 	re.False(kg1.IsSplitting())
 	kg2 = MustLoadKeyspaceGroupByID(re, suite.server, 2)

--- a/tests/server/storage/hot_region_storage_test.go
+++ b/tests/server/storage/hot_region_storage_test.go
@@ -128,45 +128,48 @@ func (s *hotRegionStorageTestSuite) checkHotRegionStorage(cluster *tests.TestClu
 		err := leaderServer.GetRaftCluster().HandleStoreHeartbeat(&pdpb.StoreHeartbeatRequest{Stats: storeStats}, &pdpb.StoreHeartbeatResponse{})
 		re.NoError(err)
 	}
-	var (
-		iter storage.HotRegionStorageIterator
-		next *storage.HistoryHotRegion
-		err  error
-	)
 	hotRegionStorage := leaderServer.GetServer().GetHistoryHotRegionStorage()
+	var writeRegions, readRegions []*storage.HistoryHotRegion
 	testutil.Eventually(re, func() bool { // wait for the history hot region to be written to the storage
-		iter = hotRegionStorage.NewIterator([]string{utils.Write.String()}, startTime*1000, time.Now().UnixMilli())
-		next, err = iter.Next()
-		return err == nil && next != nil
+		var err error
+		writeRegions, err = loadHistoryHotRegions(hotRegionStorage, utils.Write.String(), startTime*1000)
+		if err != nil || len(writeRegions) != 2 {
+			return false
+		}
+		readRegions, err = loadHistoryHotRegions(hotRegionStorage, utils.Read.String(), startTime*1000)
+		return err == nil && len(readRegions) == 2
 	})
-	re.Equal(uint64(1), next.RegionID)
-	re.Equal(uint64(1), next.StoreID)
-	re.Equal(utils.Write.String(), next.HotRegionType)
-	next, err = iter.Next()
-	re.NoError(err)
-	re.NotNil(next)
-	re.Equal(uint64(2), next.RegionID)
-	re.Equal(uint64(2), next.StoreID)
-	re.Equal(utils.Write.String(), next.HotRegionType)
-	next, err = iter.Next()
-	re.NoError(err)
-	re.Nil(next)
-	iter = hotRegionStorage.NewIterator([]string{utils.Read.String()}, startTime*1000, time.Now().UnixMilli())
-	next, err = iter.Next()
-	re.NoError(err)
-	re.NotNil(next)
-	re.Equal(uint64(3), next.RegionID)
-	re.Equal(uint64(1), next.StoreID)
-	re.Equal(utils.Read.String(), next.HotRegionType)
-	next, err = iter.Next()
-	re.NoError(err)
-	re.NotNil(next)
-	re.Equal(uint64(4), next.RegionID)
-	re.Equal(uint64(2), next.StoreID)
-	re.Equal(utils.Read.String(), next.HotRegionType)
-	next, err = iter.Next()
-	re.NoError(err)
-	re.Nil(next)
+	re.Equal(uint64(1), writeRegions[0].RegionID)
+	re.Equal(uint64(1), writeRegions[0].StoreID)
+	re.Equal(utils.Write.String(), writeRegions[0].HotRegionType)
+	re.Equal(uint64(2), writeRegions[1].RegionID)
+	re.Equal(uint64(2), writeRegions[1].StoreID)
+	re.Equal(utils.Write.String(), writeRegions[1].HotRegionType)
+	re.Equal(uint64(3), readRegions[0].RegionID)
+	re.Equal(uint64(1), readRegions[0].StoreID)
+	re.Equal(utils.Read.String(), readRegions[0].HotRegionType)
+	re.Equal(uint64(4), readRegions[1].RegionID)
+	re.Equal(uint64(2), readRegions[1].StoreID)
+	re.Equal(utils.Read.String(), readRegions[1].HotRegionType)
+}
+
+func loadHistoryHotRegions(
+	hotRegionStorage *storage.HotRegionStorage,
+	hotRegionType string,
+	startTime int64,
+) ([]*storage.HistoryHotRegion, error) {
+	iter := hotRegionStorage.NewIterator([]string{hotRegionType}, startTime, time.Now().UnixMilli())
+	regions := make([]*storage.HistoryHotRegion, 0)
+	for {
+		next, err := iter.Next()
+		if err != nil {
+			return nil, err
+		}
+		if next == nil {
+			return regions, nil
+		}
+		regions = append(regions, next)
+	}
 }
 
 func (s *hotRegionStorageTestSuite) TestHotRegionStorageReservedDayConfigChange() {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10353, Close #11229, Close #11233

`TestHotRegionStorage` can read history before the asynchronous flush has
persisted the complete batch. Client integration tests can also observe the
old leader immediately after a resignation or fail a one-shot embedded-etcd
leader transfer under CI load.

`TestTSOKeyspaceGroupManagerSuite/TestMultiNodes` can also race with the
automatic split finisher and time out after the split has already completed.

### What is changed and how does it work?

```commit-message
Wait for the complete hot-region history batch before asserting its contents.

Reuse the bounded leader-resignation retry and wait until all running servers
agree on a leader different from the previous one.

Make the split-finishing test helper accept a concurrent completion only
after verifying that the target group is no longer splitting.
```

### Check List

Tests

- Unit test
- Integration test

### Release note

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved leader transfer handling to reliably wait for leadership changes before continuing.
  - Increased resilience when completing keyspace split operations during temporary service or server errors.
  - Refined hot-region history collection to ensure write and read records are fully available before validation.

- **Tests**
  - Expanded leader-change verification across transfer and follower-forwarding scenarios.
  - Strengthened coverage for keyspace group split completion and hot-region storage behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->