### PR TITLE
storelimit: backport store limits to release-nextgen-202603

### DIFF
--- a/pkg/core/storelimit/limit.go
+++ b/pkg/core/storelimit/limit.go
@@ -28,6 +28,8 @@ const (
 	RemovePeer
 	// SendSnapshot indicates the type of sending snapshot.
 	SendSnapshot
+	// TransferLeaderIn indicates the limit for leaders transferred into a store.
+	TransferLeaderIn
 
 	storeLimitTypeLen
 )

--- a/pkg/core/storelimit/limit_test.go
+++ b/pkg/core/storelimit/limit_test.go
@@ -88,9 +88,13 @@ func TestSlidingWindow(t *testing.T) {
 	s.Ack(capacity-minSnapSize, SendSnapshot)
 	re.Equal([]int64{capacity - minSnapSize, 0, 0, 0}, s.GetUsed())
 
-	// case 3: skip the type is not the SendSnapshot
-	for range 10 {
-		re.True(s.Take(capacity, AddPeer, constant.Low))
+	// case 3: non-snapshot types bypass the window without changing its usage.
+	used := s.GetUsed()
+	for _, typ := range []Type{AddPeer, RemovePeer, TransferLeaderIn} {
+		re.True(s.Available(capacity, typ, constant.Low))
+		re.True(s.Take(capacity, typ, constant.Low))
+		s.Ack(capacity, typ)
+		re.Equal(used, s.GetUsed())
 	}
 }
 

--- a/pkg/core/storelimit/store_limit.go
+++ b/pkg/core/storelimit/store_limit.go
@@ -33,9 +33,10 @@ const (
 
 // RegionInfluence represents the influence of an operator step, which is used by store limit.
 var RegionInfluence = []int64{
-	AddPeer:      influence,
-	RemovePeer:   influence,
-	SendSnapshot: influence,
+	AddPeer:          influence,
+	RemovePeer:       influence,
+	SendSnapshot:     influence,
+	TransferLeaderIn: influence,
 }
 
 // SmallRegionInfluence represents the influence of an operator step
@@ -47,9 +48,10 @@ var SmallRegionInfluence = []int64{
 
 // TypeNameValue indicates the name of store limit type and the enum value
 var TypeNameValue = map[string]Type{
-	"add-peer":      AddPeer,
-	"remove-peer":   RemovePeer,
-	"send-snapshot": SendSnapshot,
+	"add-peer":           AddPeer,
+	"remove-peer":        RemovePeer,
+	"send-snapshot":      SendSnapshot,
+	"transfer-leader-in": TransferLeaderIn,
 }
 
 // String returns the representation of the Type

--- a/pkg/mcs/scheduling/server/apis/v1/api.go
+++ b/pkg/mcs/scheduling/server/apis/v1/api.go
@@ -357,17 +357,34 @@ func getConfig(c *gin.Context) {
 		c.String(resp.StatusCode, fmt.Sprintf("primary returned non-200 status: %s", string(body)))
 		return
 	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		c.String(http.StatusInternalServerError, "failed to read primary's config: "+err.Error())
+		return
+	}
 	var primaryCfg config.Config
-	if err := json.NewDecoder(resp.Body).Decode(&primaryCfg); err != nil {
+	if err := json.Unmarshal(body, &primaryCfg); err != nil {
 		c.String(http.StatusInternalServerError, "failed to decode primary's config: "+err.Error())
 		return
 	}
+	var fields struct {
+		Schedule json.RawMessage `json:"schedule"`
+	}
+	if err := json.Unmarshal(body, &fields); err != nil {
+		c.String(http.StatusInternalServerError, "failed to decode primary's config: "+err.Error())
+		return
+	}
+	if len(fields.Schedule) != 0 {
+		if err := primaryCfg.Schedule.MigrateDeprecatedFlagsFromJSON(fields.Schedule); err != nil {
+			c.String(http.StatusInternalServerError, "failed to migrate primary's config: "+err.Error())
+			return
+		}
+	}
 
 	// Schedule and Replication are dynamic configs managed by primary, so we need to merge them.
-	mergedCfg := localCfg
-	mergedCfg.Schedule = primaryCfg.Schedule
-	mergedCfg.Replication = primaryCfg.Replication
-	c.IndentedJSON(http.StatusOK, &mergedCfg)
+	localCfg.Schedule = primaryCfg.Schedule
+	localCfg.Replication = primaryCfg.Replication
+	c.IndentedJSON(http.StatusOK, localCfg)
 }
 
 // @Tags     admin

--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net/http"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -726,6 +727,12 @@ func (c *Cluster) collectMetrics() {
 		statistics.ObserveHotStat(s, c.hotStat.StoresStats)
 	}
 	statsMap.Collect()
+	// Remove transfer-in limit metrics recreated from a stale store snapshot.
+	for _, s := range stores {
+		if store := c.GetStore(s.GetID()); store == nil || store.IsRemoved() {
+			statistics.StoreLimitGauge.DeleteLabelValues(strconv.FormatUint(s.GetID(), 10), "transfer-leader-in")
+		}
+	}
 
 	c.coordinator.GetSchedulersController().CollectSchedulerMetrics()
 	c.coordinator.CollectHotSpotMetrics()

--- a/pkg/mcs/scheduling/server/config/config.go
+++ b/pkg/mcs/scheduling/server/config/config.go
@@ -528,6 +528,8 @@ func (o *PersistConfig) GetStoreLimitByType(storeID uint64, typ storelimit.Type)
 		return limit.AddPeer
 	case storelimit.RemovePeer:
 		return limit.RemovePeer
+	case storelimit.TransferLeaderIn:
+		return limit.TransferLeaderIn
 	// todo: impl it in store limit v2.
 	case storelimit.SendSnapshot:
 		return 0.0
@@ -589,21 +591,10 @@ func (o *PersistConfig) IsTikvRegionSplitEnabled() bool {
 // SetAllStoresLimit sets all store limit for a given type and rate.
 func (o *PersistConfig) SetAllStoresLimit(typ storelimit.Type, ratePerMin float64) {
 	v := o.GetScheduleConfig().Clone()
-	switch typ {
-	case storelimit.AddPeer:
-		v.DefaultStoreLimit.AddPeer = ratePerMin
-		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, ratePerMin)
-		for storeID := range v.StoreLimit {
-			sc := sc.StoreLimitConfig{AddPeer: ratePerMin, RemovePeer: v.StoreLimit[storeID].RemovePeer}
-			v.StoreLimit[storeID] = sc
-		}
-	case storelimit.RemovePeer:
-		v.DefaultStoreLimit.RemovePeer = ratePerMin
-		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, ratePerMin)
-		for storeID := range v.StoreLimit {
-			sc := sc.StoreLimitConfig{AddPeer: v.StoreLimit[storeID].AddPeer, RemovePeer: ratePerMin}
-			v.StoreLimit[storeID] = sc
-		}
+	v.DefaultStoreLimit = v.DefaultStoreLimit.SetLimit(typ, ratePerMin)
+	sc.DefaultStoreLimit.SetDefaultStoreLimit(typ, ratePerMin)
+	for storeID, limit := range v.StoreLimit {
+		v.StoreLimit[storeID] = limit.SetLimit(typ, ratePerMin)
 	}
 
 	o.SetScheduleConfig(v)

--- a/pkg/mcs/scheduling/server/config/config.go
+++ b/pkg/mcs/scheduling/server/config/config.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"reflect"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"time"
 	"unsafe"
@@ -190,6 +191,8 @@ func (c *Config) Clone() *Config {
 // PersistConfig wraps all configurations that need to persist to storage and
 // allows to access them safely.
 type PersistConfig struct {
+	scheduleMu sync.Mutex
+
 	ttl *cache.TTLString
 	// Store the global configuration that is related to the scheduling.
 	clusterVersion unsafe.Pointer
@@ -252,6 +255,12 @@ func (o *PersistConfig) GetScheduleConfig() *sc.ScheduleConfig {
 
 // SetScheduleConfig sets the scheduling configuration dynamically.
 func (o *PersistConfig) SetScheduleConfig(cfg *sc.ScheduleConfig) {
+	o.scheduleMu.Lock()
+	defer o.scheduleMu.Unlock()
+	o.installScheduleConfig(cfg)
+}
+
+func (o *PersistConfig) installScheduleConfig(cfg *sc.ScheduleConfig) {
 	old := o.GetScheduleConfig()
 	o.schedule.Store(cfg)
 	// The coordinator is not aware of the underlying scheduler config changes,
@@ -259,6 +268,16 @@ func (o *PersistConfig) SetScheduleConfig(cfg *sc.ScheduleConfig) {
 	if !reflect.DeepEqual(old.Schedulers, cfg.Schedulers) {
 		o.tryNotifySchedulersUpdating()
 	}
+}
+
+// SetSchedulers replaces only the scheduler list.
+func (o *PersistConfig) SetSchedulers(schedulers sc.SchedulerConfigs) {
+	o.scheduleMu.Lock()
+	defer o.scheduleMu.Unlock()
+
+	next := o.GetScheduleConfig().Clone()
+	next.Schedulers = append(sc.SchedulerConfigs(nil), schedulers...)
+	o.installScheduleConfig(next)
 }
 
 // AdjustScheduleCfg adjusts the schedule config during the initialization.
@@ -271,6 +290,7 @@ func AdjustScheduleCfg(scheduleCfg *sc.ScheduleConfig) {
 			scheduleCfg.Schedulers = append(scheduleCfg.Schedulers, ps)
 		}
 	}
+	scheduleCfg.MigrateDeprecatedFlags()
 }
 
 // GetReplicationConfig returns replication configurations.
@@ -494,10 +514,7 @@ func (o *PersistConfig) GetStoreLimit(storeID uint64) (returnSC sc.StoreLimitCon
 		return limit
 	}
 	cfg := o.GetScheduleConfig().Clone()
-	limitCfg := sc.StoreLimitConfig{
-		AddPeer:    sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer),
-		RemovePeer: sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer),
-	}
+	limitCfg := cfg.GetDefaultStoreLimit()
 	cfg.StoreLimit[storeID] = limitCfg
 	o.SetScheduleConfig(cfg)
 	return o.GetScheduleConfig().StoreLimit[storeID]
@@ -574,12 +591,14 @@ func (o *PersistConfig) SetAllStoresLimit(typ storelimit.Type, ratePerMin float6
 	v := o.GetScheduleConfig().Clone()
 	switch typ {
 	case storelimit.AddPeer:
+		v.DefaultStoreLimit.AddPeer = ratePerMin
 		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, ratePerMin)
 		for storeID := range v.StoreLimit {
 			sc := sc.StoreLimitConfig{AddPeer: ratePerMin, RemovePeer: v.StoreLimit[storeID].RemovePeer}
 			v.StoreLimit[storeID] = sc
 		}
 	case storelimit.RemovePeer:
+		v.DefaultStoreLimit.RemovePeer = ratePerMin
 		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, ratePerMin)
 		for storeID := range v.StoreLimit {
 			sc := sc.StoreLimitConfig{AddPeer: v.StoreLimit[storeID].AddPeer, RemovePeer: ratePerMin}

--- a/pkg/mcs/scheduling/server/config/config_test.go
+++ b/pkg/mcs/scheduling/server/config/config_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/tikv/pd/pkg/core/storelimit"
+	sc "github.com/tikv/pd/pkg/schedule/config"
+	"github.com/tikv/pd/pkg/utils/testutil"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m, testutil.LeakOptions...)
+}
+
+func TestPersistConfigDefaultStoreLimit(t *testing.T) {
+	re := require.New(t)
+	oldAddPeer := sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer)
+	oldRemovePeer := sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer)
+	defer func() {
+		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, oldAddPeer)
+		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, oldRemovePeer)
+	}()
+	sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, 15)
+	sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, 15)
+
+	cfg := NewConfig()
+	re.NoError(cfg.adjust(nil))
+	persistConfig := NewPersistConfig(cfg, nil)
+	persistConfig.GetScheduleConfig().StoreLimit[1] = sc.StoreLimitConfig{AddPeer: 10, RemovePeer: 20}
+
+	persistConfig.SetAllStoresLimit(storelimit.AddPeer, 60)
+	re.Equal(sc.StoreLimitConfig{AddPeer: 60, RemovePeer: 15}, persistConfig.GetScheduleConfig().DefaultStoreLimit)
+	re.Equal(sc.StoreLimitConfig{AddPeer: 60, RemovePeer: 20}, persistConfig.GetStoreLimit(1))
+
+	data, err := json.Marshal(persistConfig.GetScheduleConfig())
+	re.NoError(err)
+	var reloadedScheduleConfig sc.ScheduleConfig
+	re.NoError(json.Unmarshal(data, &reloadedScheduleConfig))
+	restartedConfig := NewConfig()
+	restartedConfig.Schedule = reloadedScheduleConfig
+	restartedPersistConfig := NewPersistConfig(restartedConfig, nil)
+
+	sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, 15)
+	sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, 25)
+	re.Equal(sc.StoreLimitConfig{AddPeer: 60, RemovePeer: 15}, restartedPersistConfig.GetStoreLimit(2))
+}
+
+func TestAdjustScheduleConfigDefaultStoreLimit(t *testing.T) {
+	oldAddPeer := sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer)
+	oldRemovePeer := sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer)
+	defer func() {
+		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, oldAddPeer)
+		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, oldRemovePeer)
+	}()
+
+	testCases := []struct {
+		name     string
+		config   string
+		expected sc.StoreLimitConfig
+	}{
+		{
+			name:     "legacy config without store limit default",
+			config:   `{"store-limit":{}}`,
+			expected: sc.StoreLimitConfig{AddPeer: 15, RemovePeer: 15},
+		},
+		{
+			name:     "legacy store balance rate",
+			config:   `{"store-balance-rate":60,"store-limit":{}}`,
+			expected: sc.StoreLimitConfig{AddPeer: 60, RemovePeer: 60},
+		},
+		{
+			name:     "explicit zero wins over legacy store balance rate",
+			config:   `{"store-balance-rate":60,"default-store-limit":{"add-peer":0,"remove-peer":0},"store-limit":{}}`,
+			expected: sc.StoreLimitConfig{AddPeer: 0, RemovePeer: 0},
+		},
+		{
+			name:     "legacy store balance rate backfills an omitted field",
+			config:   `{"store-balance-rate":60,"default-store-limit":{"add-peer":0},"store-limit":{}}`,
+			expected: sc.StoreLimitConfig{AddPeer: 0, RemovePeer: 60},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			re := require.New(t)
+			sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, 15)
+			sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, 15)
+			watchedConfig := &persistedConfig{
+				Schedule: sc.ScheduleConfig{DefaultStoreLimit: sc.DefaultStoreLimitConfig()},
+			}
+			re.NoError(json.Unmarshal([]byte(`{"schedule":`+testCase.config+`}`), watchedConfig))
+			AdjustScheduleCfg(&watchedConfig.Schedule)
+			re.Equal(testCase.expected, watchedConfig.Schedule.DefaultStoreLimit)
+			re.Zero(watchedConfig.Schedule.StoreBalanceRate)
+
+			cfg := NewConfig()
+			cfg.Schedule = watchedConfig.Schedule
+			persistConfig := NewPersistConfig(cfg, nil)
+			re.Equal(testCase.expected, persistConfig.GetStoreLimit(100))
+		})
+	}
+}

--- a/pkg/mcs/scheduling/server/config/config_test.go
+++ b/pkg/mcs/scheduling/server/config/config_test.go
@@ -32,23 +32,50 @@ func TestMain(m *testing.M) {
 
 func TestPersistConfigDefaultStoreLimit(t *testing.T) {
 	re := require.New(t)
-	oldAddPeer := sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer)
-	oldRemovePeer := sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer)
-	defer func() {
-		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, oldAddPeer)
-		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, oldRemovePeer)
-	}()
+	previous := sc.DefaultStoreLimitConfig()
+	t.Cleanup(func() {
+		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, previous.AddPeer)
+		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, previous.RemovePeer)
+		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.TransferLeaderIn, previous.TransferLeaderIn)
+	})
 	sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, 15)
-	sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, 15)
-
+	sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, 25)
+	sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.TransferLeaderIn, 35)
 	cfg := NewConfig()
 	re.NoError(cfg.adjust(nil))
 	persistConfig := NewPersistConfig(cfg, nil)
-	persistConfig.GetScheduleConfig().StoreLimit[1] = sc.StoreLimitConfig{AddPeer: 10, RemovePeer: 20}
+	persistConfig.GetScheduleConfig().StoreLimit[1] = sc.StoreLimitConfig{AddPeer: 10, RemovePeer: 20, TransferLeaderIn: 30}
 
-	persistConfig.SetAllStoresLimit(storelimit.AddPeer, 60)
-	re.Equal(sc.StoreLimitConfig{AddPeer: 60, RemovePeer: 15}, persistConfig.GetScheduleConfig().DefaultStoreLimit)
-	re.Equal(sc.StoreLimitConfig{AddPeer: 60, RemovePeer: 20}, persistConfig.GetStoreLimit(1))
+	// Each update must preserve the other types in both store and default limits.
+	for _, testCase := range []struct {
+		typ             storelimit.Type
+		rate            float64
+		store, defaults sc.StoreLimitConfig
+	}{
+		{
+			typ:      storelimit.AddPeer,
+			rate:     40,
+			store:    sc.StoreLimitConfig{AddPeer: 40, RemovePeer: 20, TransferLeaderIn: 30},
+			defaults: sc.StoreLimitConfig{AddPeer: 40, RemovePeer: 25, TransferLeaderIn: 35},
+		},
+		{
+			typ:      storelimit.RemovePeer,
+			rate:     50,
+			store:    sc.StoreLimitConfig{AddPeer: 40, RemovePeer: 50, TransferLeaderIn: 30},
+			defaults: sc.StoreLimitConfig{AddPeer: 40, RemovePeer: 50, TransferLeaderIn: 35},
+		},
+		{
+			typ:      storelimit.TransferLeaderIn,
+			rate:     60,
+			store:    sc.StoreLimitConfig{AddPeer: 40, RemovePeer: 50, TransferLeaderIn: 60},
+			defaults: sc.StoreLimitConfig{AddPeer: 40, RemovePeer: 50, TransferLeaderIn: 60},
+		},
+	} {
+		persistConfig.SetAllStoresLimit(testCase.typ, testCase.rate)
+		re.Equal(testCase.store, persistConfig.GetStoreLimit(1), testCase.typ.String())
+		re.Equal(testCase.defaults, persistConfig.GetScheduleConfig().DefaultStoreLimit, testCase.typ.String())
+		re.Equal(testCase.defaults, sc.DefaultStoreLimitConfig(), testCase.typ.String())
+	}
 
 	data, err := json.Marshal(persistConfig.GetScheduleConfig())
 	re.NoError(err)
@@ -60,41 +87,63 @@ func TestPersistConfigDefaultStoreLimit(t *testing.T) {
 
 	sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, 15)
 	sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, 25)
-	re.Equal(sc.StoreLimitConfig{AddPeer: 60, RemovePeer: 15}, restartedPersistConfig.GetStoreLimit(2))
+	sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.TransferLeaderIn, 35)
+	re.Equal(sc.StoreLimitConfig{AddPeer: 40, RemovePeer: 50, TransferLeaderIn: 60}, restartedPersistConfig.GetStoreLimit(2))
 }
 
 func TestAdjustScheduleConfigDefaultStoreLimit(t *testing.T) {
 	oldAddPeer := sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer)
 	oldRemovePeer := sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer)
+	oldTransferLeaderIn := sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.TransferLeaderIn)
 	defer func() {
 		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, oldAddPeer)
 		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, oldRemovePeer)
+		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.TransferLeaderIn, oldTransferLeaderIn)
 	}()
 
 	testCases := []struct {
 		name     string
 		config   string
 		expected sc.StoreLimitConfig
+		stores   map[uint64]sc.StoreLimitConfig
 	}{
+		{
+			name:     "case insensitive fields and null leader limit",
+			config:   `{"default-store-limit":{"ADD-PEER":0,"remove-peer":70,"TRANSFER-LEADER-IN":120},"store-limit":{"1":{"ADD-PEER":10,"REMOVE-PEER":20,"TRANSFER-LEADER-IN":300},"2":{"transfer-leader-in":null}}}`,
+			expected: sc.StoreLimitConfig{AddPeer: 0, RemovePeer: 70, TransferLeaderIn: 120},
+			stores: map[uint64]sc.StoreLimitConfig{
+				1: {AddPeer: 10, RemovePeer: 20, TransferLeaderIn: 300},
+				2: {TransferLeaderIn: 120},
+			},
+		},
+		{
+			name:     "per-store leader limits",
+			config:   `{"store-limit":{"1":{"add-peer":10,"remove-peer":20},"2":{"transfer-leader-in":30}}}`,
+			expected: sc.StoreLimitConfig{AddPeer: 15, RemovePeer: 15, TransferLeaderIn: storelimit.Unlimited},
+			stores: map[uint64]sc.StoreLimitConfig{
+				1: {AddPeer: 10, RemovePeer: 20, TransferLeaderIn: storelimit.Unlimited},
+				2: {TransferLeaderIn: 30},
+			},
+		},
 		{
 			name:     "legacy config without store limit default",
 			config:   `{"store-limit":{}}`,
-			expected: sc.StoreLimitConfig{AddPeer: 15, RemovePeer: 15},
+			expected: sc.StoreLimitConfig{AddPeer: 15, RemovePeer: 15, TransferLeaderIn: storelimit.Unlimited},
 		},
 		{
 			name:     "legacy store balance rate",
 			config:   `{"store-balance-rate":60,"store-limit":{}}`,
-			expected: sc.StoreLimitConfig{AddPeer: 60, RemovePeer: 60},
+			expected: sc.StoreLimitConfig{AddPeer: 60, RemovePeer: 60, TransferLeaderIn: storelimit.Unlimited},
 		},
 		{
 			name:     "explicit zero wins over legacy store balance rate",
 			config:   `{"store-balance-rate":60,"default-store-limit":{"add-peer":0,"remove-peer":0},"store-limit":{}}`,
-			expected: sc.StoreLimitConfig{AddPeer: 0, RemovePeer: 0},
+			expected: sc.StoreLimitConfig{AddPeer: 0, RemovePeer: 0, TransferLeaderIn: storelimit.Unlimited},
 		},
 		{
 			name:     "legacy store balance rate backfills an omitted field",
 			config:   `{"store-balance-rate":60,"default-store-limit":{"add-peer":0},"store-limit":{}}`,
-			expected: sc.StoreLimitConfig{AddPeer: 0, RemovePeer: 60},
+			expected: sc.StoreLimitConfig{AddPeer: 0, RemovePeer: 60, TransferLeaderIn: storelimit.Unlimited},
 		},
 	}
 	for _, testCase := range testCases {
@@ -102,6 +151,7 @@ func TestAdjustScheduleConfigDefaultStoreLimit(t *testing.T) {
 			re := require.New(t)
 			sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, 15)
 			sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, 15)
+			sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.TransferLeaderIn, storelimit.Unlimited)
 			watchedConfig := &persistedConfig{
 				Schedule: sc.ScheduleConfig{DefaultStoreLimit: sc.DefaultStoreLimitConfig()},
 			}
@@ -114,6 +164,10 @@ func TestAdjustScheduleConfigDefaultStoreLimit(t *testing.T) {
 			cfg.Schedule = watchedConfig.Schedule
 			persistConfig := NewPersistConfig(cfg, nil)
 			re.Equal(testCase.expected, persistConfig.GetStoreLimit(100))
+			for id, expected := range testCase.stores {
+				re.Equal(expected, persistConfig.GetStoreLimit(id))
+				re.Equal(expected.TransferLeaderIn, persistConfig.GetStoreLimitByType(id, storelimit.TransferLeaderIn))
+			}
 		})
 	}
 }

--- a/pkg/mcs/scheduling/server/config/watcher.go
+++ b/pkg/mcs/scheduling/server/config/watcher.go
@@ -74,6 +74,25 @@ type persistedConfig struct {
 	Store          sc.StoreConfig       `json:"store"`
 }
 
+// UnmarshalJSON consumes persisted schedule-field presence while decoding, so
+// decoder metadata never leaks into the runtime ScheduleConfig.
+func (c *persistedConfig) UnmarshalJSON(data []byte) error {
+	type plainPersistedConfig persistedConfig
+	if err := json.Unmarshal(data, (*plainPersistedConfig)(c)); err != nil {
+		return err
+	}
+	var fields struct {
+		Schedule json.RawMessage `json:"schedule"`
+	}
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	if len(fields.Schedule) == 0 {
+		return nil
+	}
+	return c.Schedule.MigrateDeprecatedFlagsFromJSON(fields.Schedule)
+}
+
 // NewWatcher creates a new watcher to watch the config meta change from PD.
 func NewWatcher(
 	ctx context.Context,
@@ -124,7 +143,9 @@ func (cw *Watcher) getSchedulersController() *schedulers.Controller {
 
 func (cw *Watcher) initializeConfigWatcher() error {
 	putFn := func(kv *mvccpb.KeyValue) error {
-		cfg := &persistedConfig{}
+		cfg := &persistedConfig{
+			Schedule: sc.ScheduleConfig{DefaultStoreLimit: sc.DefaultStoreLimitConfig()},
+		}
 		if err := json.Unmarshal(kv.Value, cfg); err != nil {
 			log.Warn("failed to unmarshal scheduling config entry",
 				zap.String("event-kv-key", string(kv.Key)), zap.Error(err))

--- a/pkg/schedule/checker/rule_checker_test.go
+++ b/pkg/schedule/checker/rule_checker_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/tikv/pd/pkg/cache"
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/core/constant"
+	"github.com/tikv/pd/pkg/core/storelimit"
 	"github.com/tikv/pd/pkg/errs"
 	"github.com/tikv/pd/pkg/mock/mockcluster"
 	"github.com/tikv/pd/pkg/mock/mockconfig"
@@ -408,6 +409,18 @@ func (suite *ruleCheckerTestSuite) TestFixRoleLeader() {
 	op := suite.rc.Check(suite.cluster.GetRegion(1))
 	re.NotNil(op)
 	re.Equal("fix-follower-role", op.Desc())
+	re.Equal(uint64(3), op.Step(0).(operator.TransferLeader).ToStore)
+
+	suite.cluster.SetStoreLimit(3, storelimit.TransferLeaderIn, 0.00006)
+	suite.cluster.ResetStoreLimit(3, storelimit.TransferLeaderIn, 0.000001)
+	limiter := suite.cluster.GetStore(3).GetStoreLimit()
+	re.True(limiter.Take(storelimit.RegionInfluence[storelimit.TransferLeaderIn], storelimit.TransferLeaderIn, constant.Medium))
+	re.Nil(suite.rc.Check(suite.cluster.GetRegion(1)))
+
+	suite.cluster.SetStoreLimit(3, storelimit.TransferLeaderIn, storelimit.Unlimited)
+	suite.cluster.ResetStoreLimit(3, storelimit.TransferLeaderIn, storelimit.Unlimited/time.Minute.Seconds())
+	op = suite.rc.Check(suite.cluster.GetRegion(1))
+	re.NotNil(op)
 	re.Equal(uint64(3), op.Step(0).(operator.TransferLeader).ToStore)
 }
 
@@ -1496,6 +1509,39 @@ func (suite *ruleCheckerTestSuite) TestFixDownPeer() {
 	err = suite.ruleManager.SetRule(rule)
 	re.NoError(err)
 	re.Nil(suite.rc.Check(region))
+}
+
+func (suite *ruleCheckerTestSuite) TestFastFailoverLeaderTransferWithExhaustedLimit() {
+	re := suite.Require()
+	tc := suite.cluster
+	for _, id := range []uint64{1, 2, 3, 4} {
+		tc.AddLeaderStore(id, 1)
+	}
+	tc.AddLeaderRegion(1, 1, 2, 3)
+	tc.SetStoreDown(1)
+	tc.PutStore(tc.GetStore(1).Clone(core.SetLastHeartbeatTS(time.Now().Add(-time.Hour))))
+	region := tc.GetRegion(1)
+	region = region.Clone(core.WithDownPeers([]*pdpb.PeerStats{{Peer: region.GetStorePeer(1), DownSeconds: 3600}}))
+	// Prefer a healthy follower over retaining the outgoing leader.
+	suite.rc.record.incOfflineLeaderCount(1)
+	for _, id := range []uint64{2, 3, 4} {
+		tc.SetStoreLimit(id, storelimit.TransferLeaderIn, 0.00006)
+		tc.ResetStoreLimit(id, storelimit.TransferLeaderIn, 0.000001)
+		re.True(tc.GetStore(id).GetStoreLimit().Take(storelimit.RegionInfluence[storelimit.TransferLeaderIn], storelimit.TransferLeaderIn, constant.Medium))
+	}
+	op := suite.rc.Check(region)
+	re.Nil(op)
+
+	// Fast failover keeps its priority but must select a target with budget.
+	tc.SetStoreLimit(2, storelimit.TransferLeaderIn, storelimit.Unlimited)
+	tc.ResetStoreLimit(2, storelimit.TransferLeaderIn, storelimit.Unlimited/time.Minute.Seconds())
+	op = suite.rc.Check(region)
+	re.NotNil(op)
+	re.Equal(constant.Urgent, op.GetPriorityLevel())
+	re.Equal("replace-rule-down-leader-peer", op.Desc())
+	influence := operator.NewTotalOpInfluence([]*operator.Operator{op}, tc.GetBasicCluster())
+	re.Equal(storelimit.RegionInfluence[storelimit.TransferLeaderIn], influence.GetStoreInfluence(2).GetStepCost(storelimit.TransferLeaderIn))
+	re.Zero(influence.GetStoreInfluence(3).GetStepCost(storelimit.TransferLeaderIn))
 }
 
 func (suite *ruleCheckerTestSuite) TestFixDownPeerWithNoWitness() {

--- a/pkg/schedule/config/config.go
+++ b/pkg/schedule/config/config.go
@@ -96,10 +96,10 @@ const (
 
 var (
 	defaultLocationLabels = []string{}
-	// DefaultStoreLimit is the default store limit of add peer and remove peer.
-	DefaultStoreLimit = StoreLimit{AddPeer: 15, RemovePeer: 15}
-	// DefaultTiFlashStoreLimit is the default TiFlash store limit of add peer and remove peer.
-	DefaultTiFlashStoreLimit = StoreLimit{AddPeer: 30, RemovePeer: 30}
+	// DefaultStoreLimit is the default store limit.
+	DefaultStoreLimit = StoreLimit{AddPeer: 15, RemovePeer: 15, TransferLeaderIn: storelimit.Unlimited}
+	// DefaultTiFlashStoreLimit is the default TiFlash store limit.
+	DefaultTiFlashStoreLimit = StoreLimit{AddPeer: 30, RemovePeer: 30, TransferLeaderIn: storelimit.Unlimited}
 )
 
 // The following consts are used to identify the config item that needs to set TTL.
@@ -129,13 +129,15 @@ const (
 	DefaultTTL        = 5 * time.Minute
 )
 
-// StoreLimit is the default limit of adding peer and removing peer when putting stores.
+// StoreLimit is the default limit for store operations when putting stores.
 type StoreLimit struct {
 	mu syncutil.RWMutex
 	// AddPeer is the default rate of adding peers for store limit (per minute).
 	AddPeer float64
 	// RemovePeer is the default rate of removing peers for store limit (per minute).
 	RemovePeer float64
+	// TransferLeaderIn is the default rate of transferring leaders into a store (per minute).
+	TransferLeaderIn float64
 }
 
 // SetDefaultStoreLimit sets the default store limit for a given type.
@@ -147,6 +149,8 @@ func (sl *StoreLimit) SetDefaultStoreLimit(typ storelimit.Type, ratePerMin float
 		sl.AddPeer = ratePerMin
 	case storelimit.RemovePeer:
 		sl.RemovePeer = ratePerMin
+	case storelimit.TransferLeaderIn:
+		sl.TransferLeaderIn = ratePerMin
 	}
 }
 
@@ -159,6 +163,8 @@ func (sl *StoreLimit) GetDefaultStoreLimit(typ storelimit.Type) float64 {
 		return sl.AddPeer
 	case storelimit.RemovePeer:
 		return sl.RemovePeer
+	case storelimit.TransferLeaderIn:
+		return sl.TransferLeaderIn
 	default:
 		panic("invalid type")
 	}
@@ -492,6 +498,9 @@ func (c *ScheduleConfig) adjustDefaultStoreLimit(meta *configutil.ConfigMetaData
 	if !meta.IsDefined("remove-peer") {
 		configutil.AdjustFloat64(&c.DefaultStoreLimit.RemovePeer, defaultStoreLimit.RemovePeer)
 	}
+	if !meta.IsDefined("transfer-leader-in") {
+		configutil.AdjustFloat64(&c.DefaultStoreLimit.TransferLeaderIn, defaultStoreLimit.TransferLeaderIn)
+	}
 }
 
 func (c *ScheduleConfig) migrateStoreBalanceRate(defaultStoreLimitMeta *configutil.ConfigMetaData) {
@@ -510,10 +519,11 @@ func (c *ScheduleConfig) migrateStoreBalanceRate(defaultStoreLimitMeta *configut
 	c.StoreBalanceRate = 0
 }
 
-func (c *ScheduleConfig) migratePersistedStoreLimit(addPeerDefined, removePeerDefined bool) {
+func (c *ScheduleConfig) migratePersistedStoreLimit(addPeerDefined, removePeerDefined, transferLeaderInDefined bool) {
 	defaultStoreLimit := DefaultStoreLimitConfig()
 	if c.StoreBalanceRate != 0 {
-		defaultStoreLimit = StoreLimitConfig{AddPeer: c.StoreBalanceRate, RemovePeer: c.StoreBalanceRate}
+		defaultStoreLimit.AddPeer = c.StoreBalanceRate
+		defaultStoreLimit.RemovePeer = c.StoreBalanceRate
 	}
 	if !addPeerDefined {
 		c.DefaultStoreLimit.AddPeer = defaultStoreLimit.AddPeer
@@ -521,8 +531,12 @@ func (c *ScheduleConfig) migratePersistedStoreLimit(addPeerDefined, removePeerDe
 	if !removePeerDefined {
 		c.DefaultStoreLimit.RemovePeer = defaultStoreLimit.RemovePeer
 	}
+	if !transferLeaderInDefined {
+		c.DefaultStoreLimit.TransferLeaderIn = defaultStoreLimit.TransferLeaderIn
+	}
 	DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, c.DefaultStoreLimit.AddPeer)
 	DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, c.DefaultStoreLimit.RemovePeer)
+	DefaultStoreLimit.SetDefaultStoreLimit(storelimit.TransferLeaderIn, c.DefaultStoreLimit.TransferLeaderIn)
 	c.StoreBalanceRate = 0
 }
 
@@ -570,31 +584,71 @@ func parseDeprecatedFlag(meta *configutil.ConfigMetaData, name string, old, new 
 	return false, nil // unreachable.
 }
 
-// MigrateDeprecatedFlags updates new flags according to deprecated flags.
-func (c *ScheduleConfig) MigrateDeprecatedFlags() {
-	c.applyDeprecatedFlagMigration(true, true)
+// UnmarshalJSON preserves omitted store limits on updates and initializes new
+// stores from the defaults in the same configuration snapshot.
+func (c *ScheduleConfig) UnmarshalJSON(data []byte) error {
+	type scheduleConfig ScheduleConfig
+	fields := struct {
+		*scheduleConfig
+		StoreLimit map[uint64]json.RawMessage `json:"store-limit"`
+	}{scheduleConfig: (*scheduleConfig)(c)}
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	if c.StoreLimit == nil && fields.StoreLimit != nil {
+		c.StoreLimit = make(map[uint64]StoreLimitConfig, len(fields.StoreLimit))
+	}
+	for storeID, data := range fields.StoreLimit {
+		limit, ok := c.StoreLimit[storeID]
+		if !ok {
+			limit = c.DefaultStoreLimit
+		}
+		// Decoding into the existing value also preserves fields sent as null.
+		if err := json.Unmarshal(data, &limit); err != nil {
+			return err
+		}
+		c.StoreLimit[storeID] = limit
+	}
+	return nil
 }
 
-// MigrateDeprecatedFlagsFromJSON migrates a full persisted or remote schedule
-// config while preserving the distinction between omitted values and explicit
-// zero values. The JSON presence is consumed at the decoding boundary and is
-// never retained in the runtime ScheduleConfig.
+// MigrateDeprecatedFlags updates new flags according to deprecated flags.
+func (c *ScheduleConfig) MigrateDeprecatedFlags() {
+	c.applyDeprecatedFlagMigration(true, true, true)
+}
+
+// MigrateDeprecatedFlagsFromJSON migrates persisted or remote scheduling
+// configuration, using JSON field presence to preserve explicit zero peer limits.
 func (c *ScheduleConfig) MigrateDeprecatedFlagsFromJSON(data []byte) error {
 	var fields struct {
-		DefaultStoreLimit map[string]json.RawMessage `json:"default-store-limit"`
+		StoreLimit        map[uint64]json.RawMessage `json:"store-limit"`
+		DefaultStoreLimit struct {
+			AddPeer          *float64 `json:"add-peer"`
+			RemovePeer       *float64 `json:"remove-peer"`
+			TransferLeaderIn *float64 `json:"transfer-leader-in"`
+		} `json:"default-store-limit"`
 	}
 	if err := json.Unmarshal(data, &fields); err != nil {
 		return err
 	}
-	_, addPeerDefined := fields.DefaultStoreLimit["add-peer"]
-	_, removePeerDefined := fields.DefaultStoreLimit["remove-peer"]
-	c.applyDeprecatedFlagMigration(addPeerDefined, removePeerDefined)
+	c.applyDeprecatedFlagMigration(fields.DefaultStoreLimit.AddPeer != nil,
+		fields.DefaultStoreLimit.RemovePeer != nil, fields.DefaultStoreLimit.TransferLeaderIn != nil)
+	// The migration may have changed the default used during JSON decoding.
+	for storeID, data := range fields.StoreLimit {
+		// Full legacy snapshots used zero for omitted peer limits. Only the new
+		// leader limit needs a migration default; API patches preserve all fields.
+		limit := StoreLimitConfig{TransferLeaderIn: c.DefaultStoreLimit.TransferLeaderIn}
+		if err := json.Unmarshal(data, &limit); err != nil {
+			return err
+		}
+		c.StoreLimit[storeID] = limit
+	}
 	return nil
 }
 
-func (c *ScheduleConfig) applyDeprecatedFlagMigration(addPeerDefined, removePeerDefined bool) {
+func (c *ScheduleConfig) applyDeprecatedFlagMigration(addPeerDefined, removePeerDefined, transferLeaderInDefined bool) {
 	c.DisableLearner = false
-	c.migratePersistedStoreLimit(addPeerDefined, removePeerDefined)
+	c.migratePersistedStoreLimit(addPeerDefined, removePeerDefined, transferLeaderInDefined)
 	for _, b := range c.migrateConfigurationMap() {
 		// If old=false (previously disabled), set both old and new to false.
 		if *b[0] {
@@ -605,13 +659,25 @@ func (c *ScheduleConfig) applyDeprecatedFlagMigration(addPeerDefined, removePeer
 
 // Validate is used to validate if some scheduling configurations are right.
 func (c *ScheduleConfig) Validate() error {
-	if math.IsNaN(c.DefaultStoreLimit.AddPeer) || math.IsInf(c.DefaultStoreLimit.AddPeer, 0) ||
-		c.DefaultStoreLimit.AddPeer < 0 {
+	if !isStoreLimitRateValid(c.DefaultStoreLimit.AddPeer) {
 		return errors.New("default-store-limit.add-peer should be finite and non-negative")
 	}
-	if math.IsNaN(c.DefaultStoreLimit.RemovePeer) || math.IsInf(c.DefaultStoreLimit.RemovePeer, 0) ||
-		c.DefaultStoreLimit.RemovePeer < 0 {
+	if !isStoreLimitRateValid(c.DefaultStoreLimit.RemovePeer) {
 		return errors.New("default-store-limit.remove-peer should be finite and non-negative")
+	}
+	if !isStoreLimitRateValid(c.DefaultStoreLimit.TransferLeaderIn) {
+		return errors.New("default-store-limit.transfer-leader-in should be finite and non-negative")
+	}
+	for storeID, limit := range c.StoreLimit {
+		if !isStoreLimitRateValid(limit.AddPeer) {
+			return errors.Errorf("store-limit[%d].add-peer should be finite and non-negative", storeID)
+		}
+		if !isStoreLimitRateValid(limit.RemovePeer) {
+			return errors.Errorf("store-limit[%d].remove-peer should be finite and non-negative", storeID)
+		}
+		if !isStoreLimitRateValid(limit.TransferLeaderIn) {
+			return errors.Errorf("store-limit[%d].transfer-leader-in should be finite and non-negative", storeID)
+		}
 	}
 	if c.TolerantSizeRatio < 0 {
 		return errors.New("tolerant-size-ratio should be non-negative")
@@ -635,6 +701,10 @@ func (c *ScheduleConfig) Validate() error {
 		return errors.Errorf("patrol-region-worker-count should be between 1 and %d", maxPatrolRegionWorkerCount)
 	}
 	return nil
+}
+
+func isStoreLimitRateValid(rate float64) bool {
+	return !math.IsNaN(rate) && !math.IsInf(rate, 0) && rate >= 0
 }
 
 // Deprecated is used to find if there is an option has been deprecated.
@@ -667,13 +737,30 @@ func (c *ScheduleConfig) Deprecated() error {
 type StoreLimitConfig struct {
 	AddPeer    float64 `toml:"add-peer" json:"add-peer"`
 	RemovePeer float64 `toml:"remove-peer" json:"remove-peer"`
+	// TransferLeaderIn is the inbound leader limit per minute, defaulting to
+	// storelimit.Unlimited (a sufficiently large rate), like unlimited peer limits.
+	TransferLeaderIn float64 `toml:"transfer-leader-in" json:"transfer-leader-in"`
+}
+
+// SetLimit returns a copy with the specified store limit updated.
+func (c StoreLimitConfig) SetLimit(typ storelimit.Type, ratePerMin float64) StoreLimitConfig {
+	switch typ {
+	case storelimit.AddPeer:
+		c.AddPeer = ratePerMin
+	case storelimit.RemovePeer:
+		c.RemovePeer = ratePerMin
+	case storelimit.TransferLeaderIn:
+		c.TransferLeaderIn = ratePerMin
+	}
+	return c
 }
 
 // DefaultStoreLimitConfig returns the current process default store limit config.
 func DefaultStoreLimitConfig() StoreLimitConfig {
 	return StoreLimitConfig{
-		AddPeer:    DefaultStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer),
-		RemovePeer: DefaultStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer),
+		AddPeer:          DefaultStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer),
+		RemovePeer:       DefaultStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer),
+		TransferLeaderIn: DefaultStoreLimit.GetDefaultStoreLimit(storelimit.TransferLeaderIn),
 	}
 }
 

--- a/pkg/schedule/config/config.go
+++ b/pkg/schedule/config/config.go
@@ -15,6 +15,8 @@
 package config
 
 import (
+	"encoding/json"
+	"math"
 	"time"
 
 	"github.com/pingcap/errors"
@@ -223,6 +225,8 @@ type ScheduleConfig struct {
 	// StoreBalanceRate is the maximum of balance rate for each store.
 	// WARN: StoreBalanceRate is deprecated.
 	StoreBalanceRate float64 `toml:"store-balance-rate" json:"store-balance-rate,omitempty"`
+	// DefaultStoreLimit is the default limit of scheduling for stores.
+	DefaultStoreLimit StoreLimitConfig `toml:"default-store-limit" json:"default-store-limit"`
 	// StoreLimit is the limit of scheduling for stores.
 	StoreLimit map[uint64]StoreLimitConfig `toml:"store-limit" json:"store-limit"`
 	// TolerantSizeRatio is the ratio of buffer size for balance scheduler.
@@ -450,6 +454,9 @@ func (c *ScheduleConfig) Adjust(meta *configutil.ConfigMetaData, reloading bool)
 	}
 
 	adjustSchedulers(&c.Schedulers, DefaultSchedulers)
+	defaultStoreLimitMeta := meta.Child("default-store-limit")
+	c.migrateStoreBalanceRate(defaultStoreLimitMeta)
+	c.adjustDefaultStoreLimit(defaultStoreLimitMeta)
 
 	for k, b := range c.migrateConfigurationMap() {
 		v, err := parseDeprecatedFlag(meta, k, *b[0], *b[1])
@@ -457,11 +464,6 @@ func (c *ScheduleConfig) Adjust(meta *configutil.ConfigMetaData, reloading bool)
 			return err
 		}
 		*b[0], *b[1] = false, v // reset old flag false to make it ignored when marshal to JSON
-	}
-
-	if c.StoreBalanceRate != 0 {
-		DefaultStoreLimit = StoreLimit{AddPeer: c.StoreBalanceRate, RemovePeer: c.StoreBalanceRate}
-		c.StoreBalanceRate = 0
 	}
 
 	if c.StoreLimit == nil {
@@ -480,6 +482,48 @@ func (c *ScheduleConfig) Adjust(meta *configutil.ConfigMetaData, reloading bool)
 		configutil.AdjustFloat64(&c.SlowStoreEvictingAffectedStoreRatioThreshold, defaultSlowStoreEvictingAffectedStoreRatioThreshold)
 	}
 	return c.Validate()
+}
+
+func (c *ScheduleConfig) adjustDefaultStoreLimit(meta *configutil.ConfigMetaData) {
+	defaultStoreLimit := DefaultStoreLimitConfig()
+	if !meta.IsDefined("add-peer") {
+		configutil.AdjustFloat64(&c.DefaultStoreLimit.AddPeer, defaultStoreLimit.AddPeer)
+	}
+	if !meta.IsDefined("remove-peer") {
+		configutil.AdjustFloat64(&c.DefaultStoreLimit.RemovePeer, defaultStoreLimit.RemovePeer)
+	}
+}
+
+func (c *ScheduleConfig) migrateStoreBalanceRate(defaultStoreLimitMeta *configutil.ConfigMetaData) {
+	if c.StoreBalanceRate == 0 {
+		return
+	}
+	defaultStoreLimit := StoreLimitConfig{AddPeer: c.StoreBalanceRate, RemovePeer: c.StoreBalanceRate}
+	if !defaultStoreLimitMeta.IsDefined("add-peer") {
+		c.DefaultStoreLimit.AddPeer = defaultStoreLimit.AddPeer
+	}
+	if !defaultStoreLimitMeta.IsDefined("remove-peer") {
+		c.DefaultStoreLimit.RemovePeer = defaultStoreLimit.RemovePeer
+	}
+	DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, c.DefaultStoreLimit.AddPeer)
+	DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, c.DefaultStoreLimit.RemovePeer)
+	c.StoreBalanceRate = 0
+}
+
+func (c *ScheduleConfig) migratePersistedStoreLimit(addPeerDefined, removePeerDefined bool) {
+	defaultStoreLimit := DefaultStoreLimitConfig()
+	if c.StoreBalanceRate != 0 {
+		defaultStoreLimit = StoreLimitConfig{AddPeer: c.StoreBalanceRate, RemovePeer: c.StoreBalanceRate}
+	}
+	if !addPeerDefined {
+		c.DefaultStoreLimit.AddPeer = defaultStoreLimit.AddPeer
+	}
+	if !removePeerDefined {
+		c.DefaultStoreLimit.RemovePeer = defaultStoreLimit.RemovePeer
+	}
+	DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, c.DefaultStoreLimit.AddPeer)
+	DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, c.DefaultStoreLimit.RemovePeer)
+	c.StoreBalanceRate = 0
 }
 
 func (c *ScheduleConfig) migrateConfigurationMap() map[string][2]*bool {
@@ -528,11 +572,29 @@ func parseDeprecatedFlag(meta *configutil.ConfigMetaData, name string, old, new 
 
 // MigrateDeprecatedFlags updates new flags according to deprecated flags.
 func (c *ScheduleConfig) MigrateDeprecatedFlags() {
-	c.DisableLearner = false
-	if c.StoreBalanceRate != 0 {
-		DefaultStoreLimit = StoreLimit{AddPeer: c.StoreBalanceRate, RemovePeer: c.StoreBalanceRate}
-		c.StoreBalanceRate = 0
+	c.applyDeprecatedFlagMigration(true, true)
+}
+
+// MigrateDeprecatedFlagsFromJSON migrates a full persisted or remote schedule
+// config while preserving the distinction between omitted values and explicit
+// zero values. The JSON presence is consumed at the decoding boundary and is
+// never retained in the runtime ScheduleConfig.
+func (c *ScheduleConfig) MigrateDeprecatedFlagsFromJSON(data []byte) error {
+	var fields struct {
+		DefaultStoreLimit map[string]json.RawMessage `json:"default-store-limit"`
 	}
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	_, addPeerDefined := fields.DefaultStoreLimit["add-peer"]
+	_, removePeerDefined := fields.DefaultStoreLimit["remove-peer"]
+	c.applyDeprecatedFlagMigration(addPeerDefined, removePeerDefined)
+	return nil
+}
+
+func (c *ScheduleConfig) applyDeprecatedFlagMigration(addPeerDefined, removePeerDefined bool) {
+	c.DisableLearner = false
+	c.migratePersistedStoreLimit(addPeerDefined, removePeerDefined)
 	for _, b := range c.migrateConfigurationMap() {
 		// If old=false (previously disabled), set both old and new to false.
 		if *b[0] {
@@ -543,6 +605,14 @@ func (c *ScheduleConfig) MigrateDeprecatedFlags() {
 
 // Validate is used to validate if some scheduling configurations are right.
 func (c *ScheduleConfig) Validate() error {
+	if math.IsNaN(c.DefaultStoreLimit.AddPeer) || math.IsInf(c.DefaultStoreLimit.AddPeer, 0) ||
+		c.DefaultStoreLimit.AddPeer < 0 {
+		return errors.New("default-store-limit.add-peer should be finite and non-negative")
+	}
+	if math.IsNaN(c.DefaultStoreLimit.RemovePeer) || math.IsInf(c.DefaultStoreLimit.RemovePeer, 0) ||
+		c.DefaultStoreLimit.RemovePeer < 0 {
+		return errors.New("default-store-limit.remove-peer should be finite and non-negative")
+	}
 	if c.TolerantSizeRatio < 0 {
 		return errors.New("tolerant-size-ratio should be non-negative")
 	}
@@ -597,6 +667,19 @@ func (c *ScheduleConfig) Deprecated() error {
 type StoreLimitConfig struct {
 	AddPeer    float64 `toml:"add-peer" json:"add-peer"`
 	RemovePeer float64 `toml:"remove-peer" json:"remove-peer"`
+}
+
+// DefaultStoreLimitConfig returns the current process default store limit config.
+func DefaultStoreLimitConfig() StoreLimitConfig {
+	return StoreLimitConfig{
+		AddPeer:    DefaultStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer),
+		RemovePeer: DefaultStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer),
+	}
+}
+
+// GetDefaultStoreLimit returns the default store limit config.
+func (c *ScheduleConfig) GetDefaultStoreLimit() StoreLimitConfig {
+	return c.DefaultStoreLimit
 }
 
 // SchedulerConfigs is a slice of customized scheduler configuration.

--- a/pkg/schedule/config/config_provider.go
+++ b/pkg/schedule/config/config_provider.go
@@ -69,6 +69,7 @@ type SchedulerConfigProvider interface {
 
 	GetScheduleConfig() *ScheduleConfig
 	SetScheduleConfig(*ScheduleConfig)
+	SetSchedulers(SchedulerConfigs)
 }
 
 // CheckerConfigProvider is the interface for checker configurations.

--- a/pkg/schedule/coordinator.go
+++ b/pkg/schedule/coordinator.go
@@ -383,7 +383,8 @@ func (c *Coordinator) InitSchedulers(needRun bool) {
 
 	// Removes the invalid scheduler config and persist.
 	scheduleCfg.Schedulers = scheduleCfg.Schedulers[:k]
-	c.cluster.GetSchedulerConfig().SetScheduleConfig(scheduleCfg)
+	validSchedulers := append(sc.SchedulerConfigs(nil), scheduleCfg.Schedulers...)
+	c.cluster.GetSchedulerConfig().SetSchedulers(validSchedulers)
 	if err := c.cluster.GetSchedulerConfig().Persist(c.cluster.GetStorage()); err != nil {
 		log.Error("cannot persist schedule config", errs.ZapError(err))
 	}

--- a/pkg/schedule/filter/counter.go
+++ b/pkg/schedule/filter/counter.go
@@ -64,6 +64,7 @@ const (
 	storeStateBusy
 	storeStateExceedRemoveLimit
 	storeStateExceedAddLimit
+	storeStateExceedTransferLeaderInLimit
 	storeStateTooManySnapshot
 	storeStateTooManyPendingPeer
 	storeStateRejectLeader
@@ -94,6 +95,7 @@ var filters = [filtersLen]string{
 	"store-state-busy-filter",
 	"store-state-exceed-remove-limit-filter",
 	"store-state-exceed-add-limit-filter",
+	"store-state-exceed-transfer-leader-in-limit-filter",
 	"store-state-too-many-snapshots-filter",
 	"store-state-too-many-pending-peers-filter",
 	"store-state-reject-leader-filter",

--- a/pkg/schedule/filter/filters.go
+++ b/pkg/schedule/filter/filters.go
@@ -444,6 +444,19 @@ func (f *StoreStateFilter) exceedAddLimit(_ config.SharedConfigProvider, store *
 	return statusOK
 }
 
+func (f *StoreStateFilter) exceedTransferLeaderInLimit(_ config.SharedConfigProvider, store *core.StoreInfo) *plan.Status {
+	// Target selection intentionally checks the budget regardless of operator priority,
+	// including when this filter is used by Builder. Controller admission retains its
+	// existing Urgent exemption; passing this filter does not reserve tokens.
+	// TODO: Reconcile leader-transfer priorities with store-limit admission semantics.
+	if !f.AllowTemporaryStates && !store.IsAvailable(storelimit.TransferLeaderIn, f.OperatorLevel) {
+		f.Reason = storeStateExceedTransferLeaderInLimit
+		return statusStoreTransferLeaderInLimit
+	}
+	f.Reason = storeStateOK
+	return statusOK
+}
+
 func (f *StoreStateFilter) tooManySnapshots(conf config.SharedConfigProvider, store *core.StoreInfo) *plan.Status {
 	if !f.AllowTemporaryStates && (uint64(store.GetSendingSnapCount()) > conf.GetMaxSnapshotCount() ||
 		uint64(store.GetReceivingSnapCount()) > conf.GetMaxSnapshotCount()) {
@@ -509,7 +522,8 @@ func (f *StoreStateFilter) anyConditionMatch(typ int, conf config.SharedConfigPr
 		funcs = []conditionFunc{f.isBusy}
 	case leaderTarget:
 		funcs = []conditionFunc{f.isRemoved, f.isRemoving, f.isDown, f.pauseLeaderTransferIn,
-			f.slowStoreEvicted, f.stoppingStoreEvicted, f.slowTrendEvicted, f.isDisconnected, f.isBusy, f.hasRejectLeaderProperty}
+			f.slowStoreEvicted, f.stoppingStoreEvicted, f.slowTrendEvicted, f.isDisconnected, f.isBusy,
+			f.hasRejectLeaderProperty, f.exceedTransferLeaderInLimit}
 	case regionTarget:
 		funcs = []conditionFunc{f.isRemoved, f.isRemoving, f.isDown, f.isDisconnected, f.isBusy,
 			f.exceedAddLimit, f.tooManySnapshots, f.tooManyPendingPeers}

--- a/pkg/schedule/filter/filters_test.go
+++ b/pkg/schedule/filter/filters_test.go
@@ -246,6 +246,8 @@ func TestStoreStateFilter(t *testing.T) {
 		&StoreStateFilter{MoveRegion: true},
 		&StoreStateFilter{TransferLeader: true, MoveRegion: true},
 		&StoreStateFilter{MoveRegion: true, AllowTemporaryStates: true},
+		&StoreStateFilter{TransferLeader: true, AllowTemporaryStates: true},
+		&StoreStateFilter{TransferLeader: true, OperatorLevel: constant.Urgent},
 	}
 	opt := mockconfig.NewTestOptions()
 	store := core.NewStoreInfoWithLabel(1, map[string]string{})
@@ -268,6 +270,22 @@ func TestStoreStateFilter(t *testing.T) {
 		{2, plan.StatusOK, plan.StatusOK},
 	}
 	check(store, testCases)
+
+	limiter := storelimit.NewStoreRateLimit(0.000001)
+	limitedStore := store.Clone(core.SetStoreLimit(limiter))
+	// Selection observes the budget without reserving it.
+	for range 2 {
+		check(limitedStore, []testCase{{0, plan.StatusOK, plan.StatusOK}})
+	}
+	re.True(limiter.Take(storelimit.RegionInfluence[storelimit.TransferLeaderIn], storelimit.TransferLeaderIn, constant.Medium))
+	check(limitedStore, []testCase{
+		{0, plan.StatusOK, plan.StatusStoreTransferLeaderInLimitThrottled},
+		{1, plan.StatusOK, plan.StatusOK},
+		{2, plan.StatusOK, plan.StatusStoreTransferLeaderInLimitThrottled},
+		{4, plan.StatusOK, plan.StatusOK},
+		{5, plan.StatusOK, plan.StatusStoreTransferLeaderInLimitThrottled},
+	})
+	re.Equal("store-state-exceed-transfer-leader-in-limit-filter", filters[0].Type().String())
 
 	// Disconnected
 	store = store.Clone(core.SetLastHeartbeatTS(time.Now().Add(-5 * time.Minute)))

--- a/pkg/schedule/filter/status.go
+++ b/pkg/schedule/filter/status.go
@@ -31,10 +31,11 @@ var (
 	statusStoreBusy         = plan.NewStatus(plan.StatusStoreBusy)
 
 	// store soft limitation
-	statusStoreSnapshotThrottled    = plan.NewStatus(plan.StatusStoreSnapshotThrottled)
-	statusStorePendingPeerThrottled = plan.NewStatus(plan.StatusStorePendingPeerThrottled)
-	statusStoreAddLimit             = plan.NewStatus(plan.StatusStoreAddLimitThrottled)
-	statusStoreRemoveLimit          = plan.NewStatus(plan.StatusStoreRemoveLimitThrottled)
+	statusStoreSnapshotThrottled     = plan.NewStatus(plan.StatusStoreSnapshotThrottled)
+	statusStorePendingPeerThrottled  = plan.NewStatus(plan.StatusStorePendingPeerThrottled)
+	statusStoreAddLimit              = plan.NewStatus(plan.StatusStoreAddLimitThrottled)
+	statusStoreRemoveLimit           = plan.NewStatus(plan.StatusStoreRemoveLimitThrottled)
+	statusStoreTransferLeaderInLimit = plan.NewStatus(plan.StatusStoreTransferLeaderInLimitThrottled)
 
 	// store config limitation
 	statusStoreRejectLeader = plan.NewStatus(plan.StatusStoreRejectLeader)

--- a/pkg/schedule/operator/create_operator_test.go
+++ b/pkg/schedule/operator/create_operator_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/hex"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -27,6 +28,8 @@ import (
 	"github.com/pingcap/kvproto/pkg/pdpb"
 
 	"github.com/tikv/pd/pkg/core"
+	"github.com/tikv/pd/pkg/core/constant"
+	"github.com/tikv/pd/pkg/core/storelimit"
 	"github.com/tikv/pd/pkg/mock/mockcluster"
 	"github.com/tikv/pd/pkg/mock/mockconfig"
 	"github.com/tikv/pd/pkg/schedule/config"
@@ -356,6 +359,43 @@ func (suite *createOperatorTestSuite) TestCreateMergeRegionOperator() {
 	}
 }
 
+func (suite *createOperatorTestSuite) TestCompositeOperatorLeaderLimit() {
+	re := suite.Require()
+	tc := suite.cluster
+	tc.AddLeaderRegion(1, 1, 2, 3)
+	region := tc.GetRegion(1)
+	for _, id := range []uint64{2, 4} {
+		tc.SetStoreLimit(id, storelimit.TransferLeaderIn, 0.00006)
+		tc.ResetStoreLimit(id, storelimit.TransferLeaderIn, 0.000001)
+		re.True(tc.GetStore(id).GetStoreLimit().Take(storelimit.RegionInfluence[storelimit.TransferLeaderIn], storelimit.TransferLeaderIn, constant.Medium))
+	}
+	peer := &metapb.Peer{Id: 14, StoreId: 4}
+	op, err := CreateMoveLeaderOperator("test", tc, region, OpRegion, 1, peer)
+	re.Error(err)
+	re.Nil(op)
+
+	// Peer-only changes do not spend the leader-transfer budget.
+	op, err = CreateAddPeerOperator("test", tc, region, peer, OpRegion)
+	re.NoError(err)
+	influence := NewTotalOpInfluence([]*Operator{op}, tc.GetBasicCluster())
+	re.Zero(influence.GetStoreInfluence(4).GetStepCost(storelimit.TransferLeaderIn))
+
+	// Removing the leader can choose another follower with available budget.
+	op, err = CreateRemovePeerOperator("test", tc, OpRegion, region, 1)
+	re.NoError(err)
+	influence = NewTotalOpInfluence([]*Operator{op}, tc.GetBasicCluster())
+	re.Zero(influence.GetStoreInfluence(2).GetStepCost(storelimit.TransferLeaderIn))
+	re.Equal(storelimit.RegionInfluence[storelimit.TransferLeaderIn], influence.GetStoreInfluence(3).GetStepCost(storelimit.TransferLeaderIn))
+
+	tc.SetStoreLimit(4, storelimit.TransferLeaderIn, storelimit.Unlimited)
+	tc.ResetStoreLimit(4, storelimit.TransferLeaderIn, storelimit.Unlimited/time.Minute.Seconds())
+	op, err = CreateMoveLeaderOperator("test", tc, region, OpAdmin, 1, peer)
+	re.NoError(err)
+	re.Equal(constant.Urgent, op.GetPriorityLevel())
+	influence = NewTotalOpInfluence([]*Operator{op}, tc.GetBasicCluster())
+	re.Equal(storelimit.RegionInfluence[storelimit.TransferLeaderIn], influence.GetStoreInfluence(4).GetStepCost(storelimit.TransferLeaderIn))
+}
+
 func (suite *createOperatorTestSuite) TestCreateTransferLeaderOperator() {
 	re := suite.Require()
 	type testCase struct {
@@ -450,6 +490,14 @@ func (suite *createOperatorTestSuite) TestCreateTransferLeaderOperator() {
 		default:
 			suite.T().Errorf("unexpected type: %s", step.String())
 		}
+	}
+	region := core.NewRegionInfo(&metapb.Region{Id: 1, Peers: testCases[0].originPeers}, testCases[0].originPeers[0])
+	suite.cluster.ResetStoreLimit(3, storelimit.TransferLeaderIn, 0.000001)
+	re.True(suite.cluster.GetStore(3).GetStoreLimit().Take(storelimit.RegionInfluence[storelimit.TransferLeaderIn], storelimit.TransferLeaderIn, constant.Medium))
+	for _, kind := range []OpKind{OpLeader, OpAdmin} {
+		op, err := CreateTransferLeaderOperator("test", suite.cluster, region, 3, nil, kind)
+		re.ErrorContains(err, "target leader is not allowed")
+		re.Nil(op)
 	}
 }
 

--- a/pkg/schedule/operator/operator_controller_test.go
+++ b/pkg/schedule/operator/operator_controller_test.go
@@ -648,6 +648,33 @@ func (suite *operatorControllerTestSuite) TestStoreLimit() {
 	op = NewTestOperator(1, &metapb.RegionEpoch{}, OpRegion, RemovePeer{FromStore: 2})
 	re.False(oc.AddOperator(op))
 	re.False(oc.RemoveOperator(op))
+
+	tc.AddLeaderStore(3, 0)
+	tc.AddLeaderRegion(1001, 1, 2, 3)
+	tc.SetStoreLimit(2, storelimit.TransferLeaderIn, 0.00006)
+	tc.SetStoreLimit(3, storelimit.TransferLeaderIn, 0.00006)
+	// Admission reserves the budget of every candidate, including store 3.
+	op, err := CreateTransferLeaderOperator("test", tc, tc.GetRegion(1001), 2, []uint64{2, 3}, OpLeader)
+	re.NoError(err)
+	pending, err := CreateTransferLeaderOperator("test", tc, tc.GetRegion(1001), 3, nil, OpLeader)
+	re.NoError(err)
+	re.True(oc.AddOperator(op))
+	checkRemoveOperatorSuccess(re, oc, op)
+	re.False(oc.AddOperator(pending))
+	re.False(oc.RemoveOperator(pending))
+
+	// Direct admission retains the Urgent exemption, independently of Builder's
+	// priority-agnostic target filter.
+	op = NewTestOperator(1001, &metapb.RegionEpoch{}, OpAdmin, TransferLeader{FromStore: 1, ToStore: 2})
+	re.True(oc.AddOperator(op))
+	checkRemoveOperatorSuccess(re, oc, op)
+
+	tc.SetStoreLimit(2, storelimit.TransferLeaderIn, storelimit.Unlimited)
+	for range 2 {
+		op = NewTestOperator(1001, &metapb.RegionEpoch{}, OpLeader, TransferLeader{FromStore: 1, ToStore: 2})
+		re.True(oc.AddOperator(op))
+		checkRemoveOperatorSuccess(re, oc, op)
+	}
 }
 
 // #1652

--- a/pkg/schedule/operator/operator_test.go
+++ b/pkg/schedule/operator/operator_test.go
@@ -176,6 +176,26 @@ func (suite *operatorTestSuite) TestInfluence() {
 		storeOpInfluence[2] = &StoreInfluence{}
 	}
 
+	// Leader-transfer cost is independent of region size.
+	for _, size := range []int64{1, 1024} {
+		TransferLeader{FromStore: 1, ToStore: 2}.Influence(&opInfluence, region.Clone(core.SetApproximateSize(size)))
+		re.Zero(storeOpInfluence[1].GetStepCost(storelimit.TransferLeaderIn))
+		re.Equal(storelimit.RegionInfluence[storelimit.TransferLeaderIn], storeOpInfluence[2].GetStepCost(storelimit.TransferLeaderIn))
+		resetInfluence()
+	}
+
+	for _, targets := range [][]uint64{{2, 3}, {3}, {2, 3, 3}} {
+		influence := NewOpInfluence()
+		TransferLeader{FromStore: 1, ToStore: 2, ToStores: targets}.Influence(influence, region)
+		re.Zero(influence.GetStoreInfluence(1).GetStepCost(storelimit.TransferLeaderIn))
+		for _, id := range []uint64{2, 3} {
+			re.Equal(storelimit.RegionInfluence[storelimit.TransferLeaderIn], influence.GetStoreInfluence(id).GetStepCost(storelimit.TransferLeaderIn))
+		}
+		re.Equal(int64(1), influence.GetStoreInfluence(2).LeaderCount)
+		re.Zero(influence.GetStoreInfluence(3).LeaderCount)
+		re.Zero(influence.GetStoreInfluence(3).LeaderSize)
+	}
+
 	AddLearner{ToStore: 2, PeerID: 2, SendStore: 1}.Influence(&opInfluence, region)
 	re.Equal(StoreInfluence{
 		LeaderSize:  0,
@@ -235,7 +255,10 @@ func (suite *operatorTestSuite) TestInfluence() {
 		LeaderCount: 1,
 		RegionSize:  50,
 		RegionCount: 1,
-		StepCost:    map[storelimit.Type]int64{storelimit.AddPeer: 1000},
+		StepCost: map[storelimit.Type]int64{
+			storelimit.AddPeer:          1000,
+			storelimit.TransferLeaderIn: 1000,
+		},
 	}, *storeOpInfluence[2])
 
 	RemovePeer{FromStore: 1}.Influence(&opInfluence, region)
@@ -251,7 +274,10 @@ func (suite *operatorTestSuite) TestInfluence() {
 		LeaderCount: 1,
 		RegionSize:  50,
 		RegionCount: 1,
-		StepCost:    map[storelimit.Type]int64{storelimit.AddPeer: 1000},
+		StepCost: map[storelimit.Type]int64{
+			storelimit.AddPeer:          1000,
+			storelimit.TransferLeaderIn: 1000,
+		},
 	}, *storeOpInfluence[2])
 
 	MergeRegion{IsPassive: false}.Influence(&opInfluence, region)
@@ -267,7 +293,10 @@ func (suite *operatorTestSuite) TestInfluence() {
 		LeaderCount: 1,
 		RegionSize:  50,
 		RegionCount: 1,
-		StepCost:    map[storelimit.Type]int64{storelimit.AddPeer: 1000},
+		StepCost: map[storelimit.Type]int64{
+			storelimit.AddPeer:          1000,
+			storelimit.TransferLeaderIn: 1000,
+		},
 	}, *storeOpInfluence[2])
 
 	MergeRegion{IsPassive: true}.Influence(&opInfluence, region)
@@ -283,7 +312,10 @@ func (suite *operatorTestSuite) TestInfluence() {
 		LeaderCount: 1,
 		RegionSize:  50,
 		RegionCount: 0,
-		StepCost:    map[storelimit.Type]int64{storelimit.AddPeer: 1000},
+		StepCost: map[storelimit.Type]int64{
+			storelimit.AddPeer:          1000,
+			storelimit.TransferLeaderIn: 1000,
+		},
 	}, *storeOpInfluence[2])
 }
 

--- a/pkg/schedule/operator/step.go
+++ b/pkg/schedule/operator/step.go
@@ -17,6 +17,7 @@ package operator
 import (
 	"bytes"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -121,6 +122,15 @@ func (tl TransferLeader) Influence(opInfluence *OpInfluence, region *core.Region
 	from.LeaderCount--
 	to.LeaderSize += region.GetApproximateSize()
 	to.LeaderCount++
+
+	// TiKV chooses the receiver, so reserve a full cost for every possible target.
+	to.AddStepCost(storelimit.TransferLeaderIn, storelimit.RegionInfluence[storelimit.TransferLeaderIn])
+	for i, storeID := range tl.ToStores {
+		if storeID == tl.ToStore || slices.Contains(tl.ToStores[:i], storeID) {
+			continue
+		}
+		opInfluence.GetStoreInfluence(storeID).AddStepCost(storelimit.TransferLeaderIn, storelimit.RegionInfluence[storelimit.TransferLeaderIn])
+	}
 }
 
 // Timeout returns duration that current step may take.

--- a/pkg/schedule/plan/status.go
+++ b/pkg/schedule/plan/status.go
@@ -43,6 +43,8 @@ const (
 	StatusStoreAddLimitThrottled
 	// StatusStoreRemoveLimitThrottled represents the store cannot be selected due to the remove peer limitation.
 	StatusStoreRemoveLimitThrottled
+	// StatusStoreTransferLeaderInLimitThrottled represents the store cannot be selected due to the leader transfer-in limitation.
+	StatusStoreTransferLeaderInLimitThrottled
 )
 
 // config limitation
@@ -112,10 +114,11 @@ var statusText = map[StatusCode]string{
 	StatusStoreNotMatchRule:    "StoreNotMatchRule",
 
 	// store is limited by soft constraint
-	StatusStoreSnapshotThrottled:    "StoreSnapshotThrottled",
-	StatusStorePendingPeerThrottled: "StorePendingPeerThrottled",
-	StatusStoreAddLimitThrottled:    "StoreAddPeerThrottled",
-	StatusStoreRemoveLimitThrottled: "StoreRemovePeerThrottled",
+	StatusStoreSnapshotThrottled:              "StoreSnapshotThrottled",
+	StatusStorePendingPeerThrottled:           "StorePendingPeerThrottled",
+	StatusStoreAddLimitThrottled:              "StoreAddPeerThrottled",
+	StatusStoreRemoveLimitThrottled:           "StoreRemovePeerThrottled",
+	StatusStoreTransferLeaderInLimitThrottled: "StoreTransferLeaderInThrottled",
 
 	// store is limited by specified configuration
 	StatusStoreRejectLeader:      "StoreRejectLeader",

--- a/pkg/schedule/schedulers/balance_leader_test.go
+++ b/pkg/schedule/schedulers/balance_leader_test.go
@@ -20,6 +20,7 @@ import (
 	"math/rand/v2"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/docker/go-units"
 	"github.com/stretchr/testify/require"
@@ -30,6 +31,7 @@ import (
 
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/core/constant"
+	"github.com/tikv/pd/pkg/core/storelimit"
 	"github.com/tikv/pd/pkg/mock/mockcluster"
 	"github.com/tikv/pd/pkg/schedule/config"
 	"github.com/tikv/pd/pkg/schedule/operator"
@@ -140,6 +142,13 @@ func (suite *balanceLeaderSchedulerTestSuite) TestBalanceLimit() {
 	// Region1:    F    F    F    L
 	suite.tc.UpdateLeaderCount(4, 16)
 	re.NotEmpty(suite.schedule())
+	exhaustTransferLeaderInLimit(suite.T(), suite.tc, 1, 2, 3, 4)
+	re.Empty(suite.schedule())
+	suite.tc.SetStoreLimit(2, storelimit.TransferLeaderIn, storelimit.Unlimited)
+	suite.tc.ResetStoreLimit(2, storelimit.TransferLeaderIn, storelimit.Unlimited/time.Minute.Seconds())
+	ops := suite.schedule()
+	re.Len(ops, 1)
+	operatorutil.CheckTransferLeader(re, ops[0], operator.OpLeader, 4, 2)
 }
 
 func (suite *balanceLeaderSchedulerTestSuite) TestBalanceLeaderSchedulePolicy() {

--- a/pkg/schedule/schedulers/balance_range_test.go
+++ b/pkg/schedule/schedulers/balance_range_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/failpoint"
 
 	"github.com/tikv/pd/pkg/core"
+	"github.com/tikv/pd/pkg/core/storelimit"
 	"github.com/tikv/pd/pkg/schedule/operator"
 	"github.com/tikv/pd/pkg/schedule/placement"
 	"github.com/tikv/pd/pkg/schedule/types"
@@ -221,11 +222,18 @@ func TestTIKVEngine(t *testing.T) {
 	tc.AddLeaderRegionWithRange(3, "120", "140", 1, 2, 3)
 	tc.AddLeaderRegionWithRange(4, "140", "160", 2, 1, 3)
 	tc.AddLeaderRegionWithRange(5, "160", "180", 2, 1, 3)
+	exhaustTransferLeaderInLimit(t, tc, 1, 2, 3)
 	// case1: transfer leader from store 1 to store 3
 	scheduler, err = CreateScheduler(types.BalanceRangeScheduler, oc, storage.NewStorageWithMemoryBackend(),
 		ConfigSliceDecoder(types.BalanceRangeScheduler,
 			[]string{"leader-scatter", "tikv", "1h", "test", "100", "300"}))
 	re.NoError(err)
+	re.True(scheduler.IsScheduleAllowed(tc))
+	ops, _ = scheduler.Schedule(tc, true)
+	re.Empty(ops)
+
+	tc.SetStoreLimit(3, storelimit.TransferLeaderIn, storelimit.Unlimited)
+	tc.ResetStoreLimit(3, storelimit.TransferLeaderIn, storelimit.Unlimited/time.Minute.Seconds())
 	re.True(scheduler.IsScheduleAllowed(tc))
 	ops, _ = scheduler.Schedule(tc, true)
 	re.NotEmpty(ops)

--- a/pkg/schedule/schedulers/evict_leader_test.go
+++ b/pkg/schedule/schedulers/evict_leader_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -27,6 +28,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/pdpb"
 
 	"github.com/tikv/pd/pkg/core"
+	"github.com/tikv/pd/pkg/core/storelimit"
 	"github.com/tikv/pd/pkg/schedule/operator"
 	"github.com/tikv/pd/pkg/schedule/types"
 	"github.com/tikv/pd/pkg/storage"
@@ -56,6 +58,14 @@ func TestEvictLeader(t *testing.T) {
 	operatorutil.CheckMultiTargetTransferLeader(re, ops[0], operator.OpLeader, 1, []uint64{2, 3})
 	re.False(ops[0].Step(0).(operator.TransferLeader).IsFinish(tc.MockRegionInfo(1, 1, []uint64{2, 3}, []uint64{}, &metapb.RegionEpoch{ConfVer: 0, Version: 0})))
 	re.True(ops[0].Step(0).(operator.TransferLeader).IsFinish(tc.MockRegionInfo(1, 2, []uint64{1, 3}, []uint64{}, &metapb.RegionEpoch{ConfVer: 0, Version: 0})))
+	exhaustTransferLeaderInLimit(t, tc, 2, 3)
+	ops, _ = sl.Schedule(tc, false)
+	re.Empty(ops)
+	tc.SetStoreLimit(2, storelimit.TransferLeaderIn, storelimit.Unlimited)
+	tc.ResetStoreLimit(2, storelimit.TransferLeaderIn, storelimit.Unlimited/time.Minute.Seconds())
+	ops, _ = sl.Schedule(tc, false)
+	re.Len(ops, 1)
+	operatorutil.CheckMultiTargetTransferLeader(re, ops[0], operator.OpLeader, 1, []uint64{2})
 }
 
 func TestEvictLeaderWithUnhealthyPeer(t *testing.T) {

--- a/pkg/schedule/schedulers/grant_hot_region_test.go
+++ b/pkg/schedule/schedulers/grant_hot_region_test.go
@@ -1,0 +1,52 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schedulers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tikv/pd/pkg/core/storelimit"
+	"github.com/tikv/pd/pkg/schedule/operator"
+	"github.com/tikv/pd/pkg/schedule/types"
+	"github.com/tikv/pd/pkg/storage"
+	"github.com/tikv/pd/pkg/utils/operatorutil"
+)
+
+func TestGrantHotRegionTransferLeaderInLimit(t *testing.T) {
+	re := require.New(t)
+	cancel, _, tc, oc := prepareSchedulersTest()
+	defer cancel()
+	for _, id := range []uint64{1, 2, 3} {
+		tc.AddLeaderStore(id, 0)
+	}
+	tc.AddLeaderRegion(1, 1, 2, 3)
+	scheduler, err := CreateScheduler(types.GrantHotRegionScheduler, oc, storage.NewStorageWithMemoryBackend(),
+		ConfigSliceDecoder(types.GrantHotRegionScheduler, []string{"2", "1,2,3"}))
+	re.NoError(err)
+	grant := scheduler.(*grantHotRegionScheduler)
+	exhaustTransferLeaderInLimit(t, tc, 2)
+	op, err := grant.transfer(tc, 1, 1, true)
+	re.Error(err)
+	re.Nil(op)
+
+	tc.SetStoreLimit(2, storelimit.TransferLeaderIn, storelimit.Unlimited)
+	tc.ResetStoreLimit(2, storelimit.TransferLeaderIn, storelimit.Unlimited/time.Minute.Seconds())
+	op, err = grant.transfer(tc, 1, 1, true)
+	re.NoError(err)
+	operatorutil.CheckTransferLeader(re, op, operator.OpLeader, 1, 2)
+}

--- a/pkg/schedule/schedulers/hot_region_test.go
+++ b/pkg/schedule/schedulers/hot_region_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/pdpb"
 
 	"github.com/tikv/pd/pkg/core"
+	"github.com/tikv/pd/pkg/core/storelimit"
 	"github.com/tikv/pd/pkg/mock/mockcluster"
 	"github.com/tikv/pd/pkg/schedule/operator"
 	"github.com/tikv/pd/pkg/schedule/placement"
@@ -1267,6 +1268,14 @@ func TestHotReadRegionScheduleByteRateOnly(t *testing.T) {
 		for _, s := range ss {
 			re.Less(500.0*units.KiB, s.GetLoad(utils.ByteDim))
 		}
+	}
+
+	exhaustTransferLeaderInLimit(t, tc, 1, 2, 3, 4, 5)
+	hb.prepareForBalance(toResourceType(utils.Read, transferLeader), tc)
+	re.Empty(newBalanceSolver(hb, tc, utils.Read, transferLeader).solve())
+	for _, id := range []uint64{1, 2, 3, 4, 5} {
+		tc.SetStoreLimit(id, storelimit.TransferLeaderIn, storelimit.Unlimited)
+		tc.ResetStoreLimit(id, storelimit.TransferLeaderIn, storelimit.Unlimited/time.Minute.Seconds())
 	}
 
 	ops, _ := hb.Schedule(tc, false)

--- a/pkg/schedule/schedulers/scheduler_test.go
+++ b/pkg/schedule/schedulers/scheduler_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/docker/go-units"
 	"github.com/stretchr/testify/require"
@@ -25,6 +26,8 @@ import (
 	"github.com/pingcap/kvproto/pkg/metapb"
 
 	"github.com/tikv/pd/pkg/core"
+	"github.com/tikv/pd/pkg/core/constant"
+	"github.com/tikv/pd/pkg/core/storelimit"
 	"github.com/tikv/pd/pkg/mock/mockcluster"
 	"github.com/tikv/pd/pkg/mock/mockconfig"
 	"github.com/tikv/pd/pkg/schedule/config"
@@ -60,6 +63,18 @@ func prepareSchedulersTest(needToRunStream ...bool) (func(), config.SchedulerCon
 	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetSchedulerConfig(), stream)
 	tc.SetHotRegionCacheHitsThreshold(1)
 	return clean, opt, tc, oc
+}
+
+func exhaustTransferLeaderInLimit(t *testing.T, cluster *mockcluster.Cluster, storeIDs ...uint64) {
+	t.Helper()
+	// One token takes long enough to refill that no sleeps or timing assertions are needed.
+	for _, id := range storeIDs {
+		cluster.SetStoreLimit(id, storelimit.TransferLeaderIn, 0.00006)
+		cluster.ResetStoreLimit(id, storelimit.TransferLeaderIn, 0.000001)
+		limiter := cluster.GetStore(id).GetStoreLimit()
+		require.True(t, limiter.Take(storelimit.RegionInfluence[storelimit.TransferLeaderIn], storelimit.TransferLeaderIn, constant.Medium))
+		require.False(t, cluster.GetStore(id).IsAvailable(storelimit.TransferLeaderIn, constant.Medium))
+	}
 }
 
 func TestReloadSchedulerConfigWithoutSchedulerDoesNotPanic(t *testing.T) {
@@ -101,6 +116,14 @@ func TestShuffleLeader(t *testing.T) {
 		re.NotEmpty(ops)
 		re.Equal(operator.OpLeader|operator.OpAdmin, ops[0].Kind())
 	}
+	exhaustTransferLeaderInLimit(t, tc, 1, 2, 3, 4)
+	ops, _ = sl.Schedule(tc, false)
+	re.Empty(ops)
+	tc.SetStoreLimit(2, storelimit.TransferLeaderIn, storelimit.Unlimited)
+	tc.ResetStoreLimit(2, storelimit.TransferLeaderIn, storelimit.Unlimited/time.Minute.Seconds())
+	ops, _ = sl.Schedule(tc, false)
+	re.Len(ops, 1)
+	re.Equal(uint64(2), ops[0].Step(0).(operator.TransferLeader).ToStore)
 }
 
 func TestRejectLeader(t *testing.T) {
@@ -154,6 +177,14 @@ func TestRejectLeader(t *testing.T) {
 	tc.UpdateSubTree(region, origin, overlaps, rangeChanged)
 	ops, _ = sl.Schedule(tc, false)
 	operatorutil.CheckTransferLeader(re, ops[0], operator.OpLeader, 1, 2)
+	exhaustTransferLeaderInLimit(t, tc, 1, 2, 3)
+	ops, _ = sl.Schedule(tc, false)
+	re.Empty(ops)
+	tc.SetStoreLimit(2, storelimit.TransferLeaderIn, storelimit.Unlimited)
+	tc.ResetStoreLimit(2, storelimit.TransferLeaderIn, storelimit.Unlimited/time.Minute.Seconds())
+	ops, _ = sl.Schedule(tc, false)
+	re.Len(ops, 1)
+	re.Equal(uint64(2), ops[0].Step(0).(operator.TransferLeader).ToStore)
 }
 
 func TestRemoveRejectLeader(t *testing.T) {

--- a/pkg/schedule/schedulers/transfer_witness_leader_test.go
+++ b/pkg/schedule/schedulers/transfer_witness_leader_test.go
@@ -16,6 +16,7 @@ package schedulers
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -23,6 +24,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/pdpb"
 
 	"github.com/tikv/pd/pkg/core"
+	"github.com/tikv/pd/pkg/core/storelimit"
 	"github.com/tikv/pd/pkg/schedule/operator"
 	"github.com/tikv/pd/pkg/schedule/types"
 	"github.com/tikv/pd/pkg/storage"
@@ -45,7 +47,16 @@ func TestTransferWitnessLeader(t *testing.T) {
 	re.NoError(err)
 	RecvRegionInfo(sl) <- tc.GetRegion(1)
 	re.True(sl.IsScheduleAllowed(tc))
+	exhaustTransferLeaderInLimit(t, tc, 2, 3)
 	ops, _ := sl.Schedule(tc, false)
+	re.Empty(ops)
+	for _, id := range []uint64{2, 3} {
+		tc.SetStoreLimit(id, storelimit.TransferLeaderIn, storelimit.Unlimited)
+		tc.ResetStoreLimit(id, storelimit.TransferLeaderIn, storelimit.Unlimited/time.Minute.Seconds())
+	}
+	RecvRegionInfo(sl) <- tc.GetRegion(1)
+	ops, _ = sl.Schedule(tc, false)
+	re.Len(ops, 1)
 	operatorutil.CheckMultiTargetTransferLeader(re, ops[0], operator.OpLeader, 1, []uint64{2, 3})
 	re.False(ops[0].Step(0).(operator.TransferLeader).IsFinish(tc.MockRegionInfo(1, 1, []uint64{2, 3}, []uint64{}, &metapb.RegionEpoch{ConfVer: 0, Version: 0})))
 	re.True(ops[0].Step(0).(operator.TransferLeader).IsFinish(tc.MockRegionInfo(1, 2, []uint64{1, 3}, []uint64{}, &metapb.RegionEpoch{ConfVer: 0, Version: 0})))

--- a/pkg/statistics/store_collection.go
+++ b/pkg/statistics/store_collection.go
@@ -285,6 +285,7 @@ func (s *storeStatistics) collect() {
 		id := strconv.FormatUint(storeID, 10)
 		StoreLimitGauge.WithLabelValues(id, "add-peer").Set(limit.AddPeer)
 		StoreLimitGauge.WithLabelValues(id, "remove-peer").Set(limit.RemovePeer)
+		StoreLimitGauge.WithLabelValues(id, "transfer-leader-in").Set(limit.TransferLeaderIn)
 	}
 }
 
@@ -321,6 +322,7 @@ func ResetStoreStatistics(storeAddress string, id string) {
 		storeStatusGauge.DeleteLabelValues(storeAddress, id, m)
 	}
 	clusterStatusGauge.DeletePartialMatch(utils.SingleLabel("store", id))
+	StoreLimitGauge.DeleteLabelValues(id, "transfer-leader-in")
 }
 
 type storeStatisticsMap struct {

--- a/pkg/statistics/store_collection_test.go
+++ b/pkg/statistics/store_collection_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/docker/go-units"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 
 	"github.com/pingcap/kvproto/pkg/metapb"
@@ -28,6 +29,7 @@ import (
 
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/core/constant"
+	"github.com/tikv/pd/pkg/core/storelimit"
 	"github.com/tikv/pd/pkg/mock/mockconfig"
 	"github.com/tikv/pd/pkg/statistics/utils"
 )
@@ -86,6 +88,24 @@ func TestStoreStatistics(t *testing.T) {
 	re.Equal([]uint64{1, 3, 5, 7}, stats.LabelCounter["host:h1"])
 	re.Len(stats.LabelCounter["host:h2"], 4)
 	re.Len(stats.LabelCounter["zone:unknown"], 2)
+}
+
+func TestStoreLimitMetricsIncludeTransferLeaderIn(t *testing.T) {
+	re := require.New(t)
+	const storeID = "1"
+	StoreLimitGauge.DeleteLabelValues(storeID, storelimit.TransferLeaderIn.String())
+	t.Cleanup(func() {
+		ResetStoreStatistics("", storeID)
+	})
+
+	opt := mockconfig.NewTestOptions()
+	opt.SetStoreLimit(1, storelimit.TransferLeaderIn, 30)
+	NewStoreStatisticsMap(opt).Collect()
+
+	re.Equal(float64(30), promtestutil.ToFloat64(
+		StoreLimitGauge.WithLabelValues(storeID, storelimit.TransferLeaderIn.String())))
+	ResetStoreStatistics("", storeID)
+	re.False(StoreLimitGauge.DeleteLabelValues(storeID, storelimit.TransferLeaderIn.String()))
 }
 
 func TestSummaryStoreInfos(t *testing.T) {

--- a/server/api/config.go
+++ b/server/api/config.go
@@ -254,20 +254,8 @@ func (h *confHandler) updateMicroserviceConfig(config *config.Config, key string
 	return err
 }
 
-func (h *confHandler) updateSchedule(config *config.Config, key string, value any) error {
-	updated, found, err := jsonutil.AddKeyValue(&config.Schedule, key, value)
-	if err != nil {
-		return err
-	}
-
-	if !found {
-		return errors.Errorf("config item %s not found", key)
-	}
-
-	if updated {
-		err = h.svr.SetScheduleConfig(config.Schedule)
-	}
-	return err
+func (h *confHandler) updateSchedule(_ *config.Config, key string, value any) error {
+	return h.svr.SetScheduleConfigItem(key, value)
 }
 
 func (h *confHandler) updateReplication(config *config.Config, key string, value any) error {
@@ -417,21 +405,14 @@ func (h *confHandler) SetScheduleConfig(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
-	config := h.svr.GetScheduleConfig()
-	err = json.Unmarshal(data, &config)
-	if err != nil {
+	if err := h.svr.PatchScheduleConfig(data); err != nil {
 		var errCode errcode.ErrorCode
-		err = apiutil.TagJSONError(err)
-		if jsonErr, ok := errors.Cause(err).(apiutil.JSONError); ok {
+		taggedErr := apiutil.TagJSONError(err)
+		if jsonErr, ok := errors.Cause(taggedErr).(apiutil.JSONError); ok {
 			errCode = errcode.NewInvalidInputErr(jsonErr.Err)
-		} else {
-			errCode = errcode.NewInternalErr(err)
+			apiutil.ErrorResp(h.rd, w, errCode)
+			return
 		}
-		apiutil.ErrorResp(h.rd, w, errCode)
-		return
-	}
-
-	if err := h.svr.SetScheduleConfig(*config); err != nil {
 		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -637,9 +618,7 @@ func (h *confHandler) getLeaderConfig() (*config.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	var leaderConfig config.Config
-	err = json.Unmarshal(b, &leaderConfig)
-	return &leaderConfig, err
+	return unmarshalRemoteConfig(b)
 }
 
 func (h *confHandler) getSchedulingServerConfig() (*config.Config, error) {
@@ -660,12 +639,26 @@ func (h *confHandler) getSchedulingServerConfig() (*config.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	var schedulingServerConfig config.Config
-	err = json.Unmarshal(b, &schedulingServerConfig)
-	if err != nil {
+	return unmarshalRemoteConfig(b)
+}
+
+func unmarshalRemoteConfig(data []byte) (*config.Config, error) {
+	var cfg config.Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
 		return nil, err
 	}
-	return &schedulingServerConfig, nil
+	var fields struct {
+		Schedule json.RawMessage `json:"schedule"`
+	}
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return nil, err
+	}
+	if len(fields.Schedule) != 0 {
+		if err := cfg.Schedule.MigrateDeprecatedFlagsFromJSON(fields.Schedule); err != nil {
+			return nil, err
+		}
+	}
+	return &cfg, nil
 }
 
 func (h *confHandler) updateControllerConfig(key string, value any) error {

--- a/server/api/config.go
+++ b/server/api/config.go
@@ -165,20 +165,45 @@ func (h *confHandler) SetConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	schedulePatch := make(map[string]any)
 	for k, v := range conf {
-		if s := strings.Split(k, "."); len(s) > 1 {
-			if err := h.updateConfig(cfg, k, v); err != nil {
-				h.rd.JSON(w, http.StatusBadRequest, err.Error())
-				return
-			}
-			continue
+		key := k
+		if !strings.Contains(k, ".") {
+			key = reflectutil.FindJSONFullTagByChildTag(reflect.TypeOf(config.Config{}), k)
 		}
-		key := reflectutil.FindJSONFullTagByChildTag(reflect.TypeOf(config.Config{}), k)
 		if key == "" {
 			h.rd.JSON(w, http.StatusBadRequest, fmt.Sprintf("config item %s not found", k))
 			return
 		}
+		if strings.HasPrefix(key, "schedule.") {
+			if h.svr.IsTTLConfigExist(key) {
+				h.rd.JSON(w, http.StatusBadRequest, fmt.Sprintf("need to clean up TTL first for %s", key))
+				return
+			}
+			name := key[strings.LastIndex(key, ".")+1:]
+			if !reflectutil.FindSameFieldByJSON(&cfg.Schedule, map[string]any{name: v}) {
+				h.rd.JSON(w, http.StatusBadRequest, fmt.Sprintf("config item %s not found", name))
+				return
+			}
+			if _, exists := schedulePatch[name]; exists {
+				h.rd.JSON(w, http.StatusBadRequest, fmt.Sprintf("config item %s specified more than once", name))
+				return
+			}
+			schedulePatch[name] = v
+			continue
+		}
 		if err := h.updateConfig(cfg, key, v); err != nil {
+			h.rd.JSON(w, http.StatusBadRequest, err.Error())
+			return
+		}
+	}
+	if len(schedulePatch) > 0 {
+		// Apply related schedule fields together, so new stores see the new defaults.
+		data, err := json.Marshal(schedulePatch)
+		if err == nil {
+			err = h.svr.PatchScheduleConfig(data)
+		}
+		if err != nil {
 			h.rd.JSON(w, http.StatusBadRequest, err.Error())
 			return
 		}

--- a/server/api/config_test.go
+++ b/server/api/config_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tikv/pd/pkg/core/storelimit"
+	sc "github.com/tikv/pd/pkg/schedule/config"
+)
+
+func TestUnmarshalRemoteConfigMigratesDefaultStoreLimit(t *testing.T) {
+	oldAddPeer := sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer)
+	oldRemovePeer := sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer)
+	t.Cleanup(func() {
+		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, oldAddPeer)
+		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, oldRemovePeer)
+	})
+
+	testCases := []struct {
+		name     string
+		data     string
+		expected sc.StoreLimitConfig
+	}{
+		{
+			name:     "missing default uses process default",
+			data:     `{"schedule":{}}`,
+			expected: sc.StoreLimitConfig{AddPeer: 15, RemovePeer: 15},
+		},
+		{
+			name:     "legacy rate backfills missing default",
+			data:     `{"schedule":{"store-balance-rate":60}}`,
+			expected: sc.StoreLimitConfig{AddPeer: 60, RemovePeer: 60},
+		},
+		{
+			name:     "explicit zero remains unlimited",
+			data:     `{"schedule":{"store-balance-rate":60,"default-store-limit":{"add-peer":0,"remove-peer":0}}}`,
+			expected: sc.StoreLimitConfig{AddPeer: 0, RemovePeer: 0},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, 15)
+			sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, 15)
+
+			cfg, err := unmarshalRemoteConfig([]byte(testCase.data))
+			require.NoError(t, err)
+			require.Equal(t, testCase.expected, cfg.Schedule.DefaultStoreLimit)
+			require.Zero(t, cfg.Schedule.StoreBalanceRate)
+
+			data, err := json.Marshal(cfg)
+			require.NoError(t, err)
+			var roundTrip struct {
+				Schedule sc.ScheduleConfig `json:"schedule"`
+			}
+			require.NoError(t, json.Unmarshal(data, &roundTrip))
+			require.Equal(t, testCase.expected, roundTrip.Schedule.DefaultStoreLimit)
+		})
+	}
+}

--- a/server/api/config_test.go
+++ b/server/api/config_test.go
@@ -27,9 +27,11 @@ import (
 func TestUnmarshalRemoteConfigMigratesDefaultStoreLimit(t *testing.T) {
 	oldAddPeer := sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer)
 	oldRemovePeer := sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer)
+	oldTransferLeaderIn := sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.TransferLeaderIn)
 	t.Cleanup(func() {
 		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, oldAddPeer)
 		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, oldRemovePeer)
+		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.TransferLeaderIn, oldTransferLeaderIn)
 	})
 
 	testCases := []struct {
@@ -40,17 +42,22 @@ func TestUnmarshalRemoteConfigMigratesDefaultStoreLimit(t *testing.T) {
 		{
 			name:     "missing default uses process default",
 			data:     `{"schedule":{}}`,
-			expected: sc.StoreLimitConfig{AddPeer: 15, RemovePeer: 15},
+			expected: sc.StoreLimitConfig{AddPeer: 15, RemovePeer: 15, TransferLeaderIn: 25},
 		},
 		{
 			name:     "legacy rate backfills missing default",
 			data:     `{"schedule":{"store-balance-rate":60}}`,
-			expected: sc.StoreLimitConfig{AddPeer: 60, RemovePeer: 60},
+			expected: sc.StoreLimitConfig{AddPeer: 60, RemovePeer: 60, TransferLeaderIn: 25},
 		},
 		{
 			name:     "explicit zero remains unlimited",
 			data:     `{"schedule":{"store-balance-rate":60,"default-store-limit":{"add-peer":0,"remove-peer":0}}}`,
-			expected: sc.StoreLimitConfig{AddPeer: 0, RemovePeer: 0},
+			expected: sc.StoreLimitConfig{AddPeer: 0, RemovePeer: 0, TransferLeaderIn: 25},
+		},
+		{
+			name:     "explicit transfer leader limit is preserved",
+			data:     `{"schedule":{"default-store-limit":{"transfer-leader-in":0}}}`,
+			expected: sc.StoreLimitConfig{AddPeer: 15, RemovePeer: 15, TransferLeaderIn: 0},
 		},
 	}
 
@@ -58,6 +65,7 @@ func TestUnmarshalRemoteConfigMigratesDefaultStoreLimit(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, 15)
 			sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, 15)
+			sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.TransferLeaderIn, 25)
 
 			cfg, err := unmarshalRemoteConfig([]byte(testCase.data))
 			require.NoError(t, err)

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -2230,8 +2230,9 @@ func (c *RaftCluster) AddStoreLimit(store *metapb.Store) {
 			slc := cfg.GetDefaultStoreLimit()
 			if core.IsStoreContainLabel(store, core.EngineKey, core.EngineTiFlash) {
 				slc = sc.StoreLimitConfig{
-					AddPeer:    sc.DefaultTiFlashStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer),
-					RemovePeer: sc.DefaultTiFlashStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer),
+					AddPeer:          sc.DefaultTiFlashStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer),
+					RemovePeer:       sc.DefaultTiFlashStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer),
+					TransferLeaderIn: sc.DefaultTiFlashStoreLimit.GetDefaultStoreLimit(storelimit.TransferLeaderIn),
 				}
 			}
 			cfg.StoreLimit[storeID] = slc
@@ -2265,6 +2266,7 @@ func (c *RaftCluster) RemoveStoreLimit(storeID uint64) {
 			id := strconv.FormatUint(storeID, 10)
 			statistics.StoreLimitGauge.DeleteLabelValues(id, "add-peer")
 			statistics.StoreLimitGauge.DeleteLabelValues(id, "remove-peer")
+			statistics.StoreLimitGauge.DeleteLabelValues(id, "transfer-leader-in")
 			return
 		}
 		time.Sleep(persistLimitWaitTime)
@@ -2417,13 +2419,7 @@ func (c *RaftCluster) SetStoreLimit(storeID uint64, typ storelimit.Type, ratePer
 		if !ok {
 			slc = cfg.GetDefaultStoreLimit()
 		}
-		switch typ {
-		case storelimit.AddPeer:
-			slc.AddPeer = ratePerMin
-		case storelimit.RemovePeer:
-			slc.RemovePeer = ratePerMin
-		}
-		cfg.StoreLimit[storeID] = slc
+		cfg.StoreLimit[storeID] = slc.SetLimit(typ, ratePerMin)
 		return true, nil
 	})
 	if err != nil {
@@ -2438,19 +2434,9 @@ func (c *RaftCluster) SetStoreLimit(storeID uint64, typ storelimit.Type, ratePer
 // SetAllStoresLimit sets all store limit for a given type and rate.
 func (c *RaftCluster) SetAllStoresLimit(typ storelimit.Type, ratePerMin float64) error {
 	err := c.opt.UpdateScheduleConfig(c.storage, func(_ *sc.ScheduleConfig, cfg *sc.ScheduleConfig) (bool, error) {
-		switch typ {
-		case storelimit.AddPeer:
-			cfg.DefaultStoreLimit.AddPeer = ratePerMin
-			for storeID, limit := range cfg.StoreLimit {
-				limit.AddPeer = ratePerMin
-				cfg.StoreLimit[storeID] = limit
-			}
-		case storelimit.RemovePeer:
-			cfg.DefaultStoreLimit.RemovePeer = ratePerMin
-			for storeID, limit := range cfg.StoreLimit {
-				limit.RemovePeer = ratePerMin
-				cfg.StoreLimit[storeID] = limit
-			}
+		cfg.DefaultStoreLimit = cfg.DefaultStoreLimit.SetLimit(typ, ratePerMin)
+		for storeID, limit := range cfg.StoreLimit {
+			cfg.StoreLimit[storeID] = limit.SetLimit(typ, ratePerMin)
 		}
 		return true, nil
 	})

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -2219,28 +2219,29 @@ func (c *RaftCluster) GetAllStoresLimit() map[uint64]sc.StoreLimitConfig {
 // AddStoreLimit add a store limit for a given store ID.
 func (c *RaftCluster) AddStoreLimit(store *metapb.Store) {
 	storeID := store.GetId()
-	cfg := c.opt.GetScheduleConfig().Clone()
-	if _, ok := cfg.StoreLimit[storeID]; ok {
-		return
-	}
-
-	slc := sc.StoreLimitConfig{
-		AddPeer:    sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer),
-		RemovePeer: sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer),
-	}
-	if core.IsStoreContainLabel(store, core.EngineKey, core.EngineTiFlash) {
-		slc = sc.StoreLimitConfig{
-			AddPeer:    sc.DefaultTiFlashStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer),
-			RemovePeer: sc.DefaultTiFlashStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer),
-		}
-	}
-
-	cfg.StoreLimit[storeID] = slc
-	c.opt.SetScheduleConfig(cfg)
 	var err error
 	for range persistLimitRetryTimes {
-		if err = c.opt.Persist(c.storage); err == nil {
-			log.Info("store limit added", zap.Uint64("store-id", storeID))
+		added := false
+		err = c.opt.UpdateScheduleConfig(c.storage, func(_ *sc.ScheduleConfig, cfg *sc.ScheduleConfig) (bool, error) {
+			if _, ok := cfg.StoreLimit[storeID]; ok {
+				return false, nil
+			}
+
+			slc := cfg.GetDefaultStoreLimit()
+			if core.IsStoreContainLabel(store, core.EngineKey, core.EngineTiFlash) {
+				slc = sc.StoreLimitConfig{
+					AddPeer:    sc.DefaultTiFlashStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer),
+					RemovePeer: sc.DefaultTiFlashStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer),
+				}
+			}
+			cfg.StoreLimit[storeID] = slc
+			added = true
+			return true, nil
+		})
+		if err == nil {
+			if added {
+				log.Info("store limit added", zap.Uint64("store-id", storeID))
+			}
 			return
 		}
 		time.Sleep(persistLimitWaitTime)
@@ -2250,15 +2251,16 @@ func (c *RaftCluster) AddStoreLimit(store *metapb.Store) {
 
 // RemoveStoreLimit remove a store limit for a given store ID.
 func (c *RaftCluster) RemoveStoreLimit(storeID uint64) {
-	cfg := c.opt.GetScheduleConfig().Clone()
 	for _, limitType := range storelimit.TypeNameValue {
 		c.ResetStoreLimit(storeID, limitType)
 	}
-	delete(cfg.StoreLimit, storeID)
-	c.opt.SetScheduleConfig(cfg)
 	var err error
 	for range persistLimitRetryTimes {
-		if err = c.opt.Persist(c.storage); err == nil {
+		err = c.opt.UpdateScheduleConfig(c.storage, func(_ *sc.ScheduleConfig, cfg *sc.ScheduleConfig) (bool, error) {
+			delete(cfg.StoreLimit, storeID)
+			return true, nil
+		})
+		if err == nil {
 			log.Info("store limit removed", zap.Uint64("store-id", storeID))
 			id := strconv.FormatUint(storeID, 10)
 			statistics.StoreLimitGauge.DeleteLabelValues(id, "add-peer")
@@ -2410,11 +2412,21 @@ func (c *RaftCluster) loadExternalTS() {
 
 // SetStoreLimit sets a store limit for a given type and rate.
 func (c *RaftCluster) SetStoreLimit(storeID uint64, typ storelimit.Type, ratePerMin float64) error {
-	old := c.opt.GetScheduleConfig().Clone()
-	c.opt.SetStoreLimit(storeID, typ, ratePerMin)
-	if err := c.opt.Persist(c.storage); err != nil {
-		// roll back the store limit
-		c.opt.SetScheduleConfig(old)
+	err := c.opt.UpdateScheduleConfig(c.storage, func(_ *sc.ScheduleConfig, cfg *sc.ScheduleConfig) (bool, error) {
+		slc, ok := cfg.StoreLimit[storeID]
+		if !ok {
+			slc = cfg.GetDefaultStoreLimit()
+		}
+		switch typ {
+		case storelimit.AddPeer:
+			slc.AddPeer = ratePerMin
+		case storelimit.RemovePeer:
+			slc.RemovePeer = ratePerMin
+		}
+		cfg.StoreLimit[storeID] = slc
+		return true, nil
+	})
+	if err != nil {
 		log.Error("persist store limit meet error", errs.ZapError(err))
 		return err
 	}
@@ -2425,18 +2437,28 @@ func (c *RaftCluster) SetStoreLimit(storeID uint64, typ storelimit.Type, ratePer
 
 // SetAllStoresLimit sets all store limit for a given type and rate.
 func (c *RaftCluster) SetAllStoresLimit(typ storelimit.Type, ratePerMin float64) error {
-	old := c.opt.GetScheduleConfig().Clone()
-	oldAdd := sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer)
-	oldRemove := sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer)
-	c.opt.SetAllStoresLimit(typ, ratePerMin)
-	if err := c.opt.Persist(c.storage); err != nil {
-		// roll back the store limit
-		c.opt.SetScheduleConfig(old)
-		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, oldAdd)
-		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, oldRemove)
+	err := c.opt.UpdateScheduleConfig(c.storage, func(_ *sc.ScheduleConfig, cfg *sc.ScheduleConfig) (bool, error) {
+		switch typ {
+		case storelimit.AddPeer:
+			cfg.DefaultStoreLimit.AddPeer = ratePerMin
+			for storeID, limit := range cfg.StoreLimit {
+				limit.AddPeer = ratePerMin
+				cfg.StoreLimit[storeID] = limit
+			}
+		case storelimit.RemovePeer:
+			cfg.DefaultStoreLimit.RemovePeer = ratePerMin
+			for storeID, limit := range cfg.StoreLimit {
+				limit.RemovePeer = ratePerMin
+				cfg.StoreLimit[storeID] = limit
+			}
+		}
+		return true, nil
+	})
+	if err != nil {
 		log.Error("persist store limit meet error", errs.ZapError(err))
 		return err
 	}
+	sc.DefaultStoreLimit.SetDefaultStoreLimit(typ, ratePerMin)
 	for _, storeID := range c.GetStoreIDs() {
 		c.refreshStoreRateLimit(storeID, typ)
 	}

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -3116,47 +3116,53 @@ func TestCheckCache(t *testing.T) {
 }
 
 func TestStoreLimitChangeRefreshLimiter(t *testing.T) {
-	re := require.New(t)
+	for _, limitType := range []storelimit.Type{storelimit.AddPeer, storelimit.TransferLeaderIn} {
+		t.Run(limitType.String(), func(t *testing.T) {
+			re := require.New(t)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+			_, opt, err := newTestScheduleConfig()
+			re.NoError(err)
+			// StoreRateLimit (v1) participates in scheduler filters.
+			opt.GetScheduleConfig().StoreLimitVersion = storelimit.VersionV1
 
-	_, opt, err := newTestScheduleConfig()
-	re.NoError(err)
-	// StoreRateLimit (v1) is used for AddPeer/RemovePeer and participates in scheduler filters.
-	opt.GetScheduleConfig().StoreLimitVersion = storelimit.VersionV1
+			rc := newTestRaftCluster(ctx, mockid.NewIDAllocator(), opt, storage.NewStorageWithMemoryBackend())
+			storeID := uint64(1)
+			store := core.NewStoreInfo(&metapb.Store{Id: storeID}, core.SetLastHeartbeatTS(time.Now()))
+			rc.PutStore(store)
 
-	rc := newTestRaftCluster(ctx, mockid.NewIDAllocator(), opt, storage.NewStorageWithMemoryBackend())
+			// Simulate an exhausted limiter that would make scheduler filters throttle this store.
+			lowRatePerSec := float64(0.0001) / time.Minute.Seconds()
+			rc.ResetStoreLimit(storeID, limitType, lowRatePerSec)
+			store = rc.GetStore(storeID)
+			re.NotNil(store)
+			re.True(store.GetStoreLimit().Take(storelimit.RegionInfluence[limitType], limitType, constant.Low))
+			re.False(store.IsAvailable(limitType, constant.Low))
 
-	storeID := uint64(1)
-	store := core.NewStoreInfo(&metapb.Store{Id: storeID}, core.SetLastHeartbeatTS(time.Now()))
-	rc.PutStore(store)
-
-	// Simulate that the limiter has been set to an extremely low rate and already consumed,
-	// which would make scheduler filters throttle this store.
-	lowRatePerSec := float64(0.0001) / 60.0
-	rc.ResetStoreLimit(storeID, storelimit.AddPeer, lowRatePerSec)
-	store = rc.GetStore(storeID)
-	re.NotNil(store)
-	re.True(store.GetStoreLimit().Take(storelimit.RegionInfluence[storelimit.AddPeer], storelimit.AddPeer, constant.Low))
-	re.False(store.IsAvailable(storelimit.AddPeer, constant.Low))
-
-	// Increase store limit via config API. Without refreshing the in-memory limiter,
-	// the store would remain throttled and be filtered out.
-	re.NoError(rc.SetStoreLimit(storeID, storelimit.AddPeer, 30))
-	store = rc.GetStore(storeID)
-	re.NotNil(store)
-	re.True(store.IsAvailable(storelimit.AddPeer, constant.Low))
+			// Increasing the persisted limit must also refresh the in-memory limiter.
+			re.NoError(rc.SetStoreLimit(storeID, limitType, 30))
+			store = rc.GetStore(storeID)
+			re.NotNil(store)
+			re.True(store.IsAvailable(limitType, constant.Low))
+		})
+	}
 }
 
 func TestAddStoreLimitUsesPersistedDefaultStoreLimit(t *testing.T) {
 	re := require.New(t)
 	oldAddPeer := sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer)
 	oldRemovePeer := sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer)
+	oldTransferLeaderIn := sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.TransferLeaderIn)
 	defer func() {
 		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, oldAddPeer)
 		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, oldRemovePeer)
+		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.TransferLeaderIn, oldTransferLeaderIn)
 	}()
+
+	sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, 15)
+	sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, 15)
+	sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.TransferLeaderIn, storelimit.Unlimited)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -3165,23 +3171,25 @@ func TestAddStoreLimitUsesPersistedDefaultStoreLimit(t *testing.T) {
 	re.NoError(err)
 	rc := newTestRaftCluster(ctx, mockid.NewIDAllocator(), opt, storage.NewStorageWithMemoryBackend())
 	opt.SetAllStoresLimit(storelimit.AddPeer, 60)
+	opt.SetAllStoresLimit(storelimit.TransferLeaderIn, 90)
 
 	// Simulate a restarted process whose package-level default goes back to the built-in value.
 	sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, 15)
 	sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, 15)
+	sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.TransferLeaderIn, storelimit.Unlimited)
 
 	rc.AddStoreLimit(&metapb.Store{Id: 1})
-	re.Equal(sc.StoreLimitConfig{AddPeer: 60, RemovePeer: 15}, opt.GetScheduleConfig().StoreLimit[1])
+	re.Equal(sc.StoreLimitConfig{AddPeer: 60, RemovePeer: 15, TransferLeaderIn: 90}, opt.GetScheduleConfig().StoreLimit[1])
 
 	opt.SetStoreLimit(2, storelimit.RemovePeer, 80)
 	rc.AddStoreLimit(&metapb.Store{Id: 2})
-	re.Equal(sc.StoreLimitConfig{AddPeer: 60, RemovePeer: 80}, opt.GetScheduleConfig().StoreLimit[2])
+	re.Equal(sc.StoreLimitConfig{AddPeer: 60, RemovePeer: 80, TransferLeaderIn: 90}, opt.GetScheduleConfig().StoreLimit[2])
 
 	rc.AddStoreLimit(&metapb.Store{
 		Id:     3,
 		Labels: []*metapb.StoreLabel{{Key: core.EngineKey, Value: core.EngineTiFlash}},
 	})
-	re.Equal(sc.StoreLimitConfig{AddPeer: 30, RemovePeer: 30}, opt.GetScheduleConfig().StoreLimit[3])
+	re.Equal(sc.StoreLimitConfig{AddPeer: 30, RemovePeer: 30, TransferLeaderIn: storelimit.Unlimited}, opt.GetScheduleConfig().StoreLimit[3])
 }
 
 type blockingSaveConfigStorage struct {

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -3149,6 +3149,195 @@ func TestStoreLimitChangeRefreshLimiter(t *testing.T) {
 	re.True(store.IsAvailable(storelimit.AddPeer, constant.Low))
 }
 
+func TestAddStoreLimitUsesPersistedDefaultStoreLimit(t *testing.T) {
+	re := require.New(t)
+	oldAddPeer := sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer)
+	oldRemovePeer := sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer)
+	defer func() {
+		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, oldAddPeer)
+		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, oldRemovePeer)
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, opt, err := newTestScheduleConfig()
+	re.NoError(err)
+	rc := newTestRaftCluster(ctx, mockid.NewIDAllocator(), opt, storage.NewStorageWithMemoryBackend())
+	opt.SetAllStoresLimit(storelimit.AddPeer, 60)
+
+	// Simulate a restarted process whose package-level default goes back to the built-in value.
+	sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, 15)
+	sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, 15)
+
+	rc.AddStoreLimit(&metapb.Store{Id: 1})
+	re.Equal(sc.StoreLimitConfig{AddPeer: 60, RemovePeer: 15}, opt.GetScheduleConfig().StoreLimit[1])
+
+	opt.SetStoreLimit(2, storelimit.RemovePeer, 80)
+	rc.AddStoreLimit(&metapb.Store{Id: 2})
+	re.Equal(sc.StoreLimitConfig{AddPeer: 60, RemovePeer: 80}, opt.GetScheduleConfig().StoreLimit[2])
+
+	rc.AddStoreLimit(&metapb.Store{
+		Id:     3,
+		Labels: []*metapb.StoreLabel{{Key: core.EngineKey, Value: core.EngineTiFlash}},
+	})
+	re.Equal(sc.StoreLimitConfig{AddPeer: 30, RemovePeer: 30}, opt.GetScheduleConfig().StoreLimit[3])
+}
+
+type blockingSaveConfigStorage struct {
+	storage.Storage
+	saveStarted chan struct{}
+	releaseSave chan struct{}
+	mu          sync.Mutex
+	saveCount   int
+}
+
+type blockingSaveSchedulerConfigStorage struct {
+	storage.Storage
+	saveStarted chan struct{}
+	releaseSave chan struct{}
+	mu          sync.Mutex
+	saveCount   int
+}
+
+func (s *blockingSaveSchedulerConfigStorage) SaveSchedulerConfig(name string, data []byte) error {
+	s.mu.Lock()
+	s.saveCount++
+	isFirstSave := s.saveCount == 1
+	s.mu.Unlock()
+	if isFirstSave {
+		close(s.saveStarted)
+		<-s.releaseSave
+	}
+	return s.Storage.SaveSchedulerConfig(name, data)
+}
+
+func (s *blockingSaveConfigStorage) SaveConfig(cfg any) error {
+	s.mu.Lock()
+	s.saveCount++
+	isFirstSave := s.saveCount == 1
+	s.mu.Unlock()
+	if isFirstSave {
+		close(s.saveStarted)
+		<-s.releaseSave
+	}
+	return s.Storage.SaveConfig(cfg)
+}
+
+func TestScheduleConfigPersistenceIsSerialized(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, opt, err := newTestScheduleConfig()
+	re.NoError(err)
+	storage := &blockingSaveConfigStorage{
+		Storage:     storage.NewStorageWithMemoryBackend(),
+		saveStarted: make(chan struct{}),
+		releaseSave: make(chan struct{}),
+	}
+	rc := newTestRaftCluster(ctx, mockid.NewIDAllocator(), opt, storage)
+
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() { close(storage.releaseSave) })
+	}
+	t.Cleanup(release)
+
+	persistDone := make(chan error, 1)
+	go func() {
+		persistDone <- opt.Persist(storage)
+	}()
+
+	select {
+	case <-storage.saveStarted:
+	case <-time.After(time.Second):
+		t.Fatal("the initial config persistence did not start")
+	}
+
+	setAllDone := make(chan error, 1)
+	go func() {
+		setAllDone <- rc.SetAllStoresLimit(storelimit.AddPeer, 60)
+	}()
+
+	select {
+	case err := <-setAllDone:
+		re.NoError(err)
+		t.Fatal("SetAllStoresLimit was not serialized with an in-flight full-config persistence")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	release()
+	select {
+	case err := <-persistDone:
+		re.NoError(err)
+	case <-time.After(time.Second):
+		t.Fatal("the initial config persistence did not finish")
+	}
+	select {
+	case err := <-setAllDone:
+		re.NoError(err)
+	case <-time.After(time.Second):
+		t.Fatal("SetAllStoresLimit did not finish")
+	}
+
+	cfg := opt.GetScheduleConfig()
+	re.Equal(float64(60), cfg.DefaultStoreLimit.AddPeer)
+
+	_, reloadedOpt, err := newTestScheduleConfig()
+	re.NoError(err)
+	re.NoError(reloadedOpt.Reload(storage))
+	re.Equal(float64(60), reloadedOpt.GetScheduleConfig().DefaultStoreLimit.AddPeer)
+}
+
+func TestInitSchedulersPreservesConcurrentScheduleUpdate(t *testing.T) {
+	re := require.New(t)
+	oldAddPeer := sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer)
+	defer sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, oldAddPeer)
+
+	blockingStorage := &blockingSaveSchedulerConfigStorage{
+		saveStarted: make(chan struct{}),
+		releaseSave: make(chan struct{}),
+	}
+	tc, co, cleanup := prepare(nil, func(tc *testCluster) {
+		blockingStorage.Storage = tc.storage
+		tc.storage = blockingStorage
+	}, nil, re)
+	defer cleanup()
+
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() { close(blockingStorage.releaseSave) })
+	}
+	defer release()
+
+	initDone := make(chan struct{})
+	go func() {
+		co.InitSchedulers(false)
+		close(initDone)
+	}()
+
+	select {
+	case <-blockingStorage.saveStarted:
+	case <-time.After(time.Second):
+		t.Fatal("InitSchedulers did not start saving scheduler config")
+	}
+
+	re.NoError(tc.SetAllStoresLimit(storelimit.AddPeer, 60))
+	release()
+	select {
+	case <-initDone:
+	case <-time.After(time.Second):
+		t.Fatal("InitSchedulers did not finish")
+	}
+
+	re.Equal(float64(60), tc.GetScheduleConfig().DefaultStoreLimit.AddPeer)
+	_, reloadedOpt, err := newTestScheduleConfig()
+	re.NoError(err)
+	re.NoError(reloadedOpt.Reload(tc.GetStorage()))
+	re.Equal(float64(60), reloadedOpt.GetScheduleConfig().DefaultStoreLimit.AddPeer)
+}
+
 func TestPatrolRegionConcurrency(t *testing.T) {
 	re := require.New(t)
 

--- a/server/cluster/scheduling_controller.go
+++ b/server/cluster/scheduling_controller.go
@@ -17,6 +17,7 @@ package cluster
 import (
 	"context"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
@@ -186,6 +187,12 @@ func (sc *schedulingController) collectSchedulingMetrics() {
 		statistics.ObserveHotStat(s, sc.hotStat.StoresStats)
 	}
 	statsMap.Collect()
+	// Remove transfer-in limit metrics recreated from a stale store snapshot.
+	for _, s := range stores {
+		if store := sc.GetStore(s.GetID()); store == nil || store.IsRemoved() {
+			statistics.StoreLimitGauge.DeleteLabelValues(strconv.FormatUint(s.GetID(), 10), "transfer-leader-in")
+		}
+	}
 	sc.coordinator.GetSchedulersController().CollectSchedulerMetrics()
 	sc.coordinator.CollectHotSpotMetrics()
 	if sc.regionStats == nil {

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
+	"github.com/tikv/pd/pkg/core/storelimit"
 	"github.com/tikv/pd/pkg/ratelimit"
 	sc "github.com/tikv/pd/pkg/schedule/config"
 	"github.com/tikv/pd/pkg/storage"
@@ -79,6 +80,156 @@ func TestReloadConfig(t *testing.T) {
 	re.Equal(5, newOpt.GetMaxReplicas())
 	re.Equal(uint64(10), newOpt.GetMaxSnapshotCount())
 	re.Equal(int64(512), newOpt.GetMaxMovableHotPeerSize())
+}
+
+func TestReloadDefaultStoreLimit(t *testing.T) {
+	re := require.New(t)
+	oldAddPeer := sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer)
+	oldRemovePeer := sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer)
+	defer func() {
+		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, oldAddPeer)
+		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, oldRemovePeer)
+	}()
+	sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, 15)
+	sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, 15)
+
+	opt, err := newTestScheduleOption()
+	re.NoError(err)
+	opt.SetAllStoresLimit(storelimit.AddPeer, 60)
+	re.Equal(sc.StoreLimitConfig{AddPeer: 60, RemovePeer: 15}, opt.GetScheduleConfig().DefaultStoreLimit)
+
+	storage := storage.NewStorageWithMemoryBackend()
+	re.NoError(opt.Persist(storage))
+
+	// Simulate a restarted process whose package-level default goes back to the built-in value.
+	sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, 15)
+	sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, 15)
+	newOpt, err := newTestScheduleOption()
+	re.NoError(err)
+	re.NoError(newOpt.Reload(storage))
+
+	expected := sc.StoreLimitConfig{AddPeer: 60, RemovePeer: 15}
+	re.Equal(expected, newOpt.GetScheduleConfig().DefaultStoreLimit)
+	re.Equal(expected, newOpt.GetStoreLimit(100))
+
+	newOpt.SetStoreLimit(101, storelimit.RemovePeer, 70)
+	re.Equal(sc.StoreLimitConfig{AddPeer: 60, RemovePeer: 70}, newOpt.GetStoreLimit(101))
+
+	cfg := newOpt.GetScheduleConfig().Clone()
+	cfg.DefaultStoreLimit.AddPeer = 0
+	newOpt.SetScheduleConfig(cfg)
+	re.NoError(newOpt.Persist(storage))
+
+	sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, 15)
+	sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, 15)
+	reloadedOpt, err := newTestScheduleOption()
+	re.NoError(err)
+	re.NoError(reloadedOpt.Reload(storage))
+	re.Equal(sc.StoreLimitConfig{AddPeer: 0, RemovePeer: 15}, reloadedOpt.GetScheduleConfig().DefaultStoreLimit)
+	re.Equal(sc.StoreLimitConfig{AddPeer: 0, RemovePeer: 15}, reloadedOpt.GetStoreLimit(102))
+}
+
+func TestDefaultStoreLimitAdjust(t *testing.T) {
+	re := require.New(t)
+	oldAddPeer := sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer)
+	oldRemovePeer := sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer)
+	defer func() {
+		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, oldAddPeer)
+		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, oldRemovePeer)
+	}()
+	sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, 15)
+	sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, 15)
+
+	cases := []struct {
+		name   string
+		config string
+		expect sc.StoreLimitConfig
+	}{
+		{
+			name: "preserve explicit zero",
+			config: `
+[schedule.default-store-limit]
+add-peer = 0
+remove-peer = 60
+`,
+			expect: sc.StoreLimitConfig{AddPeer: 0, RemovePeer: 60},
+		},
+		{
+			name: "store balance rate backfills undefined field",
+			config: `
+[schedule]
+store-balance-rate = 50
+
+[schedule.default-store-limit]
+add-peer = 0
+`,
+			expect: sc.StoreLimitConfig{AddPeer: 0, RemovePeer: 50},
+		},
+		{
+			name: "explicit default store limit wins over store balance rate",
+			config: `
+[schedule]
+store-balance-rate = 50
+
+[schedule.default-store-limit]
+add-peer = 60
+remove-peer = 70
+`,
+			expect: sc.StoreLimitConfig{AddPeer: 60, RemovePeer: 70},
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			cfg := NewConfig()
+			meta, err := toml.Decode(testCase.config, cfg)
+			require.NoError(t, err)
+			require.NoError(t, cfg.Adjust(&meta, false))
+			require.Equal(t, testCase.expect, cfg.Schedule.DefaultStoreLimit)
+		})
+	}
+
+	schedule := &sc.ScheduleConfig{}
+	data := []byte(`{"store-balance-rate":50}`)
+	re.NoError(json.Unmarshal(data, schedule))
+	re.NoError(schedule.MigrateDeprecatedFlagsFromJSON(data))
+	re.Equal(sc.StoreLimitConfig{AddPeer: 50, RemovePeer: 50}, schedule.DefaultStoreLimit)
+
+	schedule = &sc.ScheduleConfig{}
+	data = []byte(`{"store-balance-rate":50,"default-store-limit":{"add-peer":0,"remove-peer":60}}`)
+	re.NoError(json.Unmarshal(data, schedule))
+	re.NoError(schedule.MigrateDeprecatedFlagsFromJSON(data))
+	re.Equal(sc.StoreLimitConfig{AddPeer: 0, RemovePeer: 60}, schedule.DefaultStoreLimit)
+}
+
+func TestReloadLegacyStoreBalanceRate(t *testing.T) {
+	re := require.New(t)
+	oldAddPeer := sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer)
+	oldRemovePeer := sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer)
+	defer func() {
+		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, oldAddPeer)
+		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, oldRemovePeer)
+	}()
+	sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, 15)
+	sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, 15)
+
+	type legacyScheduleConfig struct {
+		StoreBalanceRate float64 `json:"store-balance-rate"`
+	}
+	type legacyConfig struct {
+		Schedule legacyScheduleConfig `json:"schedule"`
+	}
+	storage := storage.NewStorageWithMemoryBackend()
+	re.NoError(storage.SaveConfig(&legacyConfig{
+		Schedule: legacyScheduleConfig{StoreBalanceRate: 60},
+	}))
+
+	opt, err := newTestScheduleOption()
+	re.NoError(err)
+	re.NoError(opt.Reload(storage))
+	expected := sc.StoreLimitConfig{AddPeer: 60, RemovePeer: 60}
+	re.Equal(expected, opt.GetScheduleConfig().DefaultStoreLimit)
+	re.Equal(expected, opt.GetStoreLimit(100))
+	re.Zero(opt.GetScheduleConfig().StoreBalanceRate)
 }
 
 func TestReloadUpgrade(t *testing.T) {
@@ -143,6 +294,17 @@ func TestValidation(t *testing.T) {
 	cfg.Schedule.LowSpaceRatio = 0.4
 	re.Error(cfg.Schedule.Validate())
 	cfg.Schedule.LowSpaceRatio = 0.8
+	re.NoError(cfg.Schedule.Validate())
+	cfg.Schedule.DefaultStoreLimit.AddPeer = -1
+	re.ErrorContains(cfg.Schedule.Validate(), "default-store-limit.add-peer")
+	cfg.Schedule.DefaultStoreLimit.AddPeer = math.Inf(1)
+	re.ErrorContains(cfg.Schedule.Validate(), "default-store-limit.add-peer")
+	cfg.Schedule.DefaultStoreLimit.AddPeer = 15
+	cfg.Schedule.DefaultStoreLimit.RemovePeer = -1
+	re.ErrorContains(cfg.Schedule.Validate(), "default-store-limit.remove-peer")
+	cfg.Schedule.DefaultStoreLimit.RemovePeer = math.NaN()
+	re.ErrorContains(cfg.Schedule.Validate(), "default-store-limit.remove-peer")
+	cfg.Schedule.DefaultStoreLimit.RemovePeer = 15
 	re.NoError(cfg.Schedule.Validate())
 	cfg.Schedule.TolerantSizeRatio = -0.6
 	re.Error(cfg.Schedule.Validate())

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -33,6 +33,7 @@ import (
 	sc "github.com/tikv/pd/pkg/schedule/config"
 	"github.com/tikv/pd/pkg/storage"
 	"github.com/tikv/pd/pkg/utils/configutil"
+	"github.com/tikv/pd/pkg/utils/jsonutil"
 	"github.com/tikv/pd/pkg/utils/logutil"
 	"github.com/tikv/pd/pkg/utils/testutil"
 )
@@ -95,8 +96,13 @@ func TestReloadDefaultStoreLimit(t *testing.T) {
 
 	opt, err := newTestScheduleOption()
 	re.NoError(err)
+	opt.GetScheduleConfig().StoreLimit[1] = sc.StoreLimitConfig{AddPeer: 10, RemovePeer: 20, TransferLeaderIn: 30}
+	opt.GetScheduleConfig().StoreLimit[2] = sc.StoreLimitConfig{TransferLeaderIn: 0}
+	opt.SetStoreLimit(1, storelimit.AddPeer, 40)
+	re.Equal(sc.StoreLimitConfig{AddPeer: 40, RemovePeer: 20, TransferLeaderIn: 30}, opt.GetStoreLimit(1))
 	opt.SetAllStoresLimit(storelimit.AddPeer, 60)
-	re.Equal(sc.StoreLimitConfig{AddPeer: 60, RemovePeer: 15}, opt.GetScheduleConfig().DefaultStoreLimit)
+	re.Equal(sc.StoreLimitConfig{AddPeer: 60, RemovePeer: 20, TransferLeaderIn: 30}, opt.GetStoreLimit(1))
+	re.Equal(sc.StoreLimitConfig{AddPeer: 60, RemovePeer: 15, TransferLeaderIn: storelimit.Unlimited}, opt.GetScheduleConfig().DefaultStoreLimit)
 
 	storage := storage.NewStorageWithMemoryBackend()
 	re.NoError(opt.Persist(storage))
@@ -108,12 +114,14 @@ func TestReloadDefaultStoreLimit(t *testing.T) {
 	re.NoError(err)
 	re.NoError(newOpt.Reload(storage))
 
-	expected := sc.StoreLimitConfig{AddPeer: 60, RemovePeer: 15}
+	expected := sc.StoreLimitConfig{AddPeer: 60, RemovePeer: 15, TransferLeaderIn: storelimit.Unlimited}
 	re.Equal(expected, newOpt.GetScheduleConfig().DefaultStoreLimit)
 	re.Equal(expected, newOpt.GetStoreLimit(100))
+	re.Equal(sc.StoreLimitConfig{AddPeer: 60, RemovePeer: 20, TransferLeaderIn: 30}, newOpt.GetStoreLimit(1))
+	re.Zero(newOpt.GetStoreLimit(2).TransferLeaderIn)
 
 	newOpt.SetStoreLimit(101, storelimit.RemovePeer, 70)
-	re.Equal(sc.StoreLimitConfig{AddPeer: 60, RemovePeer: 70}, newOpt.GetStoreLimit(101))
+	re.Equal(sc.StoreLimitConfig{AddPeer: 60, RemovePeer: 70, TransferLeaderIn: storelimit.Unlimited}, newOpt.GetStoreLimit(101))
 
 	cfg := newOpt.GetScheduleConfig().Clone()
 	cfg.DefaultStoreLimit.AddPeer = 0
@@ -125,20 +133,23 @@ func TestReloadDefaultStoreLimit(t *testing.T) {
 	reloadedOpt, err := newTestScheduleOption()
 	re.NoError(err)
 	re.NoError(reloadedOpt.Reload(storage))
-	re.Equal(sc.StoreLimitConfig{AddPeer: 0, RemovePeer: 15}, reloadedOpt.GetScheduleConfig().DefaultStoreLimit)
-	re.Equal(sc.StoreLimitConfig{AddPeer: 0, RemovePeer: 15}, reloadedOpt.GetStoreLimit(102))
+	re.Equal(sc.StoreLimitConfig{AddPeer: 0, RemovePeer: 15, TransferLeaderIn: storelimit.Unlimited}, reloadedOpt.GetScheduleConfig().DefaultStoreLimit)
+	re.Equal(sc.StoreLimitConfig{AddPeer: 0, RemovePeer: 15, TransferLeaderIn: storelimit.Unlimited}, reloadedOpt.GetStoreLimit(102))
 }
 
 func TestDefaultStoreLimitAdjust(t *testing.T) {
 	re := require.New(t)
 	oldAddPeer := sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer)
 	oldRemovePeer := sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer)
+	oldTransferLeaderIn := sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.TransferLeaderIn)
 	defer func() {
 		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, oldAddPeer)
 		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, oldRemovePeer)
+		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.TransferLeaderIn, oldTransferLeaderIn)
 	}()
 	sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, 15)
 	sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, 15)
+	sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.TransferLeaderIn, storelimit.Unlimited)
 
 	cases := []struct {
 		name   string
@@ -151,8 +162,9 @@ func TestDefaultStoreLimitAdjust(t *testing.T) {
 [schedule.default-store-limit]
 add-peer = 0
 remove-peer = 60
+transfer-leader-in = 0
 `,
-			expect: sc.StoreLimitConfig{AddPeer: 0, RemovePeer: 60},
+			expect: sc.StoreLimitConfig{AddPeer: 0, RemovePeer: 60, TransferLeaderIn: 0},
 		},
 		{
 			name: "store balance rate backfills undefined field",
@@ -163,7 +175,7 @@ store-balance-rate = 50
 [schedule.default-store-limit]
 add-peer = 0
 `,
-			expect: sc.StoreLimitConfig{AddPeer: 0, RemovePeer: 50},
+			expect: sc.StoreLimitConfig{AddPeer: 0, RemovePeer: 50, TransferLeaderIn: storelimit.Unlimited},
 		},
 		{
 			name: "explicit default store limit wins over store balance rate",
@@ -174,8 +186,9 @@ store-balance-rate = 50
 [schedule.default-store-limit]
 add-peer = 60
 remove-peer = 70
+transfer-leader-in = 30
 `,
-			expect: sc.StoreLimitConfig{AddPeer: 60, RemovePeer: 70},
+			expect: sc.StoreLimitConfig{AddPeer: 60, RemovePeer: 70, TransferLeaderIn: 30},
 		},
 	}
 	for _, testCase := range cases {
@@ -192,13 +205,130 @@ remove-peer = 70
 	data := []byte(`{"store-balance-rate":50}`)
 	re.NoError(json.Unmarshal(data, schedule))
 	re.NoError(schedule.MigrateDeprecatedFlagsFromJSON(data))
-	re.Equal(sc.StoreLimitConfig{AddPeer: 50, RemovePeer: 50}, schedule.DefaultStoreLimit)
+	re.Equal(sc.StoreLimitConfig{AddPeer: 50, RemovePeer: 50, TransferLeaderIn: storelimit.Unlimited}, schedule.DefaultStoreLimit)
 
 	schedule = &sc.ScheduleConfig{}
 	data = []byte(`{"store-balance-rate":50,"default-store-limit":{"add-peer":0,"remove-peer":60}}`)
 	re.NoError(json.Unmarshal(data, schedule))
 	re.NoError(schedule.MigrateDeprecatedFlagsFromJSON(data))
-	re.Equal(sc.StoreLimitConfig{AddPeer: 0, RemovePeer: 60}, schedule.DefaultStoreLimit)
+	re.Equal(sc.StoreLimitConfig{AddPeer: 0, RemovePeer: 60, TransferLeaderIn: storelimit.Unlimited}, schedule.DefaultStoreLimit)
+
+	for _, testCase := range []struct {
+		name     string
+		limit    map[string]float64
+		expected float64
+	}{
+		{"omitted transfer limit", map[string]float64{"add-peer": 10, "remove-peer": 20}, 30},
+		{"explicit zero", map[string]float64{"add-peer": 10, "remove-peer": 20, "transfer-leader-in": 0}, 0},
+		{"explicit finite limit", map[string]float64{"add-peer": 10, "remove-peer": 20, "transfer-leader-in": 12}, 12},
+		{"explicit unlimited", map[string]float64{"add-peer": 10, "remove-peer": 20, "transfer-leader-in": storelimit.Unlimited}, storelimit.Unlimited},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			re := require.New(t)
+			cfg := NewConfig()
+			re.NoError(cfg.Adjust(nil, false))
+			cfg.Schedule.DefaultStoreLimit.TransferLeaderIn = 30
+			cfg.Schedule.StoreLimit[2] = sc.StoreLimitConfig{AddPeer: 40, RemovePeer: 50, TransferLeaderIn: 60}
+			updated, found, err := jsonutil.AddKeyValue(&cfg.Schedule, "store-limit", map[uint64]map[string]float64{1: testCase.limit})
+			re.NoError(err)
+			re.True(updated)
+			re.True(found)
+			re.NoError(cfg.Schedule.Validate())
+			expected := sc.StoreLimitConfig{AddPeer: 10, RemovePeer: 20, TransferLeaderIn: testCase.expected}
+			re.Equal(expected, cfg.Schedule.StoreLimit[1])
+			re.Equal(sc.StoreLimitConfig{AddPeer: 40, RemovePeer: 50, TransferLeaderIn: 60}, cfg.Schedule.StoreLimit[2])
+
+			data, err := json.Marshal(map[string]any{
+				"default-store-limit": cfg.Schedule.DefaultStoreLimit,
+				"store-limit":         map[uint64]map[string]float64{1: testCase.limit},
+			})
+			re.NoError(err)
+			persisted := &sc.ScheduleConfig{}
+			re.NoError(json.Unmarshal(data, persisted))
+			re.NoError(persisted.MigrateDeprecatedFlagsFromJSON(data))
+			re.Equal(expected, persisted.StoreLimit[1])
+		})
+	}
+}
+
+func TestStoreLimitPartialJSONUpdates(t *testing.T) {
+	for _, testCase := range []struct {
+		name     string
+		data     string
+		expected map[uint64]sc.StoreLimitConfig
+	}{
+		{"omitted store limits", `{"max-snapshot-count":64}`, nil},
+		{"null store limits", `{"max-snapshot-count":64,"store-limit":null}`, nil},
+		{"empty store limits", `{"max-snapshot-count":64,"store-limit":{}}`, map[uint64]sc.StoreLimitConfig{}},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			re := require.New(t)
+			// Tools decode into a zero-value config, without calling Adjust first.
+			cfg := &sc.ScheduleConfig{}
+			re.NoError(json.Unmarshal([]byte(testCase.data), cfg))
+			re.Equal(testCase.expected, cfg.StoreLimit)
+
+			existing := sc.StoreLimitConfig{AddPeer: 10, RemovePeer: 20, TransferLeaderIn: 300}
+			cfg.StoreLimit = map[uint64]sc.StoreLimitConfig{1: existing}
+			re.NoError(json.Unmarshal([]byte(testCase.data), cfg))
+			re.Equal(map[uint64]sc.StoreLimitConfig{1: existing}, cfg.StoreLimit)
+		})
+	}
+
+	for _, testCase := range []struct {
+		name     string
+		data     string
+		expected sc.StoreLimitConfig
+	}{
+		{"legacy peer update", `{"add-peer":30,"remove-peer":40}`, sc.StoreLimitConfig{AddPeer: 30, RemovePeer: 40, TransferLeaderIn: 300}},
+		{"leader update", `{"transfer-leader-in":120}`, sc.StoreLimitConfig{AddPeer: 10, RemovePeer: 20, TransferLeaderIn: 120}},
+		{"zero", `{"transfer-leader-in":0}`, sc.StoreLimitConfig{AddPeer: 10, RemovePeer: 20}},
+		{"unlimited", `{"transfer-leader-in":100000000}`, sc.StoreLimitConfig{AddPeer: 10, RemovePeer: 20, TransferLeaderIn: storelimit.Unlimited}},
+		{"case insensitive", `{"TRANSFER-LEADER-IN":120}`, sc.StoreLimitConfig{AddPeer: 10, RemovePeer: 20, TransferLeaderIn: 120}},
+		{"null field", `{"transfer-leader-in":null}`, sc.StoreLimitConfig{AddPeer: 10, RemovePeer: 20, TransferLeaderIn: 300}},
+		{"empty entry", `{}`, sc.StoreLimitConfig{AddPeer: 10, RemovePeer: 20, TransferLeaderIn: 300}},
+		{"null entry", `null`, sc.StoreLimitConfig{AddPeer: 10, RemovePeer: 20, TransferLeaderIn: 300}},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			re := require.New(t)
+			cfg := NewConfig()
+			re.NoError(cfg.Adjust(nil, false))
+			cfg.Schedule.StoreLimit[1] = sc.StoreLimitConfig{AddPeer: 10, RemovePeer: 20, TransferLeaderIn: 300}
+			cfg.Schedule.StoreLimit[2] = sc.StoreLimitConfig{AddPeer: 40, RemovePeer: 50, TransferLeaderIn: 600}
+			untouched := cfg.Schedule.StoreLimit[2]
+			defaults := cfg.Schedule.DefaultStoreLimit
+			re.NoError(json.Unmarshal([]byte(`{"store-limit":{"1":`+testCase.data+`}}`), &cfg.Schedule))
+			re.Equal(testCase.expected, cfg.Schedule.StoreLimit[1])
+			re.Equal(untouched, cfg.Schedule.StoreLimit[2])
+			re.Equal(defaults, cfg.Schedule.DefaultStoreLimit)
+
+			store := storage.NewStorageWithMemoryBackend()
+			re.NoError(NewPersistOptions(cfg).Persist(store))
+			reloaded := NewPersistOptions(NewConfig())
+			re.NoError(reloaded.Reload(store))
+			re.Equal(cfg.Schedule.StoreLimit, reloaded.GetScheduleConfig().StoreLimit)
+		})
+	}
+
+	for _, rate := range []float64{0, 300, storelimit.Unlimited} {
+		cfg := &sc.ScheduleConfig{
+			DefaultStoreLimit: sc.StoreLimitConfig{TransferLeaderIn: 120},
+			StoreLimit:        map[uint64]sc.StoreLimitConfig{1: {TransferLeaderIn: rate}},
+		}
+		require.NoError(t, json.Unmarshal([]byte(`{"store-limit":{"1":{"add-peer":10,"remove-peer":20}}}`), cfg))
+		require.Equal(t, rate, cfg.StoreLimit[1].TransferLeaderIn)
+	}
+	for _, data := range []string{
+		`{"default-store-limit":{"add-peer":60,"remove-peer":70,"transfer-leader-in":120},"store-limit":{"1":{"transfer-leader-in":300},"2":{}}}`,
+		`{"store-limit":{"1":{"transfer-leader-in":300},"2":null},"default-store-limit":{"add-peer":60,"remove-peer":70,"transfer-leader-in":120}}`,
+	} {
+		cfg := &sc.ScheduleConfig{}
+		require.NoError(t, json.Unmarshal([]byte(data), cfg))
+		require.Equal(t, sc.StoreLimitConfig{AddPeer: 60, RemovePeer: 70, TransferLeaderIn: 300}, cfg.StoreLimit[1])
+		require.Equal(t, cfg.DefaultStoreLimit, cfg.StoreLimit[2])
+		require.NoError(t, json.Unmarshal([]byte(`{"store-limit":null}`), cfg))
+		require.Len(t, cfg.StoreLimit, 2)
+	}
 }
 
 func TestReloadLegacyStoreBalanceRate(t *testing.T) {
@@ -213,22 +343,29 @@ func TestReloadLegacyStoreBalanceRate(t *testing.T) {
 	sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, 15)
 
 	type legacyScheduleConfig struct {
-		StoreBalanceRate float64 `json:"store-balance-rate"`
+		StoreBalanceRate float64                       `json:"store-balance-rate"`
+		StoreLimit       map[uint64]map[string]float64 `json:"store-limit"`
 	}
 	type legacyConfig struct {
 		Schedule legacyScheduleConfig `json:"schedule"`
 	}
 	storage := storage.NewStorageWithMemoryBackend()
 	re.NoError(storage.SaveConfig(&legacyConfig{
-		Schedule: legacyScheduleConfig{StoreBalanceRate: 60},
+		Schedule: legacyScheduleConfig{
+			StoreBalanceRate: 60,
+			StoreLimit: map[uint64]map[string]float64{
+				1: {"add-peer": 10, "remove-peer": 20},
+			},
+		},
 	}))
 
 	opt, err := newTestScheduleOption()
 	re.NoError(err)
 	re.NoError(opt.Reload(storage))
-	expected := sc.StoreLimitConfig{AddPeer: 60, RemovePeer: 60}
+	expected := sc.StoreLimitConfig{AddPeer: 60, RemovePeer: 60, TransferLeaderIn: storelimit.Unlimited}
 	re.Equal(expected, opt.GetScheduleConfig().DefaultStoreLimit)
 	re.Equal(expected, opt.GetStoreLimit(100))
+	re.Equal(sc.StoreLimitConfig{AddPeer: 10, RemovePeer: 20, TransferLeaderIn: storelimit.Unlimited}, opt.GetStoreLimit(1))
 	re.Zero(opt.GetScheduleConfig().StoreBalanceRate)
 }
 
@@ -305,6 +442,32 @@ func TestValidation(t *testing.T) {
 	cfg.Schedule.DefaultStoreLimit.RemovePeer = math.NaN()
 	re.ErrorContains(cfg.Schedule.Validate(), "default-store-limit.remove-peer")
 	cfg.Schedule.DefaultStoreLimit.RemovePeer = 15
+	for _, rate := range []float64{-1, math.NaN(), math.Inf(1)} {
+		cfg.Schedule.DefaultStoreLimit.TransferLeaderIn = rate
+		re.ErrorContains(cfg.Schedule.Validate(), "default-store-limit.transfer-leader-in")
+	}
+	cfg.Schedule.DefaultStoreLimit.TransferLeaderIn = 0
+	for _, rate := range []float64{-1, math.NaN(), math.Inf(1), math.Inf(-1), 0, 15, storelimit.Unlimited} {
+		for _, testCase := range []struct {
+			name  string
+			limit sc.StoreLimitConfig
+		}{
+			{"add-peer", sc.StoreLimitConfig{AddPeer: rate}},
+			{"remove-peer", sc.StoreLimitConfig{RemovePeer: rate}},
+			{"transfer-leader-in", sc.StoreLimitConfig{TransferLeaderIn: rate}},
+		} {
+			t.Run(fmt.Sprintf("store-limit/%s/%v", testCase.name, rate), func(t *testing.T) {
+				re := require.New(t)
+				cfg.Schedule.StoreLimit[1] = testCase.limit
+				if rate < 0 || math.IsNaN(rate) || math.IsInf(rate, 0) {
+					re.ErrorContains(cfg.Schedule.Validate(), "store-limit[1]."+testCase.name)
+				} else {
+					re.NoError(cfg.Schedule.Validate())
+				}
+			})
+		}
+	}
+	delete(cfg.Schedule.StoreLimit, 1)
 	re.NoError(cfg.Schedule.Validate())
 	cfg.Schedule.TolerantSizeRatio = -0.6
 	re.Error(cfg.Schedule.Validate())

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -16,8 +16,10 @@ package config
 
 import (
 	"context"
+	"encoding/json"
 	"reflect"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"time"
 	"unsafe"
@@ -45,6 +47,8 @@ import (
 // PersistOptions wraps all configurations that need to persist to storage and
 // allows to access them safely.
 type PersistOptions struct {
+	persistMu sync.Mutex
+
 	// configuration -> ttl value
 	ttl             *cache.TTLString
 	schedule        atomic.Value
@@ -84,6 +88,50 @@ func (o *PersistOptions) GetScheduleConfig() *sc.ScheduleConfig {
 // SetScheduleConfig sets the PD scheduling configuration.
 func (o *PersistOptions) SetScheduleConfig(cfg *sc.ScheduleConfig) {
 	o.schedule.Store(cfg)
+}
+
+// mutateScheduleConfig serializes an in-memory field update with schedule
+// persistence transactions. It prevents a helper from publishing a stale full
+// ScheduleConfig after another field has changed.
+func (o *PersistOptions) mutateScheduleConfig(update func(next *sc.ScheduleConfig)) {
+	o.persistMu.Lock()
+	defer o.persistMu.Unlock()
+
+	next := o.GetScheduleConfig().Clone()
+	update(next)
+	o.SetScheduleConfig(next)
+}
+
+// UpdateScheduleConfig serializes a schedule-config read-modify-persist
+// transaction with every other full-config persistence. The current config is
+// read-only; changes must be applied to next. Returning changed=false skips the
+// in-memory publication and persistence.
+func (o *PersistOptions) UpdateScheduleConfig(
+	storage endpoint.ConfigStorage,
+	update func(current, next *sc.ScheduleConfig) (changed bool, err error),
+) error {
+	o.persistMu.Lock()
+	defer o.persistMu.Unlock()
+
+	current := o.GetScheduleConfig()
+	next := current.Clone()
+	changed, err := update(current, next)
+	if err != nil || !changed {
+		return err
+	}
+	o.SetScheduleConfig(next)
+	if err := o.persistLocked(storage); err != nil {
+		o.SetScheduleConfig(current)
+		return err
+	}
+	return nil
+}
+
+// SetSchedulers replaces only the scheduler list on the latest schedule config.
+func (o *PersistOptions) SetSchedulers(schedulers sc.SchedulerConfigs) {
+	o.mutateScheduleConfig(func(next *sc.ScheduleConfig) {
+		next.Schedulers = append(sc.SchedulerConfigs(nil), schedulers...)
+	})
 }
 
 // GetReplicationConfig returns replication configurations.
@@ -371,48 +419,50 @@ func (o *PersistOptions) SetMaxMergeRegionKeys(maxMergeRegionKeys uint64) {
 
 // SetStoreLimit sets a store limit for a given type and rate.
 func (o *PersistOptions) SetStoreLimit(storeID uint64, typ storelimit.Type, ratePerMin float64) {
-	v := o.GetScheduleConfig().Clone()
-	var slc sc.StoreLimitConfig
-	var rate float64
-	switch typ {
-	case storelimit.AddPeer:
-		if _, ok := v.StoreLimit[storeID]; !ok {
-			rate = sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer)
-		} else {
-			rate = v.StoreLimit[storeID].RemovePeer
+	o.mutateScheduleConfig(func(next *sc.ScheduleConfig) {
+		defaultStoreLimit := next.GetDefaultStoreLimit()
+		var slc sc.StoreLimitConfig
+		var rate float64
+		switch typ {
+		case storelimit.AddPeer:
+			if _, ok := next.StoreLimit[storeID]; !ok {
+				rate = defaultStoreLimit.RemovePeer
+			} else {
+				rate = next.StoreLimit[storeID].RemovePeer
+			}
+			slc = sc.StoreLimitConfig{AddPeer: ratePerMin, RemovePeer: rate}
+		case storelimit.RemovePeer:
+			if _, ok := next.StoreLimit[storeID]; !ok {
+				rate = defaultStoreLimit.AddPeer
+			} else {
+				rate = next.StoreLimit[storeID].AddPeer
+			}
+			slc = sc.StoreLimitConfig{AddPeer: rate, RemovePeer: ratePerMin}
 		}
-		slc = sc.StoreLimitConfig{AddPeer: ratePerMin, RemovePeer: rate}
-	case storelimit.RemovePeer:
-		if _, ok := v.StoreLimit[storeID]; !ok {
-			rate = sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer)
-		} else {
-			rate = v.StoreLimit[storeID].AddPeer
-		}
-		slc = sc.StoreLimitConfig{AddPeer: rate, RemovePeer: ratePerMin}
-	}
-	v.StoreLimit[storeID] = slc
-	o.SetScheduleConfig(v)
+		next.StoreLimit[storeID] = slc
+	})
 }
 
 // SetAllStoresLimit sets all store limit for a given type and rate.
 func (o *PersistOptions) SetAllStoresLimit(typ storelimit.Type, ratePerMin float64) {
-	v := o.GetScheduleConfig().Clone()
-	switch typ {
-	case storelimit.AddPeer:
-		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, ratePerMin)
-		for storeID := range v.StoreLimit {
-			sc := sc.StoreLimitConfig{AddPeer: ratePerMin, RemovePeer: v.StoreLimit[storeID].RemovePeer}
-			v.StoreLimit[storeID] = sc
+	o.mutateScheduleConfig(func(next *sc.ScheduleConfig) {
+		switch typ {
+		case storelimit.AddPeer:
+			next.DefaultStoreLimit.AddPeer = ratePerMin
+			sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, ratePerMin)
+			for storeID := range next.StoreLimit {
+				sc := sc.StoreLimitConfig{AddPeer: ratePerMin, RemovePeer: next.StoreLimit[storeID].RemovePeer}
+				next.StoreLimit[storeID] = sc
+			}
+		case storelimit.RemovePeer:
+			next.DefaultStoreLimit.RemovePeer = ratePerMin
+			sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, ratePerMin)
+			for storeID := range next.StoreLimit {
+				sc := sc.StoreLimitConfig{AddPeer: next.StoreLimit[storeID].AddPeer, RemovePeer: ratePerMin}
+				next.StoreLimit[storeID] = sc
+			}
 		}
-	case storelimit.RemovePeer:
-		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, ratePerMin)
-		for storeID := range v.StoreLimit {
-			sc := sc.StoreLimitConfig{AddPeer: v.StoreLimit[storeID].AddPeer, RemovePeer: ratePerMin}
-			v.StoreLimit[storeID] = sc
-		}
-	}
-
-	o.SetScheduleConfig(v)
+	})
 }
 
 // IsOneWayMergeEnabled returns if a region can only be merged into the next region of it.
@@ -475,14 +525,15 @@ func (o *PersistOptions) GetStoreLimit(storeID uint64) (returnSC sc.StoreLimitCo
 	if limit, ok := o.GetScheduleConfig().StoreLimit[storeID]; ok {
 		return limit
 	}
-	cfg := o.GetScheduleConfig().Clone()
-	limitCfg := sc.StoreLimitConfig{
-		AddPeer:    sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer),
-		RemovePeer: sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer),
-	}
-	cfg.StoreLimit[storeID] = limitCfg
-	o.SetScheduleConfig(cfg)
-	return o.GetScheduleConfig().StoreLimit[storeID]
+	o.mutateScheduleConfig(func(next *sc.ScheduleConfig) {
+		if limit, ok := next.StoreLimit[storeID]; ok {
+			returnSC = limit
+			return
+		}
+		returnSC = next.GetDefaultStoreLimit()
+		next.StoreLimit[storeID] = returnSC
+	})
+	return returnSC
 }
 
 // GetStoreLimitByType returns the limit of a store with a given type.
@@ -689,42 +740,41 @@ func (o *PersistOptions) GetHotRegionsReservedDays() uint64 {
 // AddSchedulerCfg adds the scheduler configurations.
 func (o *PersistOptions) AddSchedulerCfg(tp types.CheckerSchedulerType, args []string) {
 	oldType := types.SchedulerTypeCompatibleMap[tp]
-	v := o.GetScheduleConfig().Clone()
-	for i, schedulerCfg := range v.Schedulers {
-		// comparing args is to cover the case that there are schedulers in same type but not with same name
-		// such as two schedulers of type "evict-leader",
-		// one name is "evict-leader-scheduler-1" and the other is "evict-leader-scheduler-2"
-		if reflect.DeepEqual(schedulerCfg, sc.SchedulerConfig{Type: oldType, Args: args, Disable: false}) {
-			return
-		}
+	o.mutateScheduleConfig(func(next *sc.ScheduleConfig) {
+		for i, schedulerCfg := range next.Schedulers {
+			// comparing args is to cover the case that there are schedulers in same type but not with same name
+			// such as two schedulers of type "evict-leader",
+			// one name is "evict-leader-scheduler-1" and the other is "evict-leader-scheduler-2"
+			if reflect.DeepEqual(schedulerCfg, sc.SchedulerConfig{Type: oldType, Args: args, Disable: false}) {
+				return
+			}
 
-		if reflect.DeepEqual(schedulerCfg, sc.SchedulerConfig{Type: oldType, Args: args, Disable: true}) {
-			schedulerCfg.Disable = false
-			v.Schedulers[i] = schedulerCfg
-			o.SetScheduleConfig(v)
-			return
+			if reflect.DeepEqual(schedulerCfg, sc.SchedulerConfig{Type: oldType, Args: args, Disable: true}) {
+				schedulerCfg.Disable = false
+				next.Schedulers[i] = schedulerCfg
+				return
+			}
 		}
-	}
-	v.Schedulers = append(v.Schedulers, sc.SchedulerConfig{Type: oldType, Args: args, Disable: false})
-	o.SetScheduleConfig(v)
+		next.Schedulers = append(next.Schedulers, sc.SchedulerConfig{Type: oldType, Args: args, Disable: false})
+	})
 }
 
 // RemoveSchedulerCfg removes the scheduler configurations.
 func (o *PersistOptions) RemoveSchedulerCfg(tp types.CheckerSchedulerType) {
 	oldType := types.SchedulerTypeCompatibleMap[tp]
-	v := o.GetScheduleConfig().Clone()
-	for i, schedulerCfg := range v.Schedulers {
-		if oldType == schedulerCfg.Type {
-			if sc.IsDefaultScheduler(oldType) {
-				schedulerCfg.Disable = true
-				v.Schedulers[i] = schedulerCfg
-			} else {
-				v.Schedulers = append(v.Schedulers[:i], v.Schedulers[i+1:]...)
+	o.mutateScheduleConfig(func(next *sc.ScheduleConfig) {
+		for i, schedulerCfg := range next.Schedulers {
+			if oldType == schedulerCfg.Type {
+				if sc.IsDefaultScheduler(oldType) {
+					schedulerCfg.Disable = true
+					next.Schedulers[i] = schedulerCfg
+				} else {
+					next.Schedulers = append(next.Schedulers[:i], next.Schedulers[i+1:]...)
+				}
+				return
 			}
-			o.SetScheduleConfig(v)
-			return
 		}
-	}
+	})
 }
 
 // SetLabelProperty sets the label property.
@@ -763,14 +813,41 @@ type persistedConfig struct {
 	StoreConfig sc.StoreConfig `json:"store"`
 }
 
+// UnmarshalJSON consumes persisted schedule-field presence while decoding, so
+// decoder metadata never leaks into the runtime ScheduleConfig.
+func (c *persistedConfig) UnmarshalJSON(data []byte) error {
+	type plainPersistedConfig persistedConfig
+	if err := json.Unmarshal(data, (*plainPersistedConfig)(c)); err != nil {
+		return err
+	}
+	var fields struct {
+		Schedule json.RawMessage `json:"schedule"`
+	}
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	if len(fields.Schedule) == 0 {
+		return nil
+	}
+	return c.Schedule.MigrateDeprecatedFlagsFromJSON(fields.Schedule)
+}
+
 // SwitchRaftV2 update some config if tikv raft engine switch into partition raft v2
 func (o *PersistOptions) SwitchRaftV2(storage endpoint.ConfigStorage) error {
-	o.GetScheduleConfig().StoreLimitVersion = "v2"
-	return o.Persist(storage)
+	return o.UpdateScheduleConfig(storage, func(_ *sc.ScheduleConfig, next *sc.ScheduleConfig) (bool, error) {
+		next.StoreLimitVersion = storelimit.VersionV2
+		return true, nil
+	})
 }
 
 // Persist saves the configuration to the storage.
 func (o *PersistOptions) Persist(storage endpoint.ConfigStorage) error {
+	o.persistMu.Lock()
+	defer o.persistMu.Unlock()
+	return o.persistLocked(storage)
+}
+
+func (o *PersistOptions) persistLocked(storage endpoint.ConfigStorage) error {
 	cfg := &persistedConfig{
 		Config: &Config{
 			Schedule:        *o.GetScheduleConfig(),

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -420,47 +420,21 @@ func (o *PersistOptions) SetMaxMergeRegionKeys(maxMergeRegionKeys uint64) {
 // SetStoreLimit sets a store limit for a given type and rate.
 func (o *PersistOptions) SetStoreLimit(storeID uint64, typ storelimit.Type, ratePerMin float64) {
 	o.mutateScheduleConfig(func(next *sc.ScheduleConfig) {
-		defaultStoreLimit := next.GetDefaultStoreLimit()
-		var slc sc.StoreLimitConfig
-		var rate float64
-		switch typ {
-		case storelimit.AddPeer:
-			if _, ok := next.StoreLimit[storeID]; !ok {
-				rate = defaultStoreLimit.RemovePeer
-			} else {
-				rate = next.StoreLimit[storeID].RemovePeer
-			}
-			slc = sc.StoreLimitConfig{AddPeer: ratePerMin, RemovePeer: rate}
-		case storelimit.RemovePeer:
-			if _, ok := next.StoreLimit[storeID]; !ok {
-				rate = defaultStoreLimit.AddPeer
-			} else {
-				rate = next.StoreLimit[storeID].AddPeer
-			}
-			slc = sc.StoreLimitConfig{AddPeer: rate, RemovePeer: ratePerMin}
+		limit, ok := next.StoreLimit[storeID]
+		if !ok {
+			limit = next.GetDefaultStoreLimit()
 		}
-		next.StoreLimit[storeID] = slc
+		next.StoreLimit[storeID] = limit.SetLimit(typ, ratePerMin)
 	})
 }
 
 // SetAllStoresLimit sets all store limit for a given type and rate.
 func (o *PersistOptions) SetAllStoresLimit(typ storelimit.Type, ratePerMin float64) {
 	o.mutateScheduleConfig(func(next *sc.ScheduleConfig) {
-		switch typ {
-		case storelimit.AddPeer:
-			next.DefaultStoreLimit.AddPeer = ratePerMin
-			sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, ratePerMin)
-			for storeID := range next.StoreLimit {
-				sc := sc.StoreLimitConfig{AddPeer: ratePerMin, RemovePeer: next.StoreLimit[storeID].RemovePeer}
-				next.StoreLimit[storeID] = sc
-			}
-		case storelimit.RemovePeer:
-			next.DefaultStoreLimit.RemovePeer = ratePerMin
-			sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, ratePerMin)
-			for storeID := range next.StoreLimit {
-				sc := sc.StoreLimitConfig{AddPeer: next.StoreLimit[storeID].AddPeer, RemovePeer: ratePerMin}
-				next.StoreLimit[storeID] = sc
-			}
+		next.DefaultStoreLimit = next.DefaultStoreLimit.SetLimit(typ, ratePerMin)
+		sc.DefaultStoreLimit.SetDefaultStoreLimit(typ, ratePerMin)
+		for storeID, limit := range next.StoreLimit {
+			next.StoreLimit[storeID] = limit.SetLimit(typ, ratePerMin)
 		}
 	})
 }
@@ -544,6 +518,8 @@ func (o *PersistOptions) GetStoreLimitByType(storeID uint64, typ storelimit.Type
 		return limit.AddPeer
 	case storelimit.RemovePeer:
 		return limit.RemovePeer
+	case storelimit.TransferLeaderIn:
+		return limit.TransferLeaderIn
 	// todo: impl it in store limit v2.
 	case storelimit.SendSnapshot:
 		return 0.0

--- a/server/server.go
+++ b/server/server.go
@@ -17,6 +17,7 @@ package server
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"math"
 	"math/rand/v2"
@@ -1076,27 +1077,72 @@ func (s *Server) GetScheduleConfig() *sc.ScheduleConfig {
 }
 
 // SetScheduleConfig sets the balance config information.
-// This function is exported to be used by the API.
 func (s *Server) SetScheduleConfig(cfg sc.ScheduleConfig) error {
-	if err := cfg.Validate(); err != nil {
-		return err
-	}
-	if err := cfg.Deprecated(); err != nil {
-		return err
-	}
-	old := s.persistOptions.GetScheduleConfig()
-	s.persistOptions.SetScheduleConfig(&cfg)
-	if err := s.persistOptions.Persist(s.storage); err != nil {
-		s.persistOptions.SetScheduleConfig(old)
+	return s.updateScheduleConfig(func(_ *sc.ScheduleConfig, next *sc.ScheduleConfig) (bool, error) {
+		*next = *cfg.Clone()
+		return true, nil
+	})
+}
+
+// PatchScheduleConfig applies a partial JSON update to the latest schedule
+// config inside the schedule persistence transaction.
+func (s *Server) PatchScheduleConfig(data []byte) error {
+	return s.updateScheduleConfig(func(_ *sc.ScheduleConfig, next *sc.ScheduleConfig) (bool, error) {
+		if err := json.Unmarshal(data, next); err != nil {
+			return false, err
+		}
+		return true, nil
+	})
+}
+
+// SetScheduleConfigItem applies one legacy /config schedule item to the latest
+// schedule config inside the schedule persistence transaction.
+func (s *Server) SetScheduleConfigItem(key string, value any) error {
+	return s.updateScheduleConfig(func(_ *sc.ScheduleConfig, next *sc.ScheduleConfig) (bool, error) {
+		updated, found, err := jsonutil.AddKeyValue(next, key, value)
+		if err != nil {
+			return false, err
+		}
+		if !found {
+			return false, errors.Errorf("config item %s not found", key)
+		}
+		return updated, nil
+	})
+}
+
+func (s *Server) updateScheduleConfig(
+	update func(current, next *sc.ScheduleConfig) (changed bool, err error),
+) error {
+	var oldCfg, newCfg *sc.ScheduleConfig
+	var applied bool
+	err := s.persistOptions.UpdateScheduleConfig(s.storage, func(current, next *sc.ScheduleConfig) (bool, error) {
+		changed, err := update(current, next)
+		oldCfg, newCfg = current, next
+		if err != nil || !changed {
+			return changed, err
+		}
+		if err := next.Validate(); err != nil {
+			return false, err
+		}
+		if err := next.Deprecated(); err != nil {
+			return false, err
+		}
+		applied = true
+		return true, nil
+	})
+	if err != nil {
 		log.Error("failed to update schedule config",
-			zap.Reflect("new", cfg),
-			zap.Reflect("old", old),
+			zap.Reflect("new", newCfg),
+			zap.Reflect("old", oldCfg),
 			errs.ZapError(err))
 		return err
 	}
+	if !applied {
+		return nil
+	}
 	// Update the scheduling halt status at the same time.
-	s.persistOptions.SetSchedulingAllowanceStatus(cfg.HaltScheduling, "manually")
-	log.Info("schedule config is updated", zap.Reflect("new", cfg), zap.Reflect("old", old))
+	s.persistOptions.SetSchedulingAllowanceStatus(newCfg.HaltScheduling, "manually")
+	log.Info("schedule config is updated", zap.Reflect("new", newCfg), zap.Reflect("old", oldCfg))
 	return nil
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,0 +1,101 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	sc "github.com/tikv/pd/pkg/schedule/config"
+	"github.com/tikv/pd/pkg/storage"
+	"github.com/tikv/pd/server/config"
+)
+
+func TestPartialScheduleConfigUpdatesPreserveLatestFields(t *testing.T) {
+	re := require.New(t)
+	cfg := config.NewConfig()
+	re.NoError(cfg.Adjust(nil, false))
+	store := storage.NewStorageWithMemoryBackend()
+	s := &Server{
+		persistOptions: config.NewPersistOptions(cfg),
+		storage:        store,
+	}
+
+	defaultLimit := s.GetScheduleConfig().DefaultStoreLimit.AddPeer + 30
+	re.NoError(s.persistOptions.UpdateScheduleConfig(store, func(_ *sc.ScheduleConfig, next *sc.ScheduleConfig) (bool, error) {
+		next.DefaultStoreLimit.AddPeer = defaultLimit
+		return true, nil
+	}))
+	re.NoError(s.PatchScheduleConfig([]byte(`{"max-snapshot-count":99}`)))
+	re.NoError(s.SetScheduleConfigItem("max-pending-peer-count", float64(88)))
+
+	current := s.GetScheduleConfig()
+	re.Equal(defaultLimit, current.DefaultStoreLimit.AddPeer)
+	re.Equal(uint64(99), current.MaxSnapshotCount)
+	re.Equal(uint64(88), current.MaxPendingPeerCount)
+
+	reloaded := config.NewPersistOptions(config.NewConfig())
+	re.NoError(reloaded.Reload(store))
+	re.Equal(defaultLimit, reloaded.GetScheduleConfig().DefaultStoreLimit.AddPeer)
+	re.Equal(uint64(99), reloaded.GetScheduleConfig().MaxSnapshotCount)
+	re.Equal(uint64(88), reloaded.GetScheduleConfig().MaxPendingPeerCount)
+}
+
+func TestConcurrentPartialScheduleConfigUpdatesDoNotConflict(t *testing.T) {
+	re := require.New(t)
+	cfg := config.NewConfig()
+	re.NoError(cfg.Adjust(nil, false))
+	store := storage.NewStorageWithMemoryBackend()
+	s := &Server{
+		persistOptions: config.NewPersistOptions(cfg),
+		storage:        store,
+	}
+
+	const updates = 16
+	start := make(chan struct{})
+	errCh := make(chan error, updates*2)
+	var wg sync.WaitGroup
+	for i := range updates {
+		wg.Add(2)
+		go func(value int) {
+			defer wg.Done()
+			<-start
+			errCh <- s.PatchScheduleConfig([]byte(fmt.Sprintf(`{"max-snapshot-count":%d}`, value+1)))
+		}(i)
+		go func(value int) {
+			defer wg.Done()
+			<-start
+			errCh <- s.persistOptions.UpdateScheduleConfig(store, func(_ *sc.ScheduleConfig, next *sc.ScheduleConfig) (bool, error) {
+				next.DefaultStoreLimit.AddPeer = float64(value + 30)
+				return true, nil
+			})
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		re.NoError(err)
+	}
+
+	current := s.GetScheduleConfig()
+	reloaded := config.NewPersistOptions(config.NewConfig())
+	re.NoError(reloaded.Reload(store))
+	re.Equal(current.DefaultStoreLimit, reloaded.GetScheduleConfig().DefaultStoreLimit)
+	re.Equal(current.MaxSnapshotCount, reloaded.GetScheduleConfig().MaxSnapshotCount)
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/tikv/pd/pkg/core/storelimit"
 	sc "github.com/tikv/pd/pkg/schedule/config"
 	"github.com/tikv/pd/pkg/storage"
 	"github.com/tikv/pd/server/config"
@@ -28,6 +29,12 @@ import (
 
 func TestPartialScheduleConfigUpdatesPreserveLatestFields(t *testing.T) {
 	re := require.New(t)
+	oldDefaultStoreLimit := sc.DefaultStoreLimitConfig()
+	t.Cleanup(func() {
+		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, oldDefaultStoreLimit.AddPeer)
+		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, oldDefaultStoreLimit.RemovePeer)
+		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.TransferLeaderIn, oldDefaultStoreLimit.TransferLeaderIn)
+	})
 	cfg := config.NewConfig()
 	re.NoError(cfg.Adjust(nil, false))
 	store := storage.NewStorageWithMemoryBackend()
@@ -43,17 +50,54 @@ func TestPartialScheduleConfigUpdatesPreserveLatestFields(t *testing.T) {
 	}))
 	re.NoError(s.PatchScheduleConfig([]byte(`{"max-snapshot-count":99}`)))
 	re.NoError(s.SetScheduleConfigItem("max-pending-peer-count", float64(88)))
+	re.NoError(s.SetScheduleConfigItem("default-store-limit", map[string]float64{"transfer-leader-in": 30}))
+	re.NoError(s.SetScheduleConfigItem("store-limit", map[uint64]map[string]float64{
+		1: {"add-peer": 10, "remove-peer": 20},
+	}))
 
 	current := s.GetScheduleConfig()
 	re.Equal(defaultLimit, current.DefaultStoreLimit.AddPeer)
 	re.Equal(uint64(99), current.MaxSnapshotCount)
 	re.Equal(uint64(88), current.MaxPendingPeerCount)
+	re.Equal(sc.StoreLimitConfig{AddPeer: 10, RemovePeer: 20, TransferLeaderIn: 30}, current.StoreLimit[1])
 
 	reloaded := config.NewPersistOptions(config.NewConfig())
 	re.NoError(reloaded.Reload(store))
 	re.Equal(defaultLimit, reloaded.GetScheduleConfig().DefaultStoreLimit.AddPeer)
 	re.Equal(uint64(99), reloaded.GetScheduleConfig().MaxSnapshotCount)
 	re.Equal(uint64(88), reloaded.GetScheduleConfig().MaxPendingPeerCount)
+	re.Equal(current.StoreLimit[1], reloaded.GetStoreLimit(1))
+}
+
+func TestConcurrentStoreLimitPartialUpdates(t *testing.T) {
+	re := require.New(t)
+	cfg := config.NewConfig()
+	re.NoError(cfg.Adjust(nil, false))
+	cfg.Schedule.StoreLimit[1] = sc.StoreLimitConfig{}
+	store := storage.NewStorageWithMemoryBackend()
+	s := &Server{persistOptions: config.NewPersistOptions(cfg), storage: store}
+	patches := []string{
+		`{"store-limit":{"1":{"add-peer":10}}}`,
+		`{"store-limit":{"1":{"remove-peer":20}}}`,
+		`{"store-limit":{"1":{"transfer-leader-in":30}}}`,
+	}
+	start := make(chan struct{})
+	errs := make(chan error, len(patches))
+	for _, patch := range patches {
+		go func() {
+			<-start
+			errs <- s.PatchScheduleConfig([]byte(patch))
+		}()
+	}
+	close(start)
+	for range patches {
+		re.NoError(<-errs)
+	}
+	expected := sc.StoreLimitConfig{AddPeer: 10, RemovePeer: 20, TransferLeaderIn: 30}
+	re.Equal(expected, s.GetScheduleConfig().StoreLimit[1])
+	reloaded := config.NewPersistOptions(config.NewConfig())
+	re.NoError(reloaded.Reload(store))
+	re.Equal(expected, reloaded.GetStoreLimit(1))
 }
 
 func TestConcurrentPartialScheduleConfigUpdatesDoNotConflict(t *testing.T) {

--- a/tests/integrations/mcs/scheduling/server_test.go
+++ b/tests/integrations/mcs/scheduling/server_test.go
@@ -869,6 +869,29 @@ func (suite *serverTestSuite) TestStoreLimit() {
 	}
 	op = operator.NewTestOperator(2, &metapb.RegionEpoch{}, operator.OpRegion, operator.RemovePeer{FromStore: 2})
 	checkOperatorFail(re, oc, op)
+
+	setTransferLeaderInLimit := func(rate float64) {
+		url := fmt.Sprintf("%s/pd/api/v1/store/2/limit", leaderServer.GetAddr())
+		body := fmt.Sprintf(`{"rate":%g,"type":"transfer-leader-in"}`, rate)
+		re.NoError(testutil.CheckPostJSON(tests.TestDialClient, url, []byte(body), testutil.StatusOK(re)))
+	}
+	setTransferLeaderInLimit(0.00006)
+	waitSyncFinish(re, tc, storelimit.TransferLeaderIn, 0.00006)
+	op = operator.NewTestOperator(2, &metapb.RegionEpoch{}, operator.OpLeader,
+		operator.TransferLeader{FromStore: 1, ToStore: 2})
+	checkOperatorSuccess(re, oc, op)
+	op = operator.NewTestOperator(2, &metapb.RegionEpoch{}, operator.OpLeader,
+		operator.TransferLeader{FromStore: 1, ToStore: 2})
+	checkOperatorFail(re, oc, op)
+
+	setTransferLeaderInLimit(storelimit.Unlimited)
+	waitSyncFinish(re, tc, storelimit.TransferLeaderIn, storelimit.Unlimited)
+	// Controller admission refreshes the in-memory limiter from the synchronized configuration.
+	for range 2 {
+		op = operator.NewTestOperator(2, &metapb.RegionEpoch{}, operator.OpLeader,
+			operator.TransferLeader{FromStore: 1, ToStore: 2})
+		checkOperatorSuccess(re, oc, op)
+	}
 }
 
 func checkOperatorSuccess(re *require.Assertions, oc *operator.Controller, op *operator.Operator) {

--- a/tests/server/api/store_test.go
+++ b/tests/server/api/store_test.go
@@ -15,6 +15,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -31,7 +32,10 @@ import (
 	"github.com/pingcap/kvproto/pkg/pdpb"
 
 	"github.com/tikv/pd/pkg/core"
+	"github.com/tikv/pd/pkg/mcs/discovery"
+	"github.com/tikv/pd/pkg/mcs/utils/constant"
 	"github.com/tikv/pd/pkg/response"
+	"github.com/tikv/pd/pkg/utils/keypath"
 	"github.com/tikv/pd/pkg/utils/testutil"
 	"github.com/tikv/pd/pkg/utils/typeutil"
 	"github.com/tikv/pd/pkg/versioninfo"
@@ -149,6 +153,44 @@ func (suite *storeTestSuite) checkStoresList(cluster *tests.TestCluster) {
 func (suite *storeTestSuite) TestStores() {
 	suite.env.RunTestInNonMicroserviceEnv(suite.checkGetAllLimit)
 	suite.env.RunTestInNonMicroserviceEnv(suite.checkStoreLabel)
+}
+
+func (suite *storeTestSuite) TestStoreLimitRemainsAvailableDuringRollingUpgrade() {
+	suite.env.RunTest(suite.checkStoreLimitRemainsAvailableDuringRollingUpgrade)
+}
+
+func (suite *storeTestSuite) checkStoreLimitRemainsAvailableDuringRollingUpgrade(cluster *tests.TestCluster) {
+	re := suite.Require()
+	leader := cluster.GetLeaderServer()
+	url := leader.GetAddr() + "/pd/api/v1/stores/limit"
+	currentDefault := leader.GetPersistOptions().GetScheduleConfig().DefaultStoreLimit.AddPeer
+	newDefault := currentDefault + 45
+	body := []byte(fmt.Sprintf(`{"rate":%v,"type":"add-peer"}`, newDefault))
+
+	if schedulingServer := cluster.GetSchedulingPrimaryServer(); schedulingServer != nil {
+		entry := &discovery.ServiceRegistryEntry{
+			Name:        "pre-feature-scheduling",
+			ServiceAddr: "http://127.0.0.1:1",
+			Version:     versioninfo.PDReleaseVersion,
+		}
+		serializedEntry, err := entry.Serialize()
+		re.NoError(err)
+		registryPath := keypath.RegistryPath(constant.SchedulingServiceName, entry.ServiceAddr)
+		_, err = cluster.GetEtcdClient().Put(context.Background(), registryPath, serializedEntry)
+		re.NoError(err)
+		// /stores/limit existed before default persistence. Keep it available
+		// during rolling upgrades without synchronously depending on every
+		// registered Scheduling Service member.
+		err = testutil.CheckPostJSON(tests.TestDialClient, url, body, testutil.StatusOK(re))
+		re.NoError(err)
+		re.Equal(newDefault, leader.GetPersistOptions().GetScheduleConfig().DefaultStoreLimit.AddPeer)
+		_, err = cluster.GetEtcdClient().Delete(context.Background(), registryPath)
+		re.NoError(err)
+		return
+	}
+	err := testutil.CheckPostJSON(tests.TestDialClient, url, body, testutil.StatusOK(re))
+	re.NoError(err)
+	re.Equal(newDefault, leader.GetPersistOptions().GetScheduleConfig().DefaultStoreLimit.AddPeer)
 }
 
 func (suite *storeTestSuite) checkGetAllLimit(cluster *tests.TestCluster) {

--- a/tests/server/cluster/cluster_test.go
+++ b/tests/server/cluster/cluster_test.go
@@ -1217,7 +1217,7 @@ func TestTiFlashWithPlacementRules(t *testing.T) {
 	re.NoError(err)
 	re.Equal(pdpb.ErrorType_OK, resp.GetHeader().GetError().GetType())
 	// test TiFlash store limit
-	expect := map[uint64]sc.StoreLimitConfig{11: {AddPeer: 30, RemovePeer: 30}}
+	expect := map[uint64]sc.StoreLimitConfig{11: {AddPeer: 30, RemovePeer: 30, TransferLeaderIn: storelimit.Unlimited}}
 	re.Equal(expect, svr.GetScheduleConfig().StoreLimit)
 
 	// cannot disable placement rules with TiFlash nodes

--- a/tests/server/config/config_test.go
+++ b/tests/server/config/config_test.go
@@ -257,6 +257,114 @@ func (suite *configTestSuite) checkConfigSchedule(cluster *tests.TestCluster) {
 		testutil.StringContain(re, "default-store-limit.add-peer should be finite and non-negative"))
 	re.NoError(err)
 	re.Equal(scheduleConfig.DefaultStoreLimit, leaderServer.GetPersistOptions().GetScheduleConfig().DefaultStoreLimit)
+
+	for _, endpoint := range []string{"config", "config/schedule"} {
+		addr := fmt.Sprintf("%s/pd/api/v1/%s", urlPrefix, endpoint)
+		postData = []byte(`{"store-limit":{"1":{"add-peer":0,"remove-peer":0,"transfer-leader-in":0},"2":{"add-peer":10,"remove-peer":20,"transfer-leader-in":30}}}`)
+		re.NoError(testutil.CheckPostJSON(tests.TestDialClient, addr, postData, testutil.StatusOK(re)))
+		current := leaderServer.GetPersistOptions().GetScheduleConfig().Clone()
+		re.Equal(sc.StoreLimitConfig{}, current.StoreLimit[1])
+		re.Equal(sc.StoreLimitConfig{AddPeer: 10, RemovePeer: 20, TransferLeaderIn: 30}, current.StoreLimit[2])
+		re.Equal(scheduleConfig.DefaultStoreLimit, current.DefaultStoreLimit)
+		re.Equal(scheduleConfig.MaxStoreDownTime, current.MaxStoreDownTime)
+		persisted := &config.Config{}
+		exists, err := leaderServer.GetServer().GetStorage().LoadConfig(persisted)
+		re.NoError(err)
+		re.True(exists)
+		re.Equal(current.StoreLimit, persisted.Schedule.StoreLimit)
+
+		for _, field := range []string{"add-peer", "remove-peer", "transfer-leader-in"} {
+			postData, err = json.Marshal(map[string]any{
+				"store-limit": map[string]any{"1": map[string]float64{field: -1}},
+			})
+			re.NoError(err)
+			re.NoError(testutil.CheckPostJSON(tests.TestDialClient, addr, postData,
+				testutil.StatusNotOK(re),
+				testutil.StringContain(re, "store-limit[1]."+field+" should be finite and non-negative")))
+			re.Equal(current, leaderServer.GetPersistOptions().GetScheduleConfig())
+			after := &config.Config{}
+			exists, err = leaderServer.GetServer().GetStorage().LoadConfig(after)
+			re.NoError(err)
+			re.True(exists)
+			re.Equal(persisted.Schedule, after.Schedule)
+		}
+	}
+}
+
+func (suite *configTestSuite) TestStoreLimitPartialUpdates() {
+	suite.env.RunTest(suite.checkStoreLimitPartialUpdates)
+}
+
+func (suite *configTestSuite) checkStoreLimitPartialUpdates(cluster *tests.TestCluster) {
+	re := suite.Require()
+	leader := cluster.GetLeaderServer()
+	for _, endpoint := range []string{"config", "config/schedule"} {
+		addr := leader.GetAddr() + "/pd/api/v1/" + endpoint
+		for _, testCase := range []struct {
+			patch    string
+			expected sc.StoreLimitConfig
+		}{
+			{`{"add-peer":30,"remove-peer":40}`, sc.StoreLimitConfig{AddPeer: 30, RemovePeer: 40, TransferLeaderIn: 300}},
+			{`{"transfer-leader-in":120}`, sc.StoreLimitConfig{AddPeer: 10, RemovePeer: 20, TransferLeaderIn: 120}},
+			{`{"transfer-leader-in":0}`, sc.StoreLimitConfig{AddPeer: 10, RemovePeer: 20}},
+			{`{"TRANSFER-LEADER-IN":120}`, sc.StoreLimitConfig{AddPeer: 10, RemovePeer: 20, TransferLeaderIn: 120}},
+			{`{"add-peer":null,"remove-peer":null,"transfer-leader-in":null}`, sc.StoreLimitConfig{AddPeer: 10, RemovePeer: 20, TransferLeaderIn: 300}},
+			{`{}`, sc.StoreLimitConfig{AddPeer: 10, RemovePeer: 20, TransferLeaderIn: 300}},
+			{`null`, sc.StoreLimitConfig{AddPeer: 10, RemovePeer: 20, TransferLeaderIn: 300}},
+		} {
+			seed := []byte(`{"store-limit":{"1":{"add-peer":10,"remove-peer":20,"transfer-leader-in":300}}}`)
+			re.NoError(testutil.CheckPostJSON(tests.TestDialClient, addr, seed, testutil.StatusOK(re)))
+			before := leader.GetPersistOptions().GetScheduleConfig().Clone()
+			patch := []byte(`{"store-limit":{"1":` + testCase.patch + `}}`)
+			re.NoError(testutil.CheckPostJSON(tests.TestDialClient, addr, patch, testutil.StatusOK(re)))
+			before.StoreLimit[1] = testCase.expected
+			re.Equal(before, leader.GetPersistOptions().GetScheduleConfig())
+			persisted := &config.Config{}
+			exists, err := leader.GetServer().GetStorage().LoadConfig(persisted)
+			re.NoError(err)
+			re.True(exists)
+			re.Equal(before.StoreLimit, persisted.Schedule.StoreLimit)
+		}
+
+		// Each request adds a fresh store so an earlier iteration cannot mask a
+		// default/store ordering bug. Exercise both legacy key spellings as well.
+		for i := range 20 {
+			prefix := ""
+			if endpoint == "config" && i%2 == 0 {
+				prefix = "schedule."
+			}
+			storeID := uint64(9000 + i)
+			if endpoint == "config/schedule" {
+				storeID += 1000
+			}
+			patch := fmt.Appendf(nil, `{"%sstore-limit":{"%d":{"transfer-leader-in":300},"%d":{}},"%sdefault-store-limit":{"add-peer":%d,"remove-peer":70,"transfer-leader-in":120}}`,
+				prefix, storeID, storeID+100, prefix, 60+i)
+			re.NoError(testutil.CheckPostJSON(tests.TestDialClient, addr, patch, testutil.StatusOK(re)))
+			current := leader.GetPersistOptions().GetScheduleConfig()
+			re.Equal(sc.StoreLimitConfig{AddPeer: float64(60 + i), RemovePeer: 70, TransferLeaderIn: 300}, current.StoreLimit[storeID])
+			re.Equal(current.DefaultStoreLimit, current.StoreLimit[storeID+100])
+		}
+		before := leader.GetPersistOptions().GetScheduleConfig().Clone()
+		invalidPatches := []string{
+			`{"default-store-limit":{"add-peer":99},"store-limit":{"1":{"transfer-leader-in":-1}}}`,
+			`{"default-store-limit":{"add-peer":99},"store-limit":{"1":{"transfer-leader-in":"invalid"}}}`,
+		}
+		if endpoint == "config" {
+			invalidPatches = append(invalidPatches,
+				`{"default-store-limit":{"add-peer":99},"schedule.unknown-option":1}`,
+				`{"default-store-limit":{"add-peer":99},"schedule.default-store-limit":{"add-peer":100}}`)
+		}
+		for _, patch := range invalidPatches {
+			re.NoError(testutil.CheckPostJSON(tests.TestDialClient, addr, []byte(patch), testutil.StatusNotOK(re)))
+			re.Equal(before, leader.GetPersistOptions().GetScheduleConfig())
+			persisted := &config.Config{}
+			exists, err := leader.GetServer().GetStorage().LoadConfig(persisted)
+			re.NoError(err)
+			re.True(exists)
+			re.Equal(before.StoreLimit, persisted.Schedule.StoreLimit)
+			re.Equal(before.DefaultStoreLimit, persisted.Schedule.DefaultStoreLimit)
+		}
+	}
 }
 
 func (suite *configTestSuite) TestConfigReplication() {

--- a/tests/server/config/config_test.go
+++ b/tests/server/config/config_test.go
@@ -243,6 +243,20 @@ func (suite *configTestSuite) checkConfigSchedule(cluster *tests.TestCluster) {
 		re.NoError(testutil.ReadGetJSON(re, tests.TestDialClient, addr, scheduleConfig1))
 		return reflect.DeepEqual(*scheduleConfig1, *scheduleConfig)
 	})
+
+	invalidDefaultStoreLimit := map[string]any{
+		"default-store-limit": map[string]any{
+			"add-peer":    -1,
+			"remove-peer": scheduleConfig.DefaultStoreLimit.RemovePeer,
+		},
+	}
+	postData, err = json.Marshal(invalidDefaultStoreLimit)
+	re.NoError(err)
+	err = testutil.CheckPostJSON(tests.TestDialClient, addr, postData,
+		testutil.StatusNotOK(re),
+		testutil.StringContain(re, "default-store-limit.add-peer should be finite and non-negative"))
+	re.NoError(err)
+	re.Equal(scheduleConfig.DefaultStoreLimit, leaderServer.GetPersistOptions().GetScheduleConfig().DefaultStoreLimit)
 }
 
 func (suite *configTestSuite) TestConfigReplication() {

--- a/tools/pd-ctl/pdctl/command/store_command.go
+++ b/tools/pd-ctl/pdctl/command/store_command.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/pingcap/kvproto/pkg/metapb"
 
+	"github.com/tikv/pd/pkg/core/storelimit"
 	"github.com/tikv/pd/pkg/response"
 )
 
@@ -135,7 +136,7 @@ func NewStoreLimitCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "limit [<store_id>|<all> [<key> <value>]... <limit> <type>]",
 		Short: "show or set a store's rate limit",
-		Long:  "show or set a store's rate limit, <type> can be 'add-peer'(default) or 'remove-peer'",
+		Long:  "show or set a store's rate limit, <type> can be 'add-peer'(default), 'remove-peer', or 'transfer-leader-in'",
 		Run:   storeLimitCommandFunc,
 	}
 	return c
@@ -201,7 +202,7 @@ func NewShowStoresCommand() *cobra.Command {
 func NewShowAllStoresLimitCommand() *cobra.Command {
 	sc := &cobra.Command{
 		Use:        "limit <type>",
-		Short:      "show all stores' limit, <type> can be 'add-peer'(default) or 'remove-peer'",
+		Short:      "show all stores' limit, <type> can be 'add-peer'(default), 'remove-peer', or 'transfer-leader-in'",
 		Deprecated: "use store limit instead",
 		Run:        showAllStoresLimitCommandFunc,
 	}
@@ -224,7 +225,7 @@ func NewSetAllLimitCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:        "limit <rate> <type>",
 		Short:      "set all store's rate limit",
-		Long:       "set all store's rate limit, <type> can be 'add-peer'(default) or 'remove-peer'",
+		Long:       "set all store's rate limit, <type> can be 'add-peer'(default), 'remove-peer', or 'transfer-leader-in'",
 		Deprecated: "use store limit all <rate> instead",
 		Run:        setAllLimitCommandFunc,
 	}
@@ -565,7 +566,7 @@ func storeLimitCommandFunc(cmd *cobra.Command, args []string) {
 		var prefix string
 		if args[0] == "all" {
 			prefix = storesLimitPrefix
-			if rate > maxStoreLimit {
+			if rate > maxStoreLimit && rate != storelimit.Unlimited {
 				cmd.Printf("rate should be less than %.1f for all\n", maxStoreLimit)
 				return
 			}
@@ -595,7 +596,7 @@ func storeLimitCommandFunc(cmd *cobra.Command, args []string) {
 				cmd.Println("rate should be a number that > 0.")
 				return
 			}
-			if rate > maxStoreLimit {
+			if rate > maxStoreLimit && rate != storelimit.Unlimited {
 				cmd.Printf("rate should be less than %.1f for all\n", maxStoreLimit)
 				return
 			}

--- a/tools/pd-ctl/tests/store/store_test.go
+++ b/tools/pd-ctl/tests/store/store_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -95,6 +96,104 @@ func (s *storeTestSuite) checkStoreLimitV2(cluster *pdTests.TestCluster) {
 func (s *storeTestSuite) TestStore() {
 	// TODO: enable this test in microservice mode
 	s.env.RunTestInNonMicroserviceEnv(s.checkStore)
+}
+
+func (s *storeTestSuite) TestTransferLeaderInStoreLimit() {
+	s.env.RunTestInNonMicroserviceEnv(s.checkTransferLeaderInStoreLimit)
+}
+
+func (s *storeTestSuite) checkTransferLeaderInStoreLimit(cluster *pdTests.TestCluster) {
+	re := s.Require()
+	pdAddr := cluster.GetConfig().GetClientURL()
+	leaderServer := cluster.GetLeaderServer()
+	for _, storeID := range []uint64{1, 2} {
+		pdTests.MustPutStore(re, cluster, &metapb.Store{
+			Id:        storeID,
+			State:     metapb.StoreState_Up,
+			NodeState: metapb.NodeState_Serving,
+			Labels:    []*metapb.StoreLabel{{Key: "zone", Value: strconv.FormatUint(storeID, 10)}},
+		})
+	}
+
+	peerLimits := leaderServer.GetRaftCluster().GetScheduleConfig().StoreLimit
+
+	cmd := ctl.GetRootCmd()
+	args := []string{"-u", pdAddr, "store", "limit", "1", "30", "transfer-leader-in"}
+	_, err := tests.ExecuteCommand(cmd, args...)
+	re.NoError(err)
+	re.Equal(float64(30), leaderServer.GetRaftCluster().GetStoreLimitByType(1, storelimit.TransferLeaderIn))
+
+	cmd = ctl.GetRootCmd()
+	args = []string{"-u", pdAddr, "store", "limit", "transfer-leader-in"}
+	output, err := tests.ExecuteCommand(cmd, args...)
+	re.NoError(err)
+	limits := make(map[string]map[string]float64)
+	re.NoError(json.Unmarshal(output, &limits))
+	re.Equal(float64(30), limits["1"]["transfer-leader-in"])
+
+	cmd = ctl.GetRootCmd()
+	args = []string{"-u", pdAddr, "store", "limit", "all", "20", "transfer-leader-in"}
+	_, err = tests.ExecuteCommand(cmd, args...)
+	re.NoError(err)
+	for _, storeID := range []uint64{1, 2} {
+		re.Equal(float64(20), leaderServer.GetRaftCluster().GetStoreLimitByType(storeID, storelimit.TransferLeaderIn))
+	}
+
+	re.NoError(leaderServer.Stop())
+	re.NoError(leaderServer.Run())
+	re.NotEmpty(cluster.WaitLeader())
+	re.Equal(float64(20), leaderServer.GetRaftCluster().GetStoreLimitByType(1, storelimit.TransferLeaderIn))
+
+	cmd = ctl.GetRootCmd()
+	args = []string{"-u", pdAddr, "store", "limit", "1", "0", "transfer-leader-in"}
+	output, err = tests.ExecuteCommand(cmd, args...)
+	re.NoError(err)
+	re.Contains(string(output), "rate should be a number")
+	re.Equal(float64(20), leaderServer.GetRaftCluster().GetStoreLimitByType(1, storelimit.TransferLeaderIn))
+
+	unlimited := strconv.FormatFloat(storelimit.Unlimited, 'f', -1, 64)
+	cmd = ctl.GetRootCmd()
+	args = []string{"-u", pdAddr, "store", "limit", "1", unlimited, "transfer-leader-in"}
+	output, err = tests.ExecuteCommand(cmd, args...)
+	re.NoError(err)
+	re.NotContains(string(output), "rate should")
+	re.Equal(storelimit.Unlimited, leaderServer.GetRaftCluster().GetStoreLimitByType(1, storelimit.TransferLeaderIn))
+
+	cmd = ctl.GetRootCmd()
+	args = []string{"-u", pdAddr, "store", "limit", "all", "0", "transfer-leader-in"}
+	output, err = tests.ExecuteCommand(cmd, args...)
+	re.NoError(err)
+	re.Contains(string(output), "rate should be a number")
+	re.Equal(float64(20), leaderServer.GetRaftCluster().GetStoreLimitByType(2, storelimit.TransferLeaderIn))
+
+	cmd = ctl.GetRootCmd()
+	args = []string{"-u", pdAddr, "store", "limit", "all", "zone", "2", unlimited, "transfer-leader-in"}
+	output, err = tests.ExecuteCommand(cmd, args...)
+	re.NoError(err)
+	re.Contains(string(output), "Success!")
+	re.Equal(storelimit.Unlimited, leaderServer.GetRaftCluster().GetStoreLimitByType(2, storelimit.TransferLeaderIn))
+
+	cmd = ctl.GetRootCmd()
+	args = []string{"-u", pdAddr, "store", "limit", "all", "zone", "2", "25", "transfer-leader-in"}
+	output, err = tests.ExecuteCommand(cmd, args...)
+	re.NoError(err)
+	re.Contains(string(output), "Success!")
+	re.Equal(float64(25), leaderServer.GetRaftCluster().GetStoreLimitByType(2, storelimit.TransferLeaderIn))
+	re.Equal(storelimit.Unlimited, leaderServer.GetRaftCluster().GetStoreLimitByType(1, storelimit.TransferLeaderIn))
+
+	cmd = ctl.GetRootCmd()
+	args = []string{"-u", pdAddr, "store", "limit", "all", unlimited, "transfer-leader-in"}
+	output, err = tests.ExecuteCommand(cmd, args...)
+	re.NoError(err)
+	re.NotContains(string(output), "rate should")
+	re.NoError(leaderServer.Stop())
+	re.NoError(leaderServer.Run())
+	re.NotEmpty(cluster.WaitLeader())
+	for _, storeID := range []uint64{1, 2} {
+		re.Equal(storelimit.Unlimited, leaderServer.GetRaftCluster().GetStoreLimitByType(storeID, storelimit.TransferLeaderIn))
+		re.Equal(peerLimits[storeID].AddPeer, leaderServer.GetRaftCluster().GetStoreLimitByType(storeID, storelimit.AddPeer))
+		re.Equal(peerLimits[storeID].RemovePeer, leaderServer.GetRaftCluster().GetStoreLimitByType(storeID, storelimit.RemovePeer))
+	}
 }
 
 func (s *storeTestSuite) checkStore(cluster *pdTests.TestCluster) {
@@ -264,6 +363,13 @@ func (s *storeTestSuite) checkStore(cluster *pdTests.TestCluster) {
 	limit = leaderServer.GetRaftCluster().GetStoreLimitByType(1, storelimit.AddPeer)
 	re.Equal(float64(10), limit)
 
+	// Omitting the type must preserve both custom and default leader limits.
+	defaultLeaderLimit := leaderServer.GetPersistOptions().GetScheduleConfig().DefaultStoreLimit.TransferLeaderIn
+	args = []string{"-u", pdAddr, "store", "limit", "1", "37", "transfer-leader-in"}
+	output, err = tests.ExecuteCommand(cmd, args...)
+	re.NoError(err)
+	re.Contains(string(output), "Success!")
+
 	// store limit all <rate>
 	args = []string{"-u", pdAddr, "store", "limit", "all", "20"}
 	_, err = tests.ExecuteCommand(cmd, args...)
@@ -280,6 +386,8 @@ func (s *storeTestSuite) checkStore(cluster *pdTests.TestCluster) {
 	re.Equal(float64(20), limit1)
 	re.Equal(float64(20), limit2)
 	re.Equal(float64(20), limit3)
+	re.Equal(float64(37), leaderServer.GetRaftCluster().GetStoreLimitByType(1, storelimit.TransferLeaderIn))
+	re.Equal(defaultLeaderLimit, leaderServer.GetPersistOptions().GetScheduleConfig().DefaultStoreLimit.TransferLeaderIn)
 
 	re.NoError(leaderServer.Stop())
 	re.NoError(leaderServer.Run())
@@ -288,6 +396,8 @@ func (s *storeTestSuite) checkStore(cluster *pdTests.TestCluster) {
 	storesLimit := leaderServer.GetPersistOptions().GetAllStoresLimit()
 	re.Equal(float64(20), storesLimit[1].AddPeer)
 	re.Equal(float64(20), storesLimit[1].RemovePeer)
+	re.Equal(float64(37), storesLimit[1].TransferLeaderIn)
+	re.Equal(defaultLeaderLimit, leaderServer.GetPersistOptions().GetScheduleConfig().DefaultStoreLimit.TransferLeaderIn)
 
 	// store limit all <rate> <type>
 	args = []string{"-u", pdAddr, "store", "limit", "all", "25", "remove-peer"}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #11196, ref #10898

Backport #10900, #11197, and #11200 to `release-nextgen-202603`. Store-limit defaults survive restarts and leader changes, and PD/pd-ctl support configuring inbound leader-transfer limits while preserving existing peer-limit behavior.

### What is changed and how does it work?

The three source commits are retained separately with `cherry picked from` provenance:

- #10900 (`a186e0cc61`): persist defaults for future stores and serialize schedule configuration updates.
- #11197 (`2d43fe93a5`): add `transfer-leader-in` configuration, v1 token accounting, target filtering, and metrics. Partial configuration updates preserve omitted peer/leader fields.
- #11200 (`349e7ee532`): document the CLI type, allow the Unlimited sentinel for bulk updates, and cover CLI behavior and persistence. `store limit all <rate>` without a type continues to update only add-peer/remove-peer; both custom and default leader limits remain unchanged.

Backport adaptations:

- Keep this branch's `ResetStoreStatistics(address, id)` interface. Add cleanup only for the new transfer-in metric, including the upstream store-state recheck after metrics collection. This preserves the leader-limit cleanup behavior without importing the broader metrics changes from #11127.
- Recreate missing test files using the applicable source-added tests and necessary imports/test entry point. Omit only the eight-line extension of the internal-scatter test: this branch lacks the internal-scatter implementation introduced by #10621. Its unrelated feature and fixtures are not imported.

Upstream behavior boundaries are preserved: leader-transfer enforcement uses the v1 limiter; v2 retains its existing pass-through behavior for non-snapshot operations. Existing Urgent admission and explicit temporary-state/force exceptions remain in place, so this is not a hard cap on every leader change.

Persisted defaults for future stores are guaranteed after all PD and Scheduling Service members support the new format. If changed during a mixed-version upgrade, reapply the desired default after the upgrade. Downgrading to a pre-feature binary after changing the persisted default is unsupported.

### Check List

Tests

- Unit test
- Integration test
- Go 1.25.12: NextGen build and `make check` after each source commit; per-commit `range-diff` reviewed.
- Classic and NextGen: 13 relevant packages with race/deadlock/failpoints; complete pd-ctl store suite in both modes.
- Classic: complete HTTP configuration suite. NextGen: store API suite, partial configuration updates, TiFlash defaults, and Scheduling Service store-limit integration test.
- Ablation: removing metric cleanup fails the metric-removal assertion; making omitted-type updates include leader limits fails the CLI regression (`expected 37, actual 20`). All mutations restored.

Validation note: `TestConfigAll` waits for Dashboard initialization and fails with `without_dashboard` on the unchanged target base as well. The complete configuration suite passes with Classic/dashboard enabled; the affected configuration tests also pass with NextGen tags.

Code changes

- Has the configuration change
- Has persistent data change

### Release note

```release-note
Persist store-limit defaults across restarts and leader changes, and support configuring inbound leader-transfer limits through PD and pd-ctl. Omitting the limit type continues to update only peer limits.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `transfer-leader-in` store limit to control incoming leader transfers.
  * Scheduling now respects incoming transfer limits when selecting targets and creating operators.
  * Added status reporting and metrics for throttled or configured transfer limits.
  * Added support for configuring, updating, persisting, and restoring the new limit through APIs and `pd-ctl`.
* **Improvements**
  * Partial schedule-configuration updates now preserve unrelated settings and handle concurrent updates more reliably.
  * Legacy store-limit settings are migrated automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->